### PR TITLE
Repos for oVirt CI moved

### DIFF
--- a/automation/build-artifacts.repos.el7
+++ b/automation/build-artifacts.repos.el7
@@ -1,1 +1,2 @@
-ovirt-master-snapshot-static,http://resources.ovirt.org/pub/ovirt-master-snapshot/rpm/el7/
+http://jenkins.ovirt.org/job/ovirt-engine-nodejs_master_build-artifacts-el7-x86_64/lastSuccessfulBuild/artifact/exported-artifacts/
+http://jenkins.ovirt.org/job/ovirt-engine-nodejs-modules_master_build-artifacts-el7-x86_64/lastSuccessfulBuild/artifact/exported-artifacts/

--- a/automation/build-artifacts.repos.fc24
+++ b/automation/build-artifacts.repos.fc24
@@ -1,1 +1,2 @@
-ovirt-master-snapshot-static,http://resources.ovirt.org/pub/ovirt-master-snapshot/rpm/fc24/
+http://jenkins.ovirt.org/job/ovirt-engine-nodejs_master_build-artifacts-fc24-x86_64/lastSuccessfulBuild/artifact/exported-artifacts/
+http://jenkins.ovirt.org/job/ovirt-engine-nodejs-modules_master_build-artifacts-fc24-x86_64/lastSuccessfulBuild/artifact/exported-artifacts/


### PR DESCRIPTION
Repos for oVirt CI moved
from ovirt-master-snapshot
to http://jenkins.ovirt.org/job/ovirt-engine-nodejs ....

since the ovirt-engine-nodejs-* are newly built by oVirt Jenkins.