### PR TITLE
Avoid updating browser history for local changes

### DIFF
--- a/src/components/VmActions/index.js
+++ b/src/components/VmActions/index.js
@@ -26,6 +26,7 @@ import {
   removeVm,
 } from '../../actions/index'
 import { checkConsoleInUse, setConsoleInUse } from './actions'
+import { hrefWithoutHistory } from '../../helpers'
 
 import OnClickTopConfirmation from '../Confirmation/index'
 
@@ -91,7 +92,7 @@ class Button extends React.Component {
     }
 
     return (
-      <a href='#' onClick={onClick} className={`${button} ${style['link']}`}>
+      <a href='#' onClick={hrefWithoutHistory(onClick)} className={`${button} ${style['link']}`}>
         <span data-toggle='tooltip' data-placement='left' title={tooltip}>
           {shortTitle}
         </span>

--- a/src/components/VmDetail/index.js
+++ b/src/components/VmDetail/index.js
@@ -15,7 +15,7 @@ import {
   getRDP,
 } from '../../actions/index'
 
-import { isWindows, templateNameRenderer } from '../../helpers'
+import { isWindows, templateNameRenderer, hrefWithoutHistory } from '../../helpers'
 
 import Time from '../Time'
 import FieldHelp from '../FieldHelp/index'
@@ -56,22 +56,30 @@ const VmConsoles = ({ vm, onConsole, onRDP }) => {
     return (
       <dd>
         {
-          vmConsoles.map(c => (
-            <a
-              href='#'
-              data-toggle='tooltip'
-              data-placement='left'
-              title={`Open ${c.get('protocol').toUpperCase()} console`}
-              key={c.get('id')}
-              onClick={() => onConsole({ vmId: vm.get('id'), consoleId: c.get('id') })}
-              className={style['left-delimiter']}>
-              {c.get('protocol').toUpperCase()}
-            </a>))
+          vmConsoles.map(c => {
+            const onClick = (e) => {
+              onConsole({ vmId: vm.get('id'), consoleId: c.get('id') })
+              e.preventDefault()
+            }
+
+            return (
+              <a
+                href='#'
+                data-toggle='tooltip'
+                data-placement='left'
+                title={`Open ${c.get('protocol').toUpperCase()} console`}
+                key={c.get('id')}
+                onClick={onClick}
+                className={style['left-delimiter']}>
+                {c.get('protocol').toUpperCase()}
+              </a>
+            )
+          })
         }
 
         {
           isWindows(vm.getIn(['os', 'type']))
-            ? (<a href='#' key={vm.get('id')} onClick={onRDP} className={style['left-delimiter']}>RDP</a>) : null
+            ? (<a href='#' key={vm.get('id')} onClick={hrefWithoutHistory(onRDP)} className={style['left-delimiter']}>RDP</a>) : null
         }
       </dd>
     )
@@ -111,11 +119,13 @@ class VmDetail extends Component {
     this.consoleSettings = this.consoleSettings.bind(this)
   }
 
-  consoleSettings () {
+  consoleSettings (e) {
     this.props.onConsoleOptionsOpen()
     this.setState({
       openConsoleSettings: !this.state.openConsoleSettings,
     })
+
+    e.preventDefault()
   }
 
   render () {
@@ -139,7 +149,7 @@ class VmDetail extends Component {
     const cluster = Selectors.getClusterById(vm.getIn(['cluster', 'id']))
     const template = Selectors.getTemplateById(vm.getIn(['template', 'id']))
 
-//    const onToggleRenderDisks = () => { this.setState({ renderDisks: !this.state.renderDisks }) }
+//    const onToggleRenderDisks = (e) => { this.setState({ renderDisks: !this.state.renderDisks }); e.preventDefault() }
     const disksElement = (<VmDisks disks={disks} open={this.state.renderDisks} />)
 
     let optionsJS = options.hasIn(['options', 'consoleOptions', vm.get('id')]) ? options.getIn(['options', 'consoleOptions', vm.get('id')]).toJS() : {}

--- a/src/components/VmUserMessages/index.js
+++ b/src/components/VmUserMessages/index.js
@@ -8,6 +8,7 @@ import style from './style.css'
 import Time from '../Time'
 
 import { clearUserMessages } from '../../actions/vm'
+import { hrefWithoutHistory } from '../../helpers'
 
 const UserMessage = ({ record }) => {
   // TODO: render record.type
@@ -67,7 +68,7 @@ class VmUserMessages extends React.Component {
 
     return (
       <li className='dropdown'>
-        <a href='#' onClick={onToggle}>
+        <a href='#' onClick={hrefWithoutHistory(onToggle)}>
           <div className={isUnread(userMessages) ? style['usermsgs-unread'] : style['usermsgs-allread']}>
             <span className='pficon pficon-info' />&nbsp;Messages
           </div>
@@ -82,8 +83,8 @@ class VmUserMessages extends React.Component {
           <ContactAdminInfo userMessages={userMessages} />
 
           <div className='footer'>
-            <a href='#' onClick={onClearMessages}>Clear Messages</a>
-            <a href='#' onClick={onToggle} className={style['close-button']}>Close</a>
+            <a href='#' onClick={hrefWithoutHistory(onClearMessages)}>Clear Messages</a>
+            <a href='#' onClick={hrefWithoutHistory(onToggle)} className={style['close-button']}>Close</a>
           </div>
         </div>
       </li>

--- a/src/components/VmsPageHeader/index.js
+++ b/src/components/VmsPageHeader/index.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux'
 import ContainerFluid from '../ContainerFluid'
 import VmUserMessages from '../VmUserMessages'
 import UserMenu from './UserMenu'
+import { hrefWithoutHistory } from '../../helpers'
 
 import { refresh } from '../../actions/vm'
 
@@ -24,7 +25,7 @@ const VmsPageHeader = ({ title, onRefresh }) => {
 
         <ul className='nav navbar-nav navbar-utility'>
           <li>
-            <a href='#' onClick={onRefresh}>
+            <a href='#' onClick={hrefWithoutHistory(onRefresh)}>
               <span className='fa fa-refresh' />&nbsp;Refresh
             </a>
           </li>

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -121,3 +121,10 @@ export function templateNameRenderer (template) {
     ? (`${templateName} (${versionName})`)
     : templateName
 }
+
+export function hrefWithoutHistory (handler) {
+  return (e) => {
+    e.preventDefault()
+    handler(e)
+  }
+}


### PR DESCRIPTION
If the user do local changes, like opening of COnsole Options on VmDetail,
browser's history is not updated, so the back button works better.

Fixes: https://github.com/oVirt/ovirt-web-ui/issues/229