### PR TITLE
"Force" shut down action added

### DIFF
--- a/UserPortal.iml
+++ b/UserPortal.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "ovirt-ui-components": "0.2.1",
     "patternfly": "^3.11.0",
     "react": "^15.3.2",
+    "react-bootstrap": "^0.30.8",
     "react-dom": "^15.3.2",
     "react-redux": "^4.4.5",
     "redux": "^3.6.0",

--- a/src/components/Confirmation/index.js
+++ b/src/components/Confirmation/index.js
@@ -161,6 +161,7 @@ class ConfirmationContent extends React.Component {
   }
 
   onScroll () {
+    logDebug('onScroll() called')
     this.computePosition()
   }
 
@@ -168,10 +169,7 @@ class ConfirmationContent extends React.Component {
     this.computePosition()
 
     window.addEventListener('resize', this.onScroll)
-
-    // TODO: none of following is working when scrolling:
-    document.getElementById('root').addEventListener('scroll', this.onScroll)
-    window.addEventListener('scroll', this.onScroll)
+    document.querySelector('.container-cards-pf').addEventListener('scroll', this.onScroll)
   }
 
   componentWillUnmount () {
@@ -270,13 +268,9 @@ class ConfirmationContent extends React.Component {
   }
 
   getElementPosition (e) {
-    let x = 0
-    let y = 0
-    while (e != null) {
-      x += e.offsetLeft
-      y += e.offsetTop
-      e = e.offsetParent
-    }
+    const rect = e.getBoundingClientRect()
+    const x = rect.left
+    const y = rect.top
     return { x, y }
   }
 }

--- a/src/components/Confirmation/index.js
+++ b/src/components/Confirmation/index.js
@@ -60,12 +60,21 @@ const showConfirmation = (options) => {
   return createConfirmation(Confirmation)({ containerId, ...options })
 }
 
+export const closeAllConfirmationComponents = () => {
+  const containers = document.getElementsByClassName('confirmation-container')
+  for (let i = 0; i < containers.length; i++) {
+    const container = containers[i]
+    ReactDOM.unmountComponentAtNode(container)
+  }
+}
+
 const createConfirmation = () => {
   return (props) => {
     const { containerId } = props
     const container = document.getElementById(containerId)
     const wrapper = document.body.appendChild(container || document.createElement('div'))
     wrapper.id = containerId
+    wrapper.className = 'confirmation-container'
 
     function dispose () {
       setTimeout(() => {

--- a/src/components/Confirmation/index.js
+++ b/src/components/Confirmation/index.js
@@ -1,0 +1,303 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { Popover, Button, ButtonToolbar } from 'react-bootstrap'
+
+import { logDebug } from '../../helpers'
+
+import style from './style.css'
+
+/**
+ * Example of use:
+ * <button className='top-btn'
+ *         onClick={(e) =>
+ *              OnClickTopConfirmation({
+ *                 target, // DOM element the confirmation will be sticked to
+ *                 confirmationText, // Text/Component to be rendered
+ *                 cancelLabel,
+ *                 okLabel,
+ *                 extraButtonLabel,
+ *                 id, // unique namespace
+ *                 onOk, // action to be executed
+ *                 onExtra, // action to be executed after onClick()
+ *                 width, height, // or use defaults
+ *                 })}>
+ *      Delete Something
+ * </button>
+ */
+const OnClickTopConfirmation = ({ target, confirmationText, cancelLabel, okLabel, extraButtonLabel, id, onOk, onExtra }) => {
+  showConfirmation({
+    confirmationText,
+    okLabel,
+    cancelLabel,
+    extraButtonLabel,
+    placement: 'top',
+    element: target,
+    uniqueId: id,
+  }).then(
+    (result) => {
+      if (result === 'ok' && onOk) {
+        onOk()
+      } else if (result === 'extra' && onExtra) {
+        onExtra()
+      }
+    },
+    (result) => {
+      logDebug('OnClickTopConfirmation: cancel called', result)
+    }
+  )
+}
+
+// --------------------------------------------------------------------------------
+/**
+ * A Promise is returned
+ */
+const showConfirmation = (options) => {
+  const containerId = `confirmation-container-${options.uniqueId}`
+  const container = document.getElementById(containerId)
+  if (container) {
+    ReactDOM.unmountComponentAtNode(container)
+  }
+  return createConfirmation(Confirmation)({ containerId, ...options })
+}
+
+const createConfirmation = () => {
+  return (props) => {
+    const { containerId } = props
+    const container = document.getElementById(containerId)
+    const wrapper = document.body.appendChild(container || document.createElement('div'))
+    wrapper.id = containerId
+
+    function dispose () {
+      setTimeout(() => {
+        ReactDOM.unmountComponentAtNode(wrapper)
+        setTimeout(() => wrapper.remove(), 0)
+      }, 1)
+    }
+
+    const promise = new Promise((resolve, reject) => {
+      try {
+        ReactDOM.render(
+          <Confirmation
+            reject={reject}
+            resolve={resolve}
+            {...props}
+          />,
+          wrapper
+        )
+      } catch (e) {
+        console.error(e)
+        throw e
+      }
+    })
+
+    return promise.then((result) => {
+      dispose()
+      return result
+    }, (result) => {
+      dispose()
+      return Promise.reject(result)
+    })
+  }
+}
+
+/**
+ * Represents ConfirmationContent enriched for callbacks
+ */
+class Confirmation extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      show: true,
+    }
+
+    this.proceed = this.proceed.bind(this)
+    this.cancel = this.cancel.bind(this)
+    this.onExtra = this.onExtra.bind(this)
+  }
+  cancel () {
+    this.setState({
+      show: false,
+    }, () => {
+      this.props.reject('cancel')
+    })
+  }
+  proceed () {
+    this.setState({
+      show: false,
+    }, () => {
+      this.props.resolve('ok')
+    })
+  }
+  onExtra () {
+    this.setState({
+      show: false,
+    }, () => {
+      this.props.resolve('extra')
+    })
+  }
+  render () {
+    return <ConfirmationContent onOkClicked={this.proceed} onCancelClicked={this.cancel} onExtraButtonClicked={this.onExtra}
+      {...this.props} />
+  }
+}
+Confirmation.propTypes = {
+  reject: React.PropTypes.func,
+  resolve: React.PropTypes.func,
+}
+
+class ConfirmationContent extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      width: this.props.width || 200,
+      height: this.props.height || 70,
+      positionLeft: 0,
+      positionTop: 0,
+    }
+
+    this.onScroll = this.onScroll.bind(this)
+    this.computePosition = this.computePosition.bind(this)
+  }
+
+  onScroll () {
+    this.computePosition()
+  }
+
+  componentDidMount () {
+    this.computePosition()
+
+    window.addEventListener('resize', this.onScroll)
+
+    // TODO: none of following is working when scrolling:
+    document.getElementById('root').addEventListener('scroll', this.onScroll)
+    window.addEventListener('scroll', this.onScroll)
+  }
+
+  componentWillUnmount () {
+    window.removeEventListener('scroll', this.onScroll)
+  }
+
+  computePosition () {
+    const { element, placement } = this.props
+    const { width, height } = this.state
+    let { positionLeft, positionTop } = this.state
+
+    if (element) {
+      const { x, y } = this.getElementPosition(element)
+      switch (placement) {
+        case 'top': {
+          positionLeft = x + element.clientWidth / 2 - width / 2
+          positionTop = y - 10 - 66
+          break
+        }
+        case 'bottom': {
+          positionLeft = x + element.clientWidth / 2 - width / 2
+          positionTop = y + 10 + element.clientHeight
+          break
+        }
+        case 'left': {
+          positionLeft = x - width - 10
+          positionTop = y + element.clientHeight / 2 - height / 2
+          break
+        }
+        case 'right': {
+          positionLeft = x + 10 + element.clientWidth
+          positionTop = y + element.clientHeight / 2 - height / 2
+          break
+        }
+      }
+    }
+
+    this.setState({
+      positionLeft,
+      positionTop,
+    })
+  }
+
+  render () {
+    const {
+      okLabel = 'Yes',
+      cancelLabel = 'No',
+      extraButtonLabel = '',
+      confirmationText, // or React component
+
+      onOkClicked,
+      onCancelClicked,
+      onExtraButtonClicked,
+
+      placement = 'top',
+    } = this.props
+
+    const {
+      positionLeft,
+      positionTop,
+      width,
+      height,
+    } = this.state
+
+    let extraButton = null
+    if (extraButtonLabel) {
+      extraButton = (
+        <Button bsSize='xsmall' className={`${style['confirmation-extra-button']} button-l`} bsStyle='info' onClick={onExtraButtonClicked}>
+          {extraButtonLabel}
+        </Button>
+      )
+    }
+
+    return (
+      <div className='static-confirm'>
+        <Popover id='pop-confirm'
+          style={{ width: `${width}px`, height: `${height}px` }}
+          placement={placement}
+          positionLeft={positionLeft}
+          positionTop={positionTop}>
+          <p className={style['confirmation-text']}>
+            {confirmationText}
+          </p>
+          <ButtonToolbar className={style['confirmation-toolbar']}>
+            <Button bsSize='xsmall' className='button-l' bsStyle='info' onClick={onOkClicked}>
+              {okLabel}
+            </Button>
+            <Button bsSize='xsmall' onClick={onCancelClicked}>
+              {cancelLabel}
+            </Button>
+            {extraButton}
+          </ButtonToolbar>
+        </Popover>
+      </div>
+    )
+  }
+
+  getElementPosition (e) {
+    let x = 0
+    let y = 0
+    while (e != null) {
+      x += e.offsetLeft
+      y += e.offsetTop
+      e = e.offsetParent
+    }
+    return { x, y }
+  }
+}
+ConfirmationContent.propTypes = {
+  okLabel: React.PropTypes.string,
+  cancelLabel: React.PropTypes.string,
+  extraButtonLabel: React.PropTypes.string,
+  confirmationText: React.PropTypes.string.isRequired,
+
+  onOkClicked: React.PropTypes.func,
+  onCancelClicked: React.PropTypes.func,
+  onExtraButtonClicked: React.PropTypes.func,
+
+  element: React.PropTypes.object.isRequired,
+
+  placement: React.PropTypes.string,
+  width: React.PropTypes.number,
+  height: React.PropTypes.number,
+
+  positionLeft: React.PropTypes.number,
+  positionTop: React.PropTypes.number,
+}
+
+export default OnClickTopConfirmation

--- a/src/components/Confirmation/style.css
+++ b/src/components/Confirmation/style.css
@@ -1,0 +1,14 @@
+.confirmation-text {
+    margin: 0;
+    padding: .3em 0;
+    font-size: small;
+}
+
+.confirmation-toolbar {
+    paddingBottom: 6px;
+    float: right;
+}
+
+.confirmation-extra-button {
+    margin-left: 15px !important;
+}

--- a/src/components/DetailContainer.js
+++ b/src/components/DetailContainer.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
 
 import { closeDetail } from '../actions'
+import { closeAllConfirmationComponents } from './Confirmation'
 
 import sharedStyle from './sharedStyle.css'
 
@@ -9,6 +10,7 @@ class DetailContainer extends Component {
   componentDidMount () {
     this.onKeyDown = (event) => {
       if (event.keyCode === 27) { // ESC
+        closeAllConfirmationComponents()
         this.props.onCloseDetail()
       }
     }

--- a/src/components/VmsList/Vm.js
+++ b/src/components/VmsList/Vm.js
@@ -6,6 +6,7 @@ import style from './style.css'
 import VmStatusText from './VmStatusText'
 import VmActions from '../VmActions'
 import { VmIcon, VmStatusIcon } from 'ovirt-ui-components'
+import { closeAllConfirmationComponents } from '../Confirmation'
 
 import { selectVmDetail } from '../../actions'
 
@@ -19,6 +20,11 @@ const Vm = ({ vm, icons, onSelectVm, visibility }) => {
   const icon = icons.get(iconId)
   const isSelected = vm.get('id') === visibility.get('selectedVmDetail')
 
+  const onCardClick = () => {
+    closeAllConfirmationComponents()
+    onSelectVm()
+  }
+
   // TODO: improve the card flip:
   // TODO: https://davidwalsh.name/css-flip
   // TODO: http://tympanus.net/codrops/2013/12/18/perspective-page-view-navigation/
@@ -27,11 +33,11 @@ const Vm = ({ vm, icons, onSelectVm, visibility }) => {
     <div className={`col-xs-12 col-sm-6 col-md-4 col-lg-3 ${isSelected ? style['selectedVm'] : ''}`}>
       <div className='card-pf card-pf-view card-pf-view-select card-pf-view-single-select'>
         <div className='card-pf-body'>
-          <div className='card-pf-top-element' onClick={onSelectVm}>
+          <div className='card-pf-top-element' onClick={onCardClick}>
             <VmIcon icon={icon} className={style['card-pf-icon']}
               missingIconClassName='fa fa-birthday-cake card-pf-icon-circle' />
           </div>
-          <h2 className='card-pf-title text-center' onClick={onSelectVm}>
+          <h2 className='card-pf-title text-center' onClick={onCardClick}>
             <p className={[style['vm-name'], style['crop']].join(' ')} title={vm.get('name')} data-toggle='tooltip'>
               <VmStatusIcon state={state} />&nbsp;{vm.get('name')}
             </p>

--- a/src/components/VmsList/Vms.js
+++ b/src/components/VmsList/Vms.js
@@ -5,6 +5,7 @@ import style from './style.css'
 import Vm from './Vm'
 
 import { closeDetail } from '../../actions'
+import { closeAllConfirmationComponents } from '../Confirmation'
 
 const Vms = ({ vms, visibility, onCloseDetail }) => {
   const isDetailVisible = visibility.get('selectedVmDetail') || visibility.get('showOptions')
@@ -13,6 +14,7 @@ const Vms = ({ vms, visibility, onCloseDetail }) => {
 
   const closeDetail = isDetailVisible
     ? (event) => {
+      closeAllConfirmationComponents()
       onCloseDetail()
       event.stopPropagation()
     }

--- a/src/ovirtapi.js
+++ b/src/ovirtapi.js
@@ -184,9 +184,14 @@ OvirtApi = {
     const url = `${AppConfiguration.applicationContext}/api/vms`
     return OvirtApi._httpGet({ url })
   },
-  shutdown ({ vmId }) {
+  shutdown ({ vmId, force }) {
     OvirtApi._assertLogin({ methodName: 'shutdown' })
-    return OvirtApi._httpPost({ url: `${AppConfiguration.applicationContext}/api/vms/${vmId}/shutdown`, input: '<action />' })
+    const action = '<action />'
+    let restMethod = 'shutdown'
+    if (force) {
+      restMethod = 'stop'
+    }
+    return OvirtApi._httpPost({ url: `${AppConfiguration.applicationContext}/api/vms/${vmId}/${restMethod}`, input: action })
   },
   start ({ vmId }) {
     OvirtApi._assertLogin({ methodName: 'start' })
@@ -196,7 +201,7 @@ OvirtApi = {
     OvirtApi._assertLogin({ methodName: 'start' })
     return OvirtApi._httpPost({ url: `${AppConfiguration.applicationContext}/api/vms/${vmId}/suspend`, input: '<action />' })
   },
-  restart ({ vmId }) {
+  restart ({ vmId }) { // 'force' is not exposed by oVirt API
     OvirtApi._assertLogin({ methodName: 'restart' })
     return OvirtApi._httpPost({ url: `${AppConfiguration.applicationContext}/api/vms/${vmId}/reboot`, input: '<action />' })
   },


### PR DESCRIPTION
With this patch, the user can shut down a VM in either "polite" or "force" way.

Action confirmation dialog changed to bootstraps' popover.

Fixes: https://github.com/oVirt/ovirt-web-ui/issues/16

![confirmation](https://cloud.githubusercontent.com/assets/17194943/24900663/d39647fc-1ea4-11e7-8817-415c3c680412.png)
