### PR TITLE
PropTypes are used from 'prop-types'

### DIFF
--- a/src/components/About.js
+++ b/src/components/About.js
@@ -1,4 +1,6 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
+
 import { connect } from 'react-redux'
 
 import Product from '../version'

--- a/src/components/CloseDialogConfirmation/index.js
+++ b/src/components/CloseDialogConfirmation/index.js
@@ -1,4 +1,6 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
+
 import { connect } from 'react-redux'
 import { Modal, Button } from 'react-bootstrap'
 

--- a/src/components/Confirmation/index.js
+++ b/src/components/Confirmation/index.js
@@ -1,4 +1,6 @@
 import React from 'react'
+import PropTypes from 'prop-types'
+
 import ReactDOM from 'react-dom'
 import { Popover, Button, ButtonToolbar } from 'react-bootstrap'
 
@@ -151,8 +153,8 @@ class Confirmation extends React.Component {
   }
 }
 Confirmation.propTypes = {
-  reject: React.PropTypes.func,
-  resolve: React.PropTypes.func,
+  reject: PropTypes.func,
+  resolve: PropTypes.func,
 }
 
 class ConfirmationContent extends React.Component {
@@ -289,23 +291,23 @@ class ConfirmationContent extends React.Component {
   }
 }
 ConfirmationContent.propTypes = {
-  okLabel: React.PropTypes.string,
-  cancelLabel: React.PropTypes.string,
-  extraButtonLabel: React.PropTypes.string,
-  confirmationText: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object]),
+  okLabel: PropTypes.string,
+  cancelLabel: PropTypes.string,
+  extraButtonLabel: PropTypes.string,
+  confirmationText: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
 
-  onOkClicked: React.PropTypes.func,
-  onCancelClicked: React.PropTypes.func,
-  onExtraButtonClicked: React.PropTypes.func,
+  onOkClicked: PropTypes.func,
+  onCancelClicked: PropTypes.func,
+  onExtraButtonClicked: PropTypes.func,
 
-  element: React.PropTypes.object.isRequired,
+  element: PropTypes.object.isRequired,
 
-  placement: React.PropTypes.string,
-  width: React.PropTypes.number,
-  height: React.PropTypes.number,
+  placement: PropTypes.string,
+  width: PropTypes.number,
+  height: PropTypes.number,
 
-  positionLeft: React.PropTypes.number,
-  positionTop: React.PropTypes.number,
+  positionLeft: PropTypes.number,
+  positionTop: PropTypes.number,
 }
 
 export default OnClickTopConfirmation

--- a/src/components/ContainerFluid.js
+++ b/src/components/ContainerFluid.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 export const ContainerFluid = ({ children }) => (
   <div className='container-fluid'>

--- a/src/components/DetailContainer.js
+++ b/src/components/DetailContainer.js
@@ -1,4 +1,6 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
 import { connect } from 'react-redux'
 
 import { closeDialog } from '../actions'

--- a/src/components/ErrorAlert.js
+++ b/src/components/ErrorAlert.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 const ErrorAlert = ({ message }) => {
   return message ? (

--- a/src/components/FieldHelp.js
+++ b/src/components/FieldHelp.js
@@ -1,4 +1,6 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
+
 import { OverlayTrigger, Popover } from 'react-bootstrap'
 
 /**

--- a/src/components/LabeledSelect.js
+++ b/src/components/LabeledSelect.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 import style from './sharedStyle.css'
 

--- a/src/components/LabeledTextField.js
+++ b/src/components/LabeledTextField.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 import style from './sharedStyle.css'
 

--- a/src/components/OvirtApiCheckFailed.js
+++ b/src/components/OvirtApiCheckFailed.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 import { connect } from 'react-redux'
 import Product from '../version'

--- a/src/components/Time.js
+++ b/src/components/Time.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 import { formatTwoDigits } from '../helpers'
 

--- a/src/components/VmActions/index.js
+++ b/src/components/VmActions/index.js
@@ -1,4 +1,6 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
+
 import { connect } from 'react-redux'
 
 import style from './style.css'

--- a/src/components/VmDetail/index.js
+++ b/src/components/VmDetail/index.js
@@ -1,4 +1,6 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
 import { connect } from 'react-redux'
 
 import style from './style.css'

--- a/src/components/VmDialog/AddVmButton.js
+++ b/src/components/VmDialog/AddVmButton.js
@@ -1,4 +1,6 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
+
 import { connect } from 'react-redux'
 
 import { openAddVmDialog } from '../../actions/index'

--- a/src/components/VmDialog/index.js
+++ b/src/components/VmDialog/index.js
@@ -1,4 +1,6 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
+
 import { connect } from 'react-redux'
 
 import { logDebug, generateUnique } from '../../helpers'

--- a/src/components/VmUserMessages/index.js
+++ b/src/components/VmUserMessages/index.js
@@ -1,4 +1,6 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
+
 import { connect } from 'react-redux'
 
 import style from './style.css'

--- a/src/components/VmsList/Pool.js
+++ b/src/components/VmsList/Pool.js
@@ -1,4 +1,6 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
+
 import { connect } from 'react-redux'
 
 import style from './style.css'

--- a/src/components/VmsList/Vm.js
+++ b/src/components/VmsList/Vm.js
@@ -1,4 +1,6 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
+
 import { connect } from 'react-redux'
 
 import style from './style.css'

--- a/src/components/VmsList/VmStatusText.js
+++ b/src/components/VmsList/VmStatusText.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 import style from './style.css'
 

--- a/src/components/VmsList/Vms.js
+++ b/src/components/VmsList/Vms.js
@@ -1,4 +1,6 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
+
 import { connect } from 'react-redux'
 
 import style from './style.css'

--- a/src/components/VmsList/index.js
+++ b/src/components/VmsList/index.js
@@ -1,4 +1,6 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
+
 import { connect } from 'react-redux'
 
 import ContainerFluid from '../ContainerFluid'

--- a/src/components/VmsPageHeader/UserMenu.js
+++ b/src/components/VmsPageHeader/UserMenu.js
@@ -1,4 +1,6 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
+
 import { connect } from 'react-redux'
 
 import { Checkbox } from 'ovirt-ui-components'

--- a/src/components/VmsPageHeader/index.js
+++ b/src/components/VmsPageHeader/index.js
@@ -1,4 +1,6 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
+
 import { connect } from 'react-redux'
 
 import ContainerFluid from '../ContainerFluid'


### PR DESCRIPTION
instead of deprecated 'react' npm package.