### PR TITLE
Pass "?locale" URL query param to oVirt API

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 import $ from 'jquery'
 
-import { setLogDebug } from './helpers'
+import { setLogDebug, getURLQueryParameterByName } from './helpers'
 
 const CONFIG_URL = '/ovirt-engine/web-ui/ovirt-web-ui.config'
 
@@ -12,9 +12,15 @@ const AppConfiguration = {
 
   consoleClientResourcesURL: 'https://www.ovirt.org/documentation/admin-guide/virt/console-client-resources/',
   cockpitPort: '9090',
+
+  queryParams: { // from URL
+    locale: null,
+  },
 }
 
 export function readConfiguration () {
+  parseQueryParams()
+
   return new Promise((resolve, reject) => {
     $.ajax({
       url: CONFIG_URL,
@@ -31,6 +37,12 @@ export function readConfiguration () {
       async: true,
     })
   })
+}
+
+function parseQueryParams () {
+  // TODO: align this with intl/index.js:getLocaleFromUrl()
+  AppConfiguration.queryParams.locale = getURLQueryParameterByName('locale')
+  console.log('parseQueryParams, provided locale: ', AppConfiguration.queryParams.locale)
 }
 
 export default AppConfiguration

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -128,3 +128,20 @@ export function hrefWithoutHistory (handler) {
     handler(e)
   }
 }
+
+export function getURLQueryParameterByName (name) {
+  const url = window.location.href
+  name = name.replace(/[\[\]]/g, '\\$&')
+  const regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)')
+  const results = regex.exec(url)
+
+  if (!results) {
+    return null
+  }
+  if (!results[2]) {
+    return ''
+  }
+
+  const uriComponent = results[2].replace(/\+/g, ' ')
+  return decodeURIComponent(uriComponent)
+}

--- a/src/ovirtapi.js
+++ b/src/ovirtapi.js
@@ -31,6 +31,7 @@ OvirtApi = {
     logDebug(`_httpGet start: url="${url}"`)
     const headers = Object.assign({
       'Authorization': `Bearer ${OvirtApi._getLoginToken()}`,
+      'Accept-Language': AppConfiguration.queryParams.locale, // can be: undefined, empty or string
     }, custHeaders)
     logDebug(`_httpGet: url="${url}", headers="${JSON.stringify(headers)}"`)
 
@@ -50,6 +51,7 @@ OvirtApi = {
         'Accept': 'application/json',
         'Content-Type': contentType,
         'Authorization': `Bearer ${OvirtApi._getLoginToken()}`,
+        'Accept-Language': AppConfiguration.queryParams.locale,
         'Filter': 'true',
       },
       data: input,
@@ -66,6 +68,7 @@ OvirtApi = {
         'Accept': 'application/json',
         'Content-Type': contentType,
         'Authorization': `Bearer ${OvirtApi._getLoginToken()}`,
+        'Accept-Language': AppConfiguration.queryParams.locale,
       },
       data: input,
     }).then((data: Object): Promise<Object> => Promise.resolve(data))


### PR DESCRIPTION
With this change, the oVirt API returns localized error messages, so
they can be displayed to the user without additional modification.

Fixes: https://github.com/oVirt/ovirt-web-ui/issues/110

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/131)
<!-- Reviewable:end -->
