### PR TITLE
Fix falsely-positive check about missing VM

### DIFF
--- a/__tests__/vms/selectVmDetail.js
+++ b/__tests__/vms/selectVmDetail.js
@@ -9,8 +9,4 @@ describe('Get VM detail test: ', () => {
   it2('First we check returned data: ', (result) => {
     expect(result).toEqual(fetchSingleVm(getSingleVm({ vmId: '123' })))
   })
-
-	it2('Then we check setting loadInProgress value to false: ', (result) => {
-		expect(result).toEqual(put(loadInProgress({ value: false })))
-	})
 })

--- a/src/components/Pages/index.js
+++ b/src/components/Pages/index.js
@@ -18,9 +18,12 @@ class VmDetailPage extends React.Component {
       return (<VmDetail vm={vms.getIn(['vms', match.params.id])} config={config} />)
     } else {
       if (vms.get('loadInProgress')) {
+        console.info('VmDetailPage: VM id can not be found: ', match.params.id, ' . Load is still in progress - wating before redirect')
         return null
       }
     }
+
+    console.info('VmDetailPage: VM id can not be found: ', match.params.id, ' . Redirecting to / ')
     return <Redirect to='/' />
   }
 }

--- a/src/sagas.js
+++ b/src/sagas.js
@@ -556,7 +556,10 @@ function* downloadVmConsole (action) {
  */
 export function* selectVmDetail (action) {
   yield fetchSingleVm(getSingleVm({ vmId: action.payload.vmId })) // async data refresh
-  yield put(loadInProgress({ value: false }))
+}
+
+function* selectPoolDetail (action) {
+  yield fetchSinglePool(getSinglePool({ poolId: action.payload.poolId }))
 }
 
 function* getConsoleOptions (action) {
@@ -578,11 +581,6 @@ function* autoConnectCheck (action) {
       yield downloadVmConsole(downloadConsole({ vmId }))
     }
   }
-}
-
-function* selectPoolDetail (action) {
-  yield fetchSinglePool(getSinglePool({ poolId: action.payload.poolId }))
-  yield put(loadInProgress({ value: false }))
 }
 
 function* schedulerPerMinute (action) {


### PR DESCRIPTION
This gives more time to load data before decision that
particular VM is missing when `.../vm/{id}` URL is entered.

Fixes: https://github.com/oVirt/ovirt-web-ui/issues/251