### PR TITLE
Implement Standalone/Development mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4
+FROM node:6
 
 COPY index.html /
 COPY scripts /scripts

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ The rpm installs to `/user/share/ovirt-web-ui`.
 
 New ovirt-web-ui.war is added to the existing ovirt-engine.ear.
 
+**Development mode**
+
+`ENGINE_URL=https://my.ovirt.instance/ovirt-engine/ npm start`
+
+When asked, provide valid username (in the form of `user@domain`) and password so
+the application can start in the context of a logged in user.
 
 **Quick run using Docker**
 
@@ -49,7 +55,7 @@ oVirt engine instance.
 
 Just specify where your oVirt engine is running and expose the port `3000` from the container. Example:
 
-  `docker run --rm -it -e ENGINE_URL=https://my.ovirt.instance/ovirt-engine/ -p 3000:3000 matobet/userportal`
+  `docker run --rm -it -e ENGINE_URL=https://my.ovirt.instance/ovirt-engine/ -p 3000:3000 matobet/ovirt-web-ui`
 
 
 ## Technical Details  

--- a/package.json.in
+++ b/package.json.in
@@ -56,7 +56,9 @@
     "webpack": "1.13.2",
     "webpack-dev-server": "1.16.1",
     "whatwg-fetch": "1.0.0",
-    "react-router": "~3.0.0"
+    "react-router": "~3.0.0",
+    "readline-sync": "~1.4.5",
+    "request": "~2.79.0"
   },
   "dependencies": {
     "jquery": "^3.1.1",
@@ -69,6 +71,7 @@
     "redux-saga": "^0.11.1"
   },
   "scripts": {
+    "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "fix": "eslint -c config/eslint.js config src --fix",
     "prebuild": "npm run test",

--- a/src/config.js
+++ b/src/config.js
@@ -2,17 +2,12 @@ import $ from 'jquery'
 
 import { setLogDebug } from 'ovirt-ui-components'
 
-// For Development
-// const CONFIG_URL = '/userportal.config'
-
-// TODO: configure path automatically
-// For Production
 const CONFIG_URL = '/ovirt-engine/web-ui/userportal.config'
 
 const AppConfiguration = {
   debug: true,
-  applicationContext: '/ovirt-engine',
-  applicationURL: '/ovirt-engine/web-ui',
+  applicationContext: '',
+  applicationURL: '',
 }
 
 export function readConfiguration () {
@@ -22,7 +17,7 @@ export function readConfiguration () {
       Object.assign(AppConfiguration, JSON.parse(result))
     },
     error: (result) => {
-      console.log(`Failed to load configuration: ${JSON.stringify(result)}`)
+      console.log(`Failed to load production configuration, assuming development mode.`)
     },
     complete: () => {
       setLogDebug(AppConfiguration.debug)

--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,7 @@ function loadPersistedState () {
 
 function start () {
   readConfiguration()
-  console.log(`Merged configuration: ${JSON.stringify(AppConfiguration)}`)
+  console.log(`Current configuration: ${JSON.stringify(AppConfiguration)}`)
 
   const { token, username } = fetchToken()
 


### PR DESCRIPTION
Enabled standalone run with the usage of webpack-dev-server.
Since the application now expects already authenticated user, `npm start` will
prompt the developer for credentials to the engine instance specified in the
ENGINE_URL environment variable.

The same flow is used in the accompanying docker image.

The injection of the `userData` is facilitated by extending the `env` object
(that is used to source the webpack.DefinePlugin) by the entry of
'window.userData' with the complete object containing token & username.

Note: window.userData is also used by the JSP templates to inject such data
from the engine so we maintain consistency and fetchToken() in index.js remains
the single authoritative source of obtaining pre-existing auth token on
application startup.