### PR TITLE
package.json not processed by autotools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,5 @@ configure
 install-sh
 missing
 ovirt-web-ui.spec
-package.json
 tmp.repos/
 

--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,6 @@ test -z "${NPM}" && AC_MSG_ERROR([NodeJS npm program not found])
 
 AC_CONFIG_FILES([
 	Makefile
-	package.json
 	ovirt-web-ui.spec
 ])
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ovirt-web-ui",
-  "version": "@PACKAGE_VERSION@",
+  "version": "0.0.0",
   "private": true,
   "devDependencies": {
     "autoprefixer": "6.4.1",


### PR DESCRIPTION
From this patch on, package.json file is the authoritative source of
version of the project.

This allows to run npm/yarn right away without need for running `./autogen.sh` first.