### PR TITLE
Remove door effect, replace it by react-router

### DIFF
--- a/__tests__/vms/selectVmDetail.js
+++ b/__tests__/vms/selectVmDetail.js
@@ -1,15 +1,16 @@
 import {call, put, take} from 'redux-saga/effects'
 import sagasHelper from '../helper'
 import { selectVmDetail, fetchSingleVm } from '../../src/sagas'
-import { selectVmDetail as selectAction, setVmDetailToShow, getSingleVm } from '../../src/actions'
+import { selectVmDetail as selectAction, setVmDetailToShow, getSingleVm, loadInProgress } from '../../src/actions'
 
 describe('Get VM detail test: ', () => {
 	const it2 = sagasHelper(selectVmDetail(selectAction({ vmId: '123' })))
-	it2('First we check if it set detail to show: ', (result) => {
-		expect(result).toEqual(put(setVmDetailToShow({ vmId: '123' })))
-	})
 
-	it2('Then we must check returned data: ', (result) => {
-		expect(result).toEqual(fetchSingleVm(getSingleVm({ vmId: '123' })))
+  it2('First we check returned data: ', (result) => {
+    expect(result).toEqual(fetchSingleVm(getSingleVm({ vmId: '123' })))
+  })
+
+	it2('Then we check setting loadInProgress value to false: ', (result) => {
+		expect(result).toEqual(put(loadInProgress({ value: false })))
 	})
 })

--- a/package.json
+++ b/package.json
@@ -78,7 +78,9 @@
     "react-test-renderer": "15.5.4",
     "redux": "3.6.0",
     "redux-devtools-extension": "2.13.2",
-    "redux-saga": "0.15.3"
+    "redux-saga": "0.15.3",
+    "react-router-config": "1.0.0-beta.3",
+    "react-router-dom": "4.1.1"
   },
   "scripts": {
     "start": "node scripts/start.js",

--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,4 @@
 .navbar-top-offset {
     padding-top: 29px;
-}
-
-.main-actions {
-    padding: 5px;
-    text-align: right;
+    margin-left: 200px;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,74 +1,91 @@
 import React, { PropTypes } from 'react'
 import { connect } from 'react-redux'
-
-import style from './App.css'
+import {
+  BrowserRouter as Router,
+} from 'react-router-dom'
+import { renderRoutes } from 'react-router-config'
 
 import VmsPageHeader from './components/VmsPageHeader/index'
 
-import VmsList from './components/VmsList/index'
-import VmDetail from './components/VmDetail'
 import Options from './components/Options'
 import AboutDialog from './components/About'
 import OvirtApiCheckFailed from './components/OvirtApiCheckFailed'
 import CloseDialogConfirmation from './components/CloseDialogConfirmation/index'
 import TokenExpired from './components/TokenExpired'
+import ContainerFluid from './components/ContainerFluid'
 import LoadingData from './components/LoadingData/index'
 
-import AddVmButton from './components/VmDialog/AddVmButton'
-import VmDialog from './components/VmDialog/index'
+import VerticalMenu from './components/VerticalMenu'
 
-const App = ({ vms, visibility }) => {
-  const selectedVmId = visibility.get('selectedVmDetail') // TODO: move to 'connect()' function
-  const selectedPoolId = visibility.get('selectedPoolDetail')
-  const selectedVm = selectedVmId ? vms.getIn(['vms', selectedVmId]) : undefined
-  const selectedPool = selectedPoolId ? vms.getIn(['pools', selectedPoolId, 'vm']) : undefined
-  const isCloseDialogConfirmation = visibility.get('dialogCloseConfirmationToShow')
+import { getRoutes, getMenu } from './routes'
+import rednerModal from './components/VmModals/rednerModal'
+import AppConfiguration from './config'
 
+/**
+ * Login (token) to Engine is missing.
+ */
+const NoLogin = () => {
+  return (
+    <div className='blank-slate-pf'>
+      <div className='blank-slate-pf-icon'>
+        <span className='pficon pficon pficon-user' />
+      </div>
+      <h1>
+        Please log in ...
+      </h1>
+    </div>
+  )
+}
+
+const App = ({ vms, visibility, config }) => {
   let detailToRender = null
   switch (visibility.get('dialogToShow')) {
     case 'Options':
       detailToRender = (<Options />)
       break
-    case 'VmDialog':
-      detailToRender = (<VmDialog vm={selectedVm} />)
-      break
-    case 'VmDetail':
-      detailToRender = (<VmDetail vm={selectedVm} />)
-      break
-    case 'PoolDetail':
-      detailToRender = (<VmDetail vm={selectedPool} pool={vms.getIn(['pools', selectedPoolId])} isPool />)
-      break
   }
 
-  let closeDialogConfirmation = null
-  if (detailToRender && isCloseDialogConfirmation) {
-    closeDialogConfirmation = (<CloseDialogConfirmation />)
+  const routes = getRoutes(vms)
+  const menu = getMenu()
+
+  if (!config.get('loginToken')) { // login is missing
+    return (
+      <ContainerFluid>
+        <NoLogin />
+      </ContainerFluid>
+    )
   }
 
-  const addVmButton = detailToRender ? null : <AddVmButton name='Add New Virtual Machine' />
+  const openConfirmation = (message, callback) => {
+    rednerModal({
+      Component: CloseDialogConfirmation,
+      onYes: () => {
+        callback(true)
+      },
+      onNo: () => {
+        callback(false)
+      },
+    })
+  }
 
   return (
-    <div>
-      <VmsPageHeader title='oVirt VM Portal' />
-      <div className={'container-fluid ' + style['navbar-top-offset']}>
-        <div className={style['main-actions']}>
-          {addVmButton}
-        </div>
-
+    <Router getUserConfirmation={openConfirmation} basename={AppConfiguration.applicationURL}>
+      <div>
+        <VmsPageHeader title='oVirt VM Portal' />
+        <VerticalMenu menuItems={menu} />
         <TokenExpired />
         <LoadingData />
-
-        <VmsList />
+        {renderRoutes(routes)}
         {detailToRender}
+        <AboutDialog />
+        <OvirtApiCheckFailed />
       </div>
-      {closeDialogConfirmation}
-      <AboutDialog />
-      <OvirtApiCheckFailed />
-    </div>
+    </Router>
   )
 }
 App.propTypes = {
   vms: PropTypes.object.isRequired,
+  config: PropTypes.object.isRequired,
   visibility: PropTypes.object.isRequired,
 }
 
@@ -76,5 +93,6 @@ export default connect(
   (state) => ({
     vms: state.vms,
     visibility: state.visibility,
+    config: state.config,
   })
 )(App)

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -16,6 +16,7 @@ export * from './operatingSystems'
 export * from './templates'
 export * from './options'
 export * from './pool'
+export * from './route'
 
 export function persistState () {
   return {

--- a/src/actions/route.js
+++ b/src/actions/route.js
@@ -1,0 +1,8 @@
+export function redirectRoute ({ route }) {
+  return {
+    type: 'REDIRECT',
+    payload: {
+      route,
+    },
+  }
+}

--- a/src/actions/visibility.js
+++ b/src/actions/visibility.js
@@ -1,6 +1,5 @@
 import {
   SELECT_POOL_DETAIL,
-  SET_POOL_DETAIL_TO_SHOW,
 } from '../constants/index'
 
 export function toggleOptions () {
@@ -20,23 +19,6 @@ export function selectVmDetail ({ vmId }) {
   }
 }
 
-export function setVmDetailToShow ({ vmId }) {
-  return {
-    type: 'SET_VM_DETAIL_TO_SHOW',
-    payload: {
-      vmId,
-    },
-  }
-}
-
-export function openAddVmDialog () {
-  return {
-    type: 'OPEN_ADD_VM_DIALOG',
-    payload: {
-    },
-  }
-}
-
 export function selectPoolDetail ({ poolId }) {
   return {
     type: SELECT_POOL_DETAIL,
@@ -46,37 +28,11 @@ export function selectPoolDetail ({ poolId }) {
   }
 }
 
-export function openEditVmDialog ({ vmId }) {
-  return {
-    type: 'OPEN_EDIT_VM_DIALOG',
-    payload: {
-      vmId,
-    },
-  }
-}
-
 export function closeDialog ({ force = false }) {
   return {
     type: 'CLOSE_DIALOG',
     payload: {
       force,
-    },
-  }
-}
-
-export function setPoolDetailToShow ({ poolId }) {
-  return {
-    type: SET_POOL_DETAIL_TO_SHOW,
-    payload: {
-      poolId,
-    },
-  }
-}
-
-export function requestCloseDialogConfirmation () {
-  return {
-    type: 'REQUEST_CLOSE_DIALOG_CONFIRMATION',
-    payload: {
     },
   }
 }

--- a/src/actions/vm.js
+++ b/src/actions/vm.js
@@ -1,8 +1,6 @@
 import {
-  ADD_NEW_VM,
   CLEAR_USER_MSGS,
   DOWNLOAD_CONSOLE_VM,
-  EDIT_VM,
   GET_ALL_VMS,
   LOGIN,
   LOGIN_SUCCESSFUL,
@@ -116,19 +114,6 @@ export function suspendVm ({ vmId }) {
   }
 }
 
-/**
- * New VM will be created in oVirt (REST API)
- */
-export function createVm (vm, actionUniqueId) {
-  return {
-    type: ADD_NEW_VM,
-    actionUniqueId,
-    payload: {
-      vm,
-    },
-  }
-}
-
 export function removeVm ({ vmId, force = false, preserveDisks = false }) {
   return {
     type: REMOVE_VM,
@@ -136,19 +121,6 @@ export function removeVm ({ vmId, force = false, preserveDisks = false }) {
       vmId,
       force,
       preserveDisks,
-    },
-  }
-}
-
-/**
- * Existing VM definition will be updated in oVirt (REST API)
- */
-export function editVm (vm, actionUniqueId) {
-  return {
-    type: EDIT_VM,
-    actionUniqueId,
-    payload: {
-      vm,
     },
   }
 }

--- a/src/components/CloseDialogConfirmation/index.js
+++ b/src/components/CloseDialogConfirmation/index.js
@@ -1,17 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { connect } from 'react-redux'
 import { Modal, Button } from 'react-bootstrap'
-
-import {
-  closeDialog,
-  requestCloseDialogConfirmation,
-} from '../../actions/index'
 
 import style from './style.css'
 
-const CloseDialogConfirmation = ({ onDismissChanges, onKeepDialog }) => {
+const CloseDialogConfirmation = ({ onYes, onNo }) => {
   return (
     <Modal show dialogClassName={style['cust-modal-content']}>
       <Modal.Header bsClass={`modal-header ${style['cust-modal-header']}`}>
@@ -21,21 +15,15 @@ const CloseDialogConfirmation = ({ onDismissChanges, onKeepDialog }) => {
         <h4>Are you sure you want to drop your changes?</h4>
       </Modal.Body>
       <Modal.Footer>
-        <Button onClick={onKeepDialog} bsClass='btn btn-default'>No</Button>
-        <Button onClick={onDismissChanges} bsClass='btn btn-info'>Yes</Button>
+        <Button onClick={onNo} bsClass='btn btn-default'>No</Button>
+        <Button onClick={onYes} bsClass='btn btn-info'>Yes</Button>
       </Modal.Footer>
     </Modal>
   )
 }
 CloseDialogConfirmation.propTypes = {
-  onDismissChanges: PropTypes.func.isRequired,
-  onKeepDialog: PropTypes.func.isRequired,
+  onYes: PropTypes.func.isRequired,
+  onNo: PropTypes.func.isRequired,
 }
 
-export default connect(
-  (state) => ({}),
-  (dispatch) => ({
-    onDismissChanges: () => dispatch(closeDialog({ force: true })),
-    onKeepDialog: () => dispatch(requestCloseDialogConfirmation()),
-  })
-)(CloseDialogConfirmation)
+export default CloseDialogConfirmation

--- a/src/components/Confirmation/index.js
+++ b/src/components/Confirmation/index.js
@@ -186,7 +186,7 @@ class ConfirmationContent extends React.Component {
     this.computePosition()
 
     window.addEventListener('resize', this.onScroll)
-    document.querySelector('.container-cards-pf').addEventListener('scroll', this.onScroll)
+    document.querySelector('.actions-line').addEventListener('scroll', this.onScroll)
   }
 
   componentWillUnmount () {

--- a/src/components/LoadingData/style.css
+++ b/src/components/LoadingData/style.css
@@ -6,4 +6,6 @@
     top: 2.4em;
     margin-left: 50%;
     border-color: #ecc89e;
+    min-width: 100px;
+    text-align: center;
 }

--- a/src/components/PageRouter.js
+++ b/src/components/PageRouter.js
@@ -1,0 +1,115 @@
+import React, { PropTypes } from 'react'
+import { connect } from 'react-redux'
+import { matchRoutes } from 'react-router-config'
+
+import {
+  Link,
+  withRouter,
+  Redirect,
+} from 'react-router-dom'
+
+import { redirectRoute } from '../actions/route'
+
+import style from './sharedStyle.css'
+
+import Toolbar from './Toolbar/Toolbar'
+
+const buildPath = (route) => {
+  let res = []
+  for (let i in route) {
+    if (typeof route[i].route.title === 'function') {
+      res.push({ title: route[i].route.title(route[i].match), url: route[i].match.url })
+    } else {
+      if (typeof route[i].route.title === 'string') {
+        res.push({ title: route[i].route.title, url: route[i].match.url })
+      }
+    }
+  }
+  return res
+}
+
+const Breadcrumb = ({ route, root }) => {
+  let pathArray = buildPath(route)
+  pathArray = [ root ].concat(pathArray)
+  const breadcrumbPaths = []
+  for (let i = 0; i < pathArray.length; i++) {
+    if ((i + 1) === pathArray.length) {
+      breadcrumbPaths.push(<li key={pathArray[i].url} className='active'>{pathArray[i].title}</li>)
+    } else {
+      breadcrumbPaths.push(<li key={pathArray[i].url}><Link to={pathArray[i].url}>{pathArray[i].title}</Link></li>)
+    }
+  }
+
+  return (<ol className={`breadcrumb ${style['breadcrumb']}`}>
+    {breadcrumbPaths}
+  </ol>)
+}
+
+Breadcrumb.propTypes = {
+  route: PropTypes.array.isRequired,
+  root: PropTypes.object.isRequired,
+}
+
+const findExactMatch = (branches) => {
+  if (branches.length === 1) {
+    return branches[0]
+  } else {
+    for (let i = 0; i < branches.length; i++) {
+      if (branches[i].match.isExact) {
+        return branches[i]
+      }
+    }
+  }
+  return null
+}
+
+class PageRouter extends React.Component {
+  componentDidUpdate () {
+    if (this.props.routeReducer.get('redirect') && this.props.routeReducer.get('redirect') !== this.props.location.pathname) {
+      this.props.onRedirect()
+    }
+  }
+
+  render () {
+    let { route, location, history, routeReducer } = this.props
+    if (routeReducer.get('redirect') && routeReducer.get('redirect') !== location.pathname) {
+      return (<Redirect to={routeReducer.get('redirect')} />)
+    }
+    const branches = matchRoutes(route.routes, location.pathname)
+
+    let branch = findExactMatch(branches)
+    let tools = []
+    if (branch) {
+      for (let i in branch.route.toolbars) {
+        tools.push(branch.route.toolbars[i](branch.match))
+      }
+    }
+
+    const RenderComponent = branch.route.component
+    return (<div className={style['navbar-top-offset']}>
+      <Breadcrumb route={branches} root={{ title: 'Virtual Machines', url: '/' }} />
+      <Toolbar>
+        {tools}
+      </Toolbar>
+      <RenderComponent route={branch.route} match={branch.match} location={location} history={history} />
+    </div>)
+  }
+}
+
+PageRouter.propTypes = {
+  match: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+  history: PropTypes.object.isRequired,
+  route: PropTypes.object.isRequired,
+  routeReducer: PropTypes.object.isRequired,
+  onRedirect: PropTypes.func.isRequired,
+}
+
+export default withRouter(connect(
+  (state) => ({
+    routeReducer: state.route,
+  }),
+  (dispatch) => ({
+    onRedirect: () => dispatch(redirectRoute({ route: null })),
+  })
+)(PageRouter))

--- a/src/components/Pages/VmsPage.js
+++ b/src/components/Pages/VmsPage.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import VmsList from '../VmsList/index'
+
+const VmsPage = () => {
+  return (<div className='container-fluid'>
+    <VmsList />
+  </div>)
+}
+
+export default VmsPage

--- a/src/components/Pages/index.js
+++ b/src/components/Pages/index.js
@@ -1,0 +1,109 @@
+import React, { PropTypes } from 'react'
+import { connect } from 'react-redux'
+
+import VmDetail from '../VmDetail'
+import VmDialog from '../VmDialog/index'
+import { selectVmDetail, selectPoolDetail } from '../../actions/index'
+
+class VmDetailPage extends React.Component {
+  componentWillMount () {
+    this.props.getVms({ vmId: this.props.match.params.id })
+  }
+
+  render () {
+    let { match, vms } = this.props
+    if (vms.getIn(['vms', match.params.id])) {
+      return (<VmDetail vm={vms.getIn(['vms', match.params.id])} />)
+    }
+    return null
+  }
+}
+
+VmDetailPage.propTypes = {
+  vms: PropTypes.object.isRequired,
+  getVms: PropTypes.func.isRequired,
+  route: PropTypes.object.isRequired,
+  match: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+  history: PropTypes.object.isRequired,
+}
+
+class PoolDetailPage extends React.Component {
+  componentWillMount () {
+    this.props.getPools({ poolId: this.props.match.params.id })
+  }
+  render () {
+    let { match, vms } = this.props
+    if (vms.getIn(['pools', match.params.id, 'vm'])) {
+      return (<VmDetail vm={vms.getIn(['pools', match.params.id, 'vm'])} pool={vms.getIn(['pools', match.params.id])} isPool />)
+    }
+    return null
+  }
+}
+
+PoolDetailPage.propTypes = {
+  vms: PropTypes.object.isRequired,
+  getPools: PropTypes.func.isRequired,
+  route: PropTypes.object.isRequired,
+  match: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+  history: PropTypes.object.isRequired,
+}
+
+class VmDialogPage extends React.Component {
+  componentWillMount () {
+    if (this.props.match.params.id) {
+      this.props.getVms({ vmId: this.props.match.params.id })
+    }
+  }
+
+  render () {
+    let { match, vms } = this.props
+    if ((match.params.id && vms.getIn(['vms', match.params.id])) || !match.params.id) {
+      return (<VmDialog vm={vms.getIn(['vms', match.params.id])} />)
+    }
+    return null
+  }
+}
+
+VmDialogPage.propTypes = {
+  vms: PropTypes.object.isRequired,
+  getVms: PropTypes.func.isRequired,
+  route: PropTypes.object.isRequired,
+  match: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+  history: PropTypes.object.isRequired,
+}
+
+const VmDetailPageConnected = connect(
+  (state) => ({
+    vms: state.vms,
+  }),
+  (dispatch) => ({
+    getVms: ({ vmId }) => dispatch(selectVmDetail({ vmId })),
+  })
+)(VmDetailPage)
+
+const PoolDetailPageConnected = connect(
+  (state) => ({
+    vms: state.vms,
+  }),
+  (dispatch) => ({
+    getPools: ({ poolId }) => dispatch(selectPoolDetail({ poolId })),
+  })
+)(PoolDetailPage)
+
+const VmDialogPageConnected = connect(
+  (state) => ({
+    vms: state.vms,
+  }),
+  (dispatch) => ({
+    getVms: ({ vmId }) => dispatch(selectVmDetail({ vmId })),
+  })
+)(VmDialogPage)
+
+export {
+  PoolDetailPageConnected as PoolDetailPage,
+  VmDetailPageConnected as VmDetailPage,
+  VmDialogPageConnected as VmDialogPage,
+}

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -1,0 +1,27 @@
+import React, { PropTypes } from 'react'
+import style from './style.css'
+
+const Toolbar = ({ children }) => {
+  let i = 0
+  const tempChildren = children.map((c) => {
+    i++
+    return (<div key={'toolbar' + i} className={`form-group toolbar-pf-view-selector ${style['actions-padding']}`}>{c}</div>)
+  })
+  return (<div className='container-fluid'>
+    <div className='row toolbar-pf'>
+      <div className='col-sm-12'>
+        <div className='toolbar-pf-actions'>
+          <div className='toolbar-pf-action-right'>
+            {tempChildren}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>)
+}
+
+Toolbar.propTypes = {
+  children: PropTypes.node.isRequired,
+}
+
+export default Toolbar

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -1,0 +1,42 @@
+import React, { PropTypes } from 'react'
+import { connect } from 'react-redux'
+
+import VmActions from '../VmActions'
+
+const VmDetailToolbar = ({ match, vms }) => {
+  if (vms.getIn(['vms', match.params.id])) {
+    return (<VmActions vm={vms.getIn(['vms', match.params.id])} />)
+  }
+  return null
+}
+
+VmDetailToolbar.propTypes = {
+  vms: PropTypes.object.isRequired,
+  match: PropTypes.object.isRequired,
+}
+
+const VmDetailToolbarConnected = connect(
+  (state) => ({
+    vms: state.vms,
+  })
+)(VmDetailToolbar)
+
+const PoolDetailToolbar = ({ match, vms }) => {
+  if (vms.getIn(['pools', match.params.id])) {
+    return (<VmActions vm={vms.getIn(['pools', match.params.id, 'vm'])} key='vmaction' pool={vms.getIn(['pools', match.params.id])} isPool />)
+  }
+  return null
+}
+
+PoolDetailToolbar.propTypes = {
+  vms: PropTypes.object.isRequired,
+  match: PropTypes.object.isRequired,
+}
+
+const PoolDetailToolbarConnected = connect(
+  (state) => ({
+    vms: state.vms,
+  })
+)(PoolDetailToolbar)
+
+export { VmDetailToolbarConnected as VmDetailToolbar, PoolDetailToolbarConnected as PoolDetailToolbar }

--- a/src/components/Toolbar/style.css
+++ b/src/components/Toolbar/style.css
@@ -1,0 +1,3 @@
+.actions-padding {
+	padding-left: 0px;
+}

--- a/src/components/VerticalMenu.js
+++ b/src/components/VerticalMenu.js
@@ -1,0 +1,29 @@
+import React, { PropTypes } from 'react'
+import { Link } from 'react-router-dom'
+import style from './sharedStyle.css'
+
+const VerticalMenu = ({ menuItems }) => {
+  const itemsComponents = menuItems.map((item, index) => {
+    let icon = null
+    if (item.icon !== undefined) {
+      icon = (<span className={item.icon} key={item.icon} data-toggle='tooltip' title='' data-original-title={item.title} />)
+    }
+    return (<li className='list-group-item' key={item.title}>
+      <Link to={item.to}>
+        {icon}
+        <span className='list-group-item-value'>{item.title}</span>
+      </Link>
+    </li>)
+  })
+  return (<div className={`nav-pf-vertical nav-pf-vertical-with-sub-menus nav-pf-persistent-secondary ${style['vertical-menu']}`}>
+    <ul className='list-group'>
+      {itemsComponents}
+    </ul>
+  </div>)
+}
+
+VerticalMenu.propTypes = {
+  menuItems: PropTypes.array.isRequired,
+}
+
+export default VerticalMenu

--- a/src/components/VmActions/style.css
+++ b/src/components/VmActions/style.css
@@ -14,5 +14,13 @@
 
 .left-padding {
     text-align: left;
-    padding-left: 5em;
+    /*padding-left: 5em;*/
+}
+
+.action-link {
+	color: #363636;
+}
+
+.link {
+	height: 27px;
 }

--- a/src/components/VmDetail/index.js
+++ b/src/components/VmDetail/index.js
@@ -7,14 +7,11 @@ import style from './style.css'
 
 import {
   downloadConsole,
-  startPool,
-  startVm,
   getConsoleOptions,
   saveConsoleOptions,
 } from '../../actions'
 
 import Time from '../Time'
-import VmActions from '../VmActions'
 import DetailContainer from '../DetailContainer'
 import { canConsole, userFormatOfBytes, VmIcon, VmDisks, VmStatusIcon, ConsoleOptions } from 'ovirt-ui-components'
 import Selectors from '../../selectors'
@@ -89,25 +86,10 @@ class VmDetail extends Component {
       userMessages,
       onConsole,
       isPool,
-      onStartPool,
-      onStartVm,
       onConsoleOptionsSave,
       options,
       pool,
     } = this.props
-
-    let onStart = onStartVm
-
-    if (!vm && !isPool) {
-      return null
-    }
-
-    if (isPool && pool) {
-      onStart = onStartPool
-    }
-    if (isPool && !pool) {
-      return null
-    }
 
     const name = isPool ? pool.get('name') : vm.get('name')
     const iconId = vm.getIn(['icons', 'small', 'id'])
@@ -145,31 +127,34 @@ class VmDetail extends Component {
 
     return (
       <DetailContainer>
-        <h1>
+        <h1 className={style['header']}>
           <VmIcon icon={icon} missingIconClassName='pficon pficon-virtual-machine' className={style['vm-detail-icon']} />
           &nbsp;{name}
         </h1>
-        <VmActions vm={vm} userMessages={userMessages} isPool={isPool} onStart={onStart} />
         <LastMessage vmId={vm.get('id')} userMessages={userMessages} />
-        <dl className={style['vm-properties']}>
-          <dt>State</dt>
-          <dd><VmStatusIcon state={vm.get('status')} /> {vm.get('status')}</dd>
-          <dt>Description</dt>
-          <dd>{vm.get('description')}</dd>
-          <dt>Operating System</dt>
-          <dd>{os ? os.get('description') : vm.getIn(['os', 'type'])}</dd>
-          <dt><span className='pficon pficon-memory' /> Defined Memory</dt>
-          <dd>{userFormatOfBytes(vm.getIn(['memory', 'total'])).str}</dd>
-          <dt><span className='pficon pficon-cpu' /> CPUs</dt>
-          <dd>{vm.getIn(['cpu', 'vCPUs'])}</dd>
-          <dt><span className='pficon pficon-network' /> Address</dt>
-          <dd>{vm.get('fqdn')}</dd>
-          <dt><span className='pficon pficon-screen' /> Console&nbsp;{consoleOptionsShowHide}</dt>
-          <VmConsoles vm={vm} onConsole={onConsole} />
-          <ConsoleOptions options={optionsJS} onSave={onConsoleOptionsSave} open={this.state.openConsoleSettings} />
-          <dt><span className='fa fa-database' /> Disks&nbsp;{disksShowHide}</dt>
-          <dd>{disksElement}</dd>
-        </dl>
+        <div className={style['vm-detail-container']}>
+          <dl className={style['vm-properties']}>
+            <dt>State</dt>
+            <dd><VmStatusIcon state={vm.get('status')} /> {vm.get('status')}</dd>
+            <dt>Description</dt>
+            <dd>{vm.get('description')}</dd>
+            <dt>Operating System</dt>
+            <dd>{os ? os.get('description') : vm.getIn(['os', 'type'])}</dd>
+            <dt><span className='pficon pficon-memory' /> Defined Memory</dt>
+            <dd>{userFormatOfBytes(vm.getIn(['memory', 'total'])).str}</dd>
+            <dt><span className='pficon pficon-cpu' /> CPUs</dt>
+            <dd>{vm.getIn(['cpu', 'vCPUs'])}</dd>
+            <dt><span className='pficon pficon-network' /> Address</dt>
+            <dd>{vm.get('fqdn')}</dd>
+          </dl>
+          <dl className={style['vm-properties']}>
+            <dt><span className='pficon pficon-screen' /> Console&nbsp;{consoleOptionsShowHide}</dt>
+            <VmConsoles vm={vm} onConsole={onConsole} />
+            <ConsoleOptions options={optionsJS} onSave={onConsoleOptionsSave} open={this.state.openConsoleSettings} />
+            <dt><span className='fa fa-database' /> Disks&nbsp;{disksShowHide}</dt>
+            <dd>{disksElement}</dd>
+          </dl>
+        </div>
       </DetailContainer>
     )
   }
@@ -183,8 +168,6 @@ VmDetail.propTypes = {
   onConsoleOptionsSave: PropTypes.func.isRequired,
   onConsoleOptionsOpen: PropTypes.func.isRequired,
   options: PropTypes.object.isRequired,
-  onStartPool: PropTypes.func.isRequired,
-  onStartVm: PropTypes.func.isRequired,
   isPool: PropTypes.bool,
 }
 
@@ -194,11 +177,10 @@ export default connect(
     userMessages: state.userMessages,
     options: state.options,
   }),
-  (dispatch, { vm, pool }) => ({
+
+  (dispatch, { vm }) => ({
     onConsole: ({ vmId, consoleId }) => dispatch(downloadConsole({ vmId, consoleId })),
     onConsoleOptionsSave: ({ options }) => dispatch(saveConsoleOptions({ vmId: vm.get('id'), options })),
     onConsoleOptionsOpen: () => dispatch(getConsoleOptions({ vmId: vm.get('id') })),
-    onStartPool: () => dispatch(startPool({ poolId: pool.get('id') })),
-    onStartVm: () => dispatch(startVm({ vmId: vm.get('id') })),
   })
 )(VmDetail)

--- a/src/components/VmDetail/style.css
+++ b/src/components/VmDetail/style.css
@@ -1,5 +1,6 @@
 .vm-properties {
     font-size: large;
+    width: 50%;
 }
 
 dt {
@@ -34,4 +35,18 @@ dd {
 .left-delimiter + .left-delimiter {
     padding-left: 13px;
     border-left: 1px solid #d1d1d1;
+}
+
+.options-btn {
+    vertical-align: middle;
+    margin-left: 5px;
+    color: gray;
+}
+
+.header {
+    padding-bottom: 15px;
+}
+
+.vm-detail-container {
+    display: flex;
 }

--- a/src/components/VmDialog/AddVmButton.js
+++ b/src/components/VmDialog/AddVmButton.js
@@ -1,31 +1,12 @@
 import React from 'react'
-import PropTypes from 'prop-types'
+import { Link } from 'react-router-dom'
 
-import { connect } from 'react-redux'
-
-import { openAddVmDialog } from '../../actions/index'
-
-const AddVmButton = ({ name, toggleDialog }) => (
-  <div>
-    <button
-      width='100%'
-      type='button'
-      className='btn btn-primary'
-      onClick={toggleDialog}>
-      <span className='pfincon pficon pficon-add-circle-o' />&nbsp;{name}
-    </button>
-  </div>
-)
-
-AddVmButton.propTypes = {
-  name: PropTypes.string.isRequired,
-  toggleDialog: PropTypes.func.isRequired,
+const AddVmButton = () => {
+  return (<div>
+    <Link className='btn btn-primary' to='/vm/add'>
+      Add Virtual Machine
+    </Link>
+  </div>)
 }
 
-export default connect(
-  (state) => ({}),
-  (dispatch) => ({
-    toggleDialog: () =>
-      dispatch(openAddVmDialog()),
-  })
-)(AddVmButton)
+export default AddVmButton

--- a/src/components/VmDialog/actions.js
+++ b/src/components/VmDialog/actions.js
@@ -1,0 +1,36 @@
+import { SET_SAVED_VM, ADD_NEW_VM, EDIT_VM } from './constants'
+
+export function setSavedVm ({ vm }) {
+  return {
+    type: SET_SAVED_VM,
+    payload: {
+      vm,
+    },
+  }
+}
+
+/**
+ * New VM will be created in oVirt (REST API)
+ */
+export function createVm (vm, actionUniqueId) {
+  return {
+    type: ADD_NEW_VM,
+    actionUniqueId,
+    payload: {
+      vm,
+    },
+  }
+}
+
+/**
+ * Existing VM definition will be updated in oVirt (REST API)
+ */
+export function editVm (vm, actionUniqueId) {
+  return {
+    type: EDIT_VM,
+    actionUniqueId,
+    payload: {
+      vm,
+    },
+  }
+}

--- a/src/components/VmDialog/constants.js
+++ b/src/components/VmDialog/constants.js
@@ -1,0 +1,3 @@
+export const SET_SAVED_VM = 'VM_DIALOG_SET_SAVED_VM'
+export const ADD_NEW_VM = 'VM_DIALOG_ADD_NEW_VM'
+export const EDIT_VM = 'VM_DIALOG_EDIT_VM'

--- a/src/components/VmDialog/reducer.js
+++ b/src/components/VmDialog/reducer.js
@@ -1,0 +1,13 @@
+import Immutable from 'immutable'
+import { SET_SAVED_VM } from './constants'
+
+export function reducer (state, action) {
+  state = state || Immutable.fromJS({ vm: null })
+
+  switch (action.type) {
+    case SET_SAVED_VM:
+      return state.set('vm', Immutable.fromJS(action.payload.vm))
+    default:
+      return state
+  }
+}

--- a/src/components/VmDialog/sagas.js
+++ b/src/components/VmDialog/sagas.js
@@ -1,0 +1,29 @@
+import { put } from 'redux-saga/effects'
+import { takeEvery, takeLatest } from 'redux-saga'
+import { getAllVms, getSingleVm } from '../../actions/index'
+import { ADD_NEW_VM, EDIT_VM } from './constants'
+import { setSavedVm } from './actions'
+import Api from '../../ovirtapi'
+
+function* createNewVm (sagas, action) {
+  const result = yield sagas.callExternalAction('addNewVm', Api.addNewVm, action)
+  if (!result.error) {
+    yield put(getAllVms({ shallowFetch: false }))
+    yield put(setSavedVm({ vm: Api.vmToInternal({ vm: result }) }))
+  }
+}
+
+function* editVm (sagas, action) {
+  const result = yield sagas.callExternalAction('editVm', Api.editVm, action)
+  if (!result.error) {
+    yield sagas.fetchSingleVm(getSingleVm({ vmId: action.payload.vm.id }))
+    yield put(setSavedVm({ vm: Api.vmToInternal({ vm: result }) }))
+  }
+}
+
+export function buildSagas (sagas) {
+  return [
+    takeEvery(ADD_NEW_VM, createNewVm, sagas),
+    takeLatest(EDIT_VM, editVm, sagas),
+  ]
+}

--- a/src/components/VmModals/rednerModal.js
+++ b/src/components/VmModals/rednerModal.js
@@ -1,0 +1,42 @@
+import React from 'react'
+
+import ReactDOM from 'react-dom'
+
+export default ({ Component, onYes, onNo, props }) => {
+  const containerId = 'extrnal-modal-container'
+  const container = document.getElementById(containerId)
+  const wrapper = document.body.appendChild(container || document.createElement('div'))
+  wrapper.id = containerId
+  wrapper.className = 'confirmation-container'
+
+  function dispose () {
+    setTimeout(() => {
+      ReactDOM.unmountComponentAtNode(wrapper)
+      setTimeout(() => wrapper.remove(), 0)
+    }, 1)
+  }
+
+  const onYesWrap = (params) => {
+    dispose()
+    onYes(params)
+  }
+
+  const onNoWrap = (params) => {
+    dispose()
+    onNo(params)
+  }
+
+  try {
+    ReactDOM.render(
+      <Component
+        onYes={onYesWrap}
+        onNo={onNoWrap}
+        {...props}
+      />,
+      wrapper
+    )
+  } catch (e) {
+    console.error(e)
+    throw e
+  }
+}

--- a/src/components/VmsList/Pool.js
+++ b/src/components/VmsList/Pool.js
@@ -2,6 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { connect } from 'react-redux'
+import {
+  Redirect,
+  withRouter,
+} from 'react-router-dom'
 
 import style from './style.css'
 
@@ -9,55 +13,68 @@ import VmStatusText from './VmStatusText'
 import VmActions from '../VmActions'
 import { VmIcon, VmStatusIcon } from 'ovirt-ui-components'
 
-import { selectPoolDetail, startPool } from '../../actions'
+import { startPool } from '../../actions'
 
 /**
  * Single icon-card in the list
  */
-const Pool = ({ pool, icons, onSelectPool, visibility, onStart }) => {
-  const state = pool.get('status')
+class Pool extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = { openDetail: false }
+  }
+  render () {
+    let { pool, icons, visibility, onStart } = this.props
+    if (this.state.openDetail) {
+      return (<Redirect to={`/pool/${pool.get('id')}`} />)
+    }
 
-  const iconId = pool.getIn(['vm', 'icons', 'large', 'id'])
-  const icon = icons.get(iconId)
-  const isSelected = pool.get('id') === visibility.get('selectedPoolDetail')
+    const state = pool.get('status')
 
-  return (
-    <div className={`col-xs-12 col-sm-6 col-md-4 col-lg-3 ${isSelected ? style['selectedPool'] : ''}`}>
-      <div className='card-pf card-pf-view card-pf-view-select card-pf-view-single-select'>
-        <div className='card-pf-body'>
-          <div className='card-pf-top-element' onClick={onSelectPool}>
-            <VmIcon icon={icon} className={style['card-pf-icon']}
-              missingIconClassName='fa fa-birthday-cake card-pf-icon-circle' />
+    const iconId = pool.getIn(['vm', 'icons', 'large', 'id'])
+    const icon = icons.get(iconId)
+    const isSelected = pool.get('id') === visibility.get('selectedPoolDetail')
+
+    const onCardClick = () => {
+      this.setState({ openDetail: true })
+    }
+
+    return (
+      <div className={`col-xs-12 col-sm-6 col-md-4 col-lg-3 ${isSelected ? style['selectedPool'] : ''}`}>
+        <div className='card-pf card-pf-view card-pf-view-select card-pf-view-single-select'>
+          <div className='card-pf-body'>
+            <div className='card-pf-top-element' onClick={onCardClick}>
+              <VmIcon icon={icon} className={style['card-pf-icon']}
+                missingIconClassName='fa fa-birthday-cake card-pf-icon-circle' />
+            </div>
+            <h2 className='card-pf-title text-center' onClick={onCardClick}>
+              <p className={[style['vm-name'], style['crop']].join(' ')} title={pool.get('name')} data-toggle='tooltip'>
+                <VmStatusIcon state={state} />&nbsp;{pool.get('name')}
+              </p>
+            </h2>
+
+            <VmActions vm={pool.get('vm')} isOnCard isPool onStart={onStart} pool={pool} />
+            <VmStatusText vm={pool.get('vm')} />
+
           </div>
-          <h2 className='card-pf-title text-center' onClick={onSelectPool}>
-            <p className={[style['vm-name'], style['crop']].join(' ')} title={pool.get('name')} data-toggle='tooltip'>
-              <VmStatusIcon state={state} />&nbsp;{pool.get('name')}
-            </p>
-          </h2>
-
-          <VmActions vm={pool.get('vm')} isOnCard isPool onStart={onStart} />
-          <VmStatusText vm={pool.get('vm')} />
-
         </div>
       </div>
-    </div>
-  )
+    )
+  }
 }
 Pool.propTypes = {
   pool: PropTypes.object.isRequired,
   icons: PropTypes.object.isRequired,
-  onSelectPool: PropTypes.func.isRequired,
   onStart: PropTypes.func.isRequired,
   visibility: PropTypes.object.isRequired,
 }
 
-export default connect(
+export default withRouter(connect(
   (state) => ({
     icons: state.icons,
     visibility: state.visibility,
   }),
   (dispatch, { pool }) => ({
-    onSelectPool: () => dispatch(selectPoolDetail({ poolId: pool.get('id') })),
     onStart: () => dispatch(startPool({ poolId: pool.get('id') })),
   })
-)(Pool)
+)(Pool))

--- a/src/components/VmsList/Vm.js
+++ b/src/components/VmsList/Vm.js
@@ -2,6 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { connect } from 'react-redux'
+import {
+  Redirect,
+  withRouter,
+} from 'react-router-dom'
 
 import style from './style.css'
 
@@ -10,61 +14,77 @@ import VmActions from '../VmActions'
 import { VmIcon, VmStatusIcon } from 'ovirt-ui-components'
 import { closeAllConfirmationComponents } from '../Confirmation'
 
-import { selectVmDetail, startVm } from '../../actions/index'
+import { startVm } from '../../actions/index'
 
 /**
  * Single icon-card in the list
  */
-const Vm = ({ vm, icons, onSelectVm, visibility, onStart }) => {
-  const state = vm.get('status')
-
-  const iconId = vm.getIn(['icons', 'large', 'id'])
-  const icon = icons.get(iconId)
-  const isSelected = vm.get('id') === visibility.get('selectedVmDetail')
-
-  const onCardClick = () => {
-    closeAllConfirmationComponents()
-    onSelectVm()
+class Vm extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = { openDetail: false }
   }
 
-  return (
-    <div className={`col-xs-12 col-sm-6 col-md-4 col-lg-3 ${isSelected ? style['selectedVm'] : ''}`}>
-      <div className='card-pf card-pf-view card-pf-view-select card-pf-view-single-select'>
-        <div className='card-pf-body'>
-          <div className='card-pf-top-element' onClick={onCardClick}>
-            <VmIcon icon={icon} className={style['card-pf-icon']}
-              missingIconClassName='fa fa-birthday-cake card-pf-icon-circle' />
+  render () {
+    let { vm, icons, visibility, onStart } = this.props
+
+    if (this.state.openDetail) {
+      return (<Redirect to={`/vm/${vm.get('id')}`} />)
+    }
+
+    const state = vm.get('status')
+
+    const iconId = vm.getIn(['icons', 'large', 'id'])
+    const icon = icons.get(iconId)
+    const isSelected = vm.get('id') === visibility.get('selectedVmDetail')
+
+    const onCardClick = () => {
+      closeAllConfirmationComponents()
+      // onSelectVm()
+      this.setState({ openDetail: true })
+    }
+
+    // TODO: improve the card flip:
+    // TODO: https://davidwalsh.name/css-flip
+    // TODO: http://tympanus.net/codrops/2013/12/18/perspective-page-view-navigation/
+    // TODO: https://desandro.github.io/3dtransforms/docs/card-flip.html
+    return (
+      <div className={`col-xs-12 col-sm-6 col-md-4 col-lg-3 ${isSelected ? style['selectedVm'] : ''}`}>
+        <div className='card-pf card-pf-view card-pf-view-select card-pf-view-single-select'>
+          <div className='card-pf-body'>
+            <div className='card-pf-top-element' onClick={onCardClick}>
+              <VmIcon icon={icon} className={style['card-pf-icon']}
+                missingIconClassName='fa fa-birthday-cake card-pf-icon-circle' />
+            </div>
+            <h2 className='card-pf-title text-center' onClick={onCardClick}>
+              <p className={[style['vm-name'], style['crop']].join(' ')} title={vm.get('name')} data-toggle='tooltip'>
+                <VmStatusIcon state={state} />&nbsp;{vm.get('name')}
+              </p>
+            </h2>
+
+            <VmActions vm={vm} isOnCard onStart={onStart} />
+            <VmStatusText vm={vm} />
+
           </div>
-          <h2 className='card-pf-title text-center' onClick={onCardClick}>
-            <p className={[style['vm-name'], style['crop']].join(' ')} title={vm.get('name')} data-toggle='tooltip'>
-              <VmStatusIcon state={state} />&nbsp;{vm.get('name')}
-            </p>
-          </h2>
-
-          <VmActions vm={vm} isOnCard onStart={onStart} />
-          <VmStatusText vm={vm} />
-
         </div>
       </div>
-    </div>
-  )
+    )
+  }
 }
 
 Vm.propTypes = {
   vm: PropTypes.object.isRequired,
   icons: PropTypes.object.isRequired,
-  onSelectVm: PropTypes.func.isRequired,
   onStart: PropTypes.func.isRequired,
   visibility: PropTypes.object.isRequired,
 }
 
-export default connect(
+export default withRouter(connect(
   (state) => ({
     icons: state.icons,
     visibility: state.visibility,
   }),
   (dispatch, { vm }) => ({
-    onSelectVm: () => dispatch(selectVmDetail({ vmId: vm.get('id') })),
     onStart: () => dispatch(startVm({ vmId: vm.get('id') })),
   })
-)(Vm)
+)(Vm))

--- a/src/components/VmsList/Vms.js
+++ b/src/components/VmsList/Vms.js
@@ -7,30 +7,17 @@ import style from './style.css'
 import Vm from './Vm'
 import Pool from './Pool'
 
-import { closeDialog } from '../../actions/index'
-import { closeAllConfirmationComponents } from '../Confirmation'
-
-const Vms = ({ vms, visibility, onCloseDetail }) => {
-  const isDetailVisible = !!visibility.get('dialogToShow')
+const Vms = ({ vms, visibility }) => {
   const containerClass = ['container-fluid',
     'container-cards-pf',
     style['movable-left'],
-    style['max-window-height'],
-    isDetailVisible ? style['moved-left'] : '',
+    style['full-window'],
   ].join(' ')
-
-  const closeDetail = isDetailVisible
-    ? (event) => {
-      closeAllConfirmationComponents()
-      onCloseDetail()
-      event.stopPropagation()
-    }
-    : undefined
 
   const sortFunction = (vmA, vmB) => vmA.get('name').localeCompare(vmB.get('name'))
 
   return (
-    <div onClickCapture={closeDetail}>
+    <div>
       <div className={containerClass}>
         <div className={style['scrollingWrapper']}>
           <div className='row row-cards-pf'>
@@ -56,7 +43,6 @@ const Vms = ({ vms, visibility, onCloseDetail }) => {
 Vms.propTypes = {
   vms: PropTypes.object.isRequired,
   visibility: PropTypes.object.isRequired,
-  onCloseDetail: PropTypes.func.isRequired,
 }
 
 export default connect(
@@ -65,6 +51,5 @@ export default connect(
     visibility: state.visibility,
   }),
   (dispatch) => ({
-    onCloseDetail: () => dispatch(closeDialog({ force: false })),
   })
 )(Vms)

--- a/src/components/VmsList/index.js
+++ b/src/components/VmsList/index.js
@@ -2,9 +2,11 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { connect } from 'react-redux'
+import { withRouter } from 'react-router-dom'
 
 import ContainerFluid from '../ContainerFluid'
 import Vms from './Vms'
+import LoadingData from '../LoadingData'
 
 /**
  * Data are fetched but no VM is available to display
@@ -25,42 +27,27 @@ const NoVm = () => {
   )
 }
 
-/**
- * Login (token) to Engine is missing.
- */
-const NoLogin = () => {
-  return (
-    <div className='blank-slate-pf'>
-      <div className='blank-slate-pf-icon'>
-        <span className='pficon pficon pficon-user' />
-      </div>
-      <h1>
-        Please log in ...
-      </h1>
-    </div>
-  )
-}
-
 const VmsList = ({ vms, config, visibility }) => {
   const isDetailVisible = !!visibility.get('dialogToShow')
-  const loadInProgress = !!vms.get('loadInProgress')
 
   if (vms.get('vms') && !vms.get('vms').isEmpty()) {
     return (
       <Vms />
     )
-  } else if (!config.get('loginToken')) { // login is missing
-    return (
-      <ContainerFluid>
-        <NoLogin />
-      </ContainerFluid>
-    )
-  } else if (!isDetailVisible && !loadInProgress) { // No VM available
-    return (
-      <ContainerFluid>
-        <NoVm />
-      </ContainerFluid>
-    )
+  } else if (!isDetailVisible) {
+    if (vms.get('loadInProgress')) { // data load in progress
+      return (
+        <ContainerFluid>
+          <LoadingData />
+        </ContainerFluid>
+      )
+    } else { // No VM available
+      return (
+        <ContainerFluid>
+          <NoVm />
+        </ContainerFluid>
+      )
+    }
   }
 
   return null
@@ -71,10 +58,10 @@ VmsList.propTypes = {
   visibility: PropTypes.object.isRequired,
 }
 
-export default connect(
+export default withRouter(connect(
   (state) => ({
     vms: state.vms,
     config: state.config,
     visibility: state.visibility,
   })
-)(VmsList)
+)(VmsList))

--- a/src/components/VmsList/style.css
+++ b/src/components/VmsList/style.css
@@ -56,6 +56,7 @@
     z-index: 20;
 }
 
-.max-window-height {
-    height: calc(100vh - 100px);
+.full-window {
+    height: calc(100vh - 160px);
 }
+

--- a/src/components/sharedStyle.css
+++ b/src/components/sharedStyle.css
@@ -1,12 +1,8 @@
 .move-left-detail { /* VM detail on the right */
-    position: fixed;
-    top: 2.5em;
     height: 100%;
     display: block;
-    left: 50%;
-    width: 50%;
+    width: 100%;
     opacity:1;
-    transition:opacity 0.75s ease-in-out;
 }
 
 .move-left-detail-invisible {
@@ -24,4 +20,19 @@
 
 .usermenu-z-index {
     z-index: 2000;
+}
+
+.vertical-menu {
+	top: 29px !important;
+}
+
+.breadcrumb {
+    border-bottom: solid gray;
+    padding-left: 15px;
+    margin-bottom: 5px;
+}
+
+.navbar-top-offset {
+    padding-top: 29px;
+    margin-left: 200px;
 }

--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@ const CONFIG_URL = '/ovirt-engine/web-ui/ovirt-web-ui.config'
 const AppConfiguration = {
   debug: true,
   applicationContext: '',
-  applicationURL: '',
+  applicationURL: '/',
 }
 
 export function readConfiguration () {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,12 +1,10 @@
 // Keep alphabetically sorted
 // TODO: sort alphabetically
 // TODO: remove all constants except those used within sagas
-export const ADD_NEW_VM = 'ADD_NEW_VM'
 export const CHANGE_FILTER_PERMISSION = 'CHANGE_FILTER_PERMISSION'
 export const CHECK_TOKEN_EXPIRED = 'CHECK_TOKEN_EXPIRED'
 export const CLEAR_USER_MSGS = 'CLEAR_USER_MSGS'
 export const DOWNLOAD_CONSOLE_VM = 'DOWNLOAD_CONSOLE_VM'
-export const EDIT_VM = 'EDIT_VM'
 export const FAILED_EXTERNAL_ACTION = 'FAILED_EXTERNAL_ACTION'
 export const GET_ALL_CLUSTERS = 'GET_ALL_CLUSTERS'
 export const GET_ALL_OS = 'GET_ALL_OS'
@@ -37,10 +35,8 @@ export const SELECT_VM_DETAIL = 'SELECT_VM_DETAIL'
 export const SET_ADMINISTATOR = 'SET_ADMINISTATOR'
 export const SET_LOAD_IN_PROGRESS = 'SET_LOAD_IN_PROGRESS'
 export const SET_OVIRT_API_VERSION = 'SET_OVIRT_API_VERSION'
-export const SET_POOL_DETAIL_TO_SHOW = 'SET_POOL_DETAIL_TO_SHOW'
 export const SET_USER_FILTER_PERMISSION = 'SET_USER_FILTER_PERMISSION'
 export const SET_VM_CONSOLES = 'SET_VM_CONSOLES'
-export const SET_VM_DETAIL_TO_SHOW = 'SET_VM_DETAIL_TO_SHOW'
 export const SET_VM_DISKS = 'SET_VM_DISKS'
 export const SET_VM_SESSIONS = 'SET_VM_SESSIONS'
 export const SHUTDOWN_VM = 'SHUTDOWN_VM'

--- a/src/index-nomodules.css
+++ b/src/index-nomodules.css
@@ -36,3 +36,14 @@ body {
   margin-left: 10px;
   font-weight: normal;
 }
+
+div.toolbar-pf {
+  height: 38px;
+  padding-top: 0;
+  margin-top: 5px;
+}
+
+.alert {
+  top: 30px;
+  margin-left: 201px;
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -9,8 +9,10 @@ import options from './options'
 
 import templates from './templates'
 import clusters from './clusters'
+import route from './route'
 import operatingSystems from './operatingSystems'
 import { reducer as VmAction } from '../components/VmActions/reducer'
+import { reducer as VmDialog } from '../components/VmDialog/reducer'
 
 function router (redirectUrl = '/', action) {
   switch (action.type) {
@@ -30,5 +32,7 @@ export default combineReducers({
   templates,
   clusters,
   operatingSystems,
+  route,
   VmAction,
+  VmDialog,
 })

--- a/src/reducers/route.js
+++ b/src/reducers/route.js
@@ -1,0 +1,20 @@
+import Immutable from 'immutable'
+import { actionReducer } from './utils'
+
+/**
+ * The Route reducer
+ *
+ * @param state
+ * @param action
+ * @returns {*}
+ */
+const route = actionReducer(Immutable.fromJS({
+  redirect: undefined, // undefined, '/', '/vm/00-0000-00000-000' and etc.
+}), {
+  REDIRECT (state, action) {
+    return state
+      .set('redirect', action.payload.route)
+  },
+})
+
+export default route

--- a/src/reducers/visibility.js
+++ b/src/reducers/visibility.js
@@ -32,35 +32,9 @@ const visibility = actionReducer(Immutable.fromJS({
       .set('dialogCloseConfirmationToShow', null)
   },
 
-  REQUEST_CLOSE_DIALOG_CONFIRMATION (state) {
-    return state
-      .set('dialogConfirmationRequested', true)
-      .set('dialogCloseConfirmationToShow', false)
-  },
-
   TOGGLE_OPTIONS (state) { // TODO: rename to OPEN_SETTINGS
     return state
       .set('dialogToShow', state.get('dialogToShow') === 'Options' ? null : 'Options')
-  },
-  SET_VM_DETAIL_TO_SHOW (state, action) { // rename to OPEN_VM_DETAIL
-    return state
-      .set('selectedVmDetail', action.payload.vmId)
-      .set('dialogToShow', 'VmDetail')
-  },
-  SET_POOL_DETAIL_TO_SHOW (state, { payload: { poolId } }) {
-    return state
-      .set('selectedPoolDetail', poolId)
-      .set('dialogToShow', 'PoolDetail')
-  },
-  OPEN_ADD_VM_DIALOG (state) {
-    return state
-      .set('dialogToShow', 'VmDialog')
-  },
-
-  OPEN_EDIT_VM_DIALOG (state, action) {
-    return state
-      .set('dialogToShow', 'VmDialog')
-      .set('selectedVmDetail', action.payload.vmId)
   },
 })
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,0 +1,75 @@
+import React from 'react'
+
+import AddVmButton from './components/VmDialog/AddVmButton'
+import PageRouter from './components/PageRouter'
+import { VmDetailToolbar, PoolDetailToolbar } from './components/Toolbar/index'
+import VmsPage from './components/Pages/VmsPage'
+import { VmDetailPage, PoolDetailPage, VmDialogPage } from './components/Pages/index'
+
+/**
+ * Function get vms object, and return routes object
+ * Every route must has path, component that presentate page,
+ * title (except top route), it can be function (get match parameter) or string,
+ * toolbars as array of functions that get match parameter and return component.
+ * @param vms {object}
+ * @return {array}
+ */
+const getRoutes = (vms) => ([
+  {
+    component: PageRouter,
+    routes: [
+      {
+        path: '/',
+        exact: true,
+        component: () =>
+          (<VmsPage />),
+        toolbars: [(match) => (<AddVmButton key='addbutton' />)],
+      },
+      {
+        path: '/vm/add',
+        exact: true,
+        title: (match) => 'Add new VM',
+        component: VmDialogPage,
+        toolbars: [],
+      },
+      {
+        path: '/vm/:id',
+        title: (match) => {
+          return vms.getIn(['vms', match.params.id, 'name'])
+        },
+        component: VmDetailPage,
+        toolbars: [(match) => (<VmDetailToolbar match={match} key='vmaction' />)],
+        routes: [
+          {
+            path: '/vm/:id/edit',
+            component: VmDialogPage,
+            title: 'Edit',
+            toolbars: [],
+          },
+        ],
+      },
+      {
+        path: '/pool/:id',
+        title: (match) => {
+          return vms.getIn(['pools', match.params.id, 'name'])
+        },
+        component: PoolDetailPage,
+        toolbars: [(match) => (<PoolDetailToolbar match={match} key='poolaction' />)],
+      },
+    ],
+  },
+])
+
+/**
+ * Return array of objects that describe vertical menu
+ * @return {array}
+ */
+const getMenu = () => ([
+  {
+    icon: 'pficon pficon-virtual-machine',
+    title: 'Virtual Machines',
+    to: '/',
+  },
+])
+
+export { getRoutes, getMenu }

--- a/src/sagasBuilder.js
+++ b/src/sagasBuilder.js
@@ -1,4 +1,5 @@
 import { buildSagas as VmActionsSagas } from './components/VmActions/sagas'
+import { buildSagas as VmDialogSagas } from './components/VmDialog/sagas'
 
 /**
   SagasBuiler takes sagas workers from modules, and merge it to one array.
@@ -8,4 +9,5 @@ import { buildSagas as VmActionsSagas } from './components/VmActions/sagas'
 */
 export default (sagas) => [
   ...VmActionsSagas(sagas),
+  ...VmDialogSagas(sagas),
 ]


### PR DESCRIPTION
Partially fixes: https://github.com/oVirt/ovirt-web-ui/issues/156

@jelkosz @mareklibra @matobet 

------------------------
Must-Have (see https://github.com/oVirt/ovirt-web-ui/pull/197#pullrequestreview-40267230 ):

[ ] all code review comments addressed
[ ] Error message for expired/invalidated token is rendered badly - hiden by page header. Look for the TokenExpired component.
[ ] When leaving Add/Edit VM screen with "unsaved" changes, confirmation is no more shown (but should be).
[ ] When on VM Detail and Remove VM is confirmed, the flow shall lead to VmsList.
[ ] Breadcrumb: rename for Edit VM to:  Virtual Machines >> [VM Name] >> Edit
       (so no need to repeat the VM name after "Edit" text)
[ ] Change flow: Add new VM -> Create VM button -> NEW: VM detail (instead of standing on Add VM view)
[ ] Similar change for Update VM: successful submit leads to read-only VM Detail
[ ] Rearrange VM Detail to:
  - Description first and spreading over whole screen width
  - Left column:
    - State
    - Cluster
    - Template
    - Operating System
    - Memory
    - CPU
    - Address
  - Right column
    - Console
    - Disks
  - **Question ??**: Do we still need show/hide for Console and Disks? What about making "Disks" a link causing more details rendered on the right side of the page. Multiple such "subviews" can be rendered simultaneously.

[ ] ...