### PR TITLE
VM detail scrolling fixed

### DIFF
--- a/src/components/PageRouter.js
+++ b/src/components/PageRouter.js
@@ -111,12 +111,14 @@ class PageRouter extends React.Component {
     }
 
     const RenderComponent = branch.route.component
-    return (<div className={style['navbar-top-offset']}>
+    return (<div className={style['page-router']}>
       <Breadcrumb route={branches} root={{ title: msg.virtualMachines(), url: '/' }} />
       <Toolbar>
         {tools}
       </Toolbar>
-      <RenderComponent route={branch.route} match={branch.match} location={location} history={history} />
+      <div className={style['page-router-render-component']}>
+        <RenderComponent route={branch.route} match={branch.match} location={location} history={history} />
+      </div>
     </div>)
   }
 }

--- a/src/components/Pages/VmsPage.js
+++ b/src/components/Pages/VmsPage.js
@@ -1,8 +1,10 @@
 import React from 'react'
 import VmsList from '../VmsList/index'
 
+import style from './style.css'
+
 const VmsPage = () => {
-  return (<div className='container-fluid'>
+  return (<div className={`container-fluid ${style['vms-page']}`}>
     <VmsList />
   </div>)
 }

--- a/src/components/Pages/style.css
+++ b/src/components/Pages/style.css
@@ -1,0 +1,4 @@
+.vms-page {
+    overflow: auto;
+    height: 100%
+}

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -8,7 +8,7 @@ const Toolbar = ({ children }) => {
     i++
     return (<div key={'toolbar' + i} className={`form-group toolbar-pf-view-selector ${style['actions-padding']}`}>{c}</div>)
   })
-  return (<div className='container-fluid'>
+  return (<div className={`container-fluid ${style['toolbar']}`}>
     <div className='row toolbar-pf'>
       <div className='col-sm-12'>
         <div className='toolbar-pf-actions'>

--- a/src/components/Toolbar/style.css
+++ b/src/components/Toolbar/style.css
@@ -1,3 +1,8 @@
 .actions-padding {
-	padding-left: 0px;
+    padding-left: 0px;
+}
+
+.toolbar {
+    flex-shrink: 0;
+    width: 100%;
 }

--- a/src/components/VmDetail/index.js
+++ b/src/components/VmDetail/index.js
@@ -175,91 +175,93 @@ class VmDetail extends Component {
     }
 
     return (
-      <div>
+      <div className={style['main-container']}>
         <VmsListNavigation selectedVm={vm} expanded={this.state.vmsNavigationExpanded} toggleExpansion={this.toggleVmsNavExpansion} />
 
-        <div className={this.state.vmsNavigationExpanded ? style['vms-nav-expanded'] : style['vms-nav-collapsed']}>
-          <DetailContainer>
-            <h1 className={style['header']}>
-              {vmIcon}
-              &nbsp;<span className={style['vm-name']}>{name}</span>
-            </h1>
-            <NextRunLabel vm={vm} />
-            <LastMessage vmId={vm.get('id')} userMessages={userMessages} />
-            <div className={style['vm-detail-container']}>
-              <dl className={sharedStyle['vm-properties']}>
-                <dt>
-                  <FieldHelp content={msg.actualStateVmIsIn()} text={msg.state()} />
-                </dt>
-                <dd>
-                  <VmStatus vm={vm} />
-                </dd>
+        <div className={style['vm-detail-main']}>
+          <div className={this.state.vmsNavigationExpanded ? style['vms-nav-expanded'] : style['vms-nav-collapsed']}>
+            <DetailContainer>
+              <h1 className={style['header']}>
+                {vmIcon}
+                &nbsp;<span className={style['vm-name']}>{name}</span>
+              </h1>
+              <NextRunLabel vm={vm} />
+              <LastMessage vmId={vm.get('id')} userMessages={userMessages} />
+              <div className={style['vm-detail-container']}>
+                <dl className={sharedStyle['vm-properties']}>
+                  <dt>
+                    <FieldHelp content={msg.actualStateVmIsIn()} text={msg.state()} />
+                  </dt>
+                  <dd>
+                    <VmStatus vm={vm} />
+                  </dd>
 
-                <dt>
-                  <FieldHelp content={msg.optionalUserDescriptionOfVm()} text={msg.description()} />
-                </dt>
-                <dd>{vm.get('description')}</dd>
+                  <dt>
+                    <FieldHelp content={msg.optionalUserDescriptionOfVm()} text={msg.description()} />
+                  </dt>
+                  <dd>{vm.get('description')}</dd>
 
-                <dt>
-                  <FieldHelp content={msg.groupOfHostsVmCanBeRunningOn()} text={msg.cluster()} />
-                </dt>
-                <dd>{cluster ? cluster.get('name') : ''}</dd>
+                  <dt>
+                    <FieldHelp content={msg.groupOfHostsVmCanBeRunningOn()} text={msg.cluster()} />
+                  </dt>
+                  <dd>{cluster ? cluster.get('name') : ''}</dd>
 
-                <dt>
-                  <FieldHelp content={msg.containsConfigurationAndDisksWhichWillBeUsedToCreateThisVm()} text={msg.template()} />
-                </dt>
-                <dd>{template ? templateNameRenderer(template) : ''}</dd>
+                  <dt>
+                    <FieldHelp content={msg.containsConfigurationAndDisksWhichWillBeUsedToCreateThisVm()} text={msg.template()} />
+                  </dt>
+                  <dd>{template ? templateNameRenderer(template) : ''}</dd>
 
-                <dt>
-                  <FieldHelp content={msg.operatingSystemInstalledOnVm()} text={msg.operatingSystem()} />
-                </dt>
-                <dd>{os ? os.get('description') : vm.getIn(['os', 'type'])}</dd>
+                  <dt>
+                    <FieldHelp content={msg.operatingSystemInstalledOnVm()} text={msg.operatingSystem()} />
+                  </dt>
+                  <dd>{os ? os.get('description') : vm.getIn(['os', 'type'])}</dd>
 
-                <dt>
-                  <FieldHelp content={msg.typeOfWorkloadVmConfigurationIsOptimizedFor()} text={msg.optimizedFor()} />
-                </dt>
-                <dd>{rephraseVmType(vm.get('type'))}</dd>
+                  <dt>
+                    <FieldHelp content={msg.typeOfWorkloadVmConfigurationIsOptimizedFor()} text={msg.optimizedFor()} />
+                  </dt>
+                  <dd>{rephraseVmType(vm.get('type'))}</dd>
 
-                <dt><span className='pficon pficon-memory' />&nbsp;
-                  <FieldHelp content={msg.totalMemoryVmWillBeEquippedWith()} text={msg.definedMemory()} />
-                </dt>
-                <dd>{userFormatOfBytes(vm.getIn(['memory', 'total'])).str}</dd>
+                  <dt><span className='pficon pficon-memory' />&nbsp;
+                    <FieldHelp content={msg.totalMemoryVmWillBeEquippedWith()} text={msg.definedMemory()} />
+                  </dt>
+                  <dd>{userFormatOfBytes(vm.getIn(['memory', 'total'])).str}</dd>
 
-                <dt><span className='pficon pficon-cpu' />&nbsp;
-                  <FieldHelp content={msg.totalCountOfVirtualProcessorsVmWillBeEquippedWith()} text={msg.cpus()} />
-                </dt>
-                <dd>{vm.getIn(['cpu', 'vCPUs'])}</dd>
+                  <dt><span className='pficon pficon-cpu' />&nbsp;
+                    <FieldHelp content={msg.totalCountOfVirtualProcessorsVmWillBeEquippedWith()} text={msg.cpus()} />
+                  </dt>
+                  <dd>{vm.getIn(['cpu', 'vCPUs'])}</dd>
 
-                <dt><span className='pficon pficon-network' />&nbsp;
-                  <FieldHelp content={msg.fullyQualifiedDomainName()} text={msg.address()} />
-                </dt>
-                <dd>{vm.get('fqdn')}</dd>
-                <dt><span className='pficon pficon-storage-domain' />&nbsp;
-                  <FieldHelp content={msg.currentlyInsertedIsoInCdRom()} text={msg.cdRom()} />
-                </dt>
-                <dd>{vm.getIn(['cdrom', 'file', 'id']) ? vm.getIn(['cdrom', 'file', 'id']) : msg.empty() }</dd>
-              </dl>
+                  <dt><span className='pficon pficon-network' />&nbsp;
+                    <FieldHelp content={msg.fullyQualifiedDomainName()} text={msg.address()} />
+                  </dt>
+                  <dd>{vm.get('fqdn')}</dd>
+                  <dt><span className='pficon pficon-storage-domain' />&nbsp;
+                    <FieldHelp content={msg.currentlyInsertedIsoInCdRom()} text={msg.cdRom()} />
+                  </dt>
+                  <dd>{vm.getIn(['cdrom', 'file', 'id']) ? vm.getIn(['cdrom', 'file', 'id']) : msg.empty() }</dd>
+                </dl>
 
-              <dl className={sharedStyle['vm-properties']}>
-                <dt><span className='pficon pficon-screen' />
-                  &nbsp;
-                  <FieldHelp content={consolesHelp} text={msg.consoles()} />
-                  &nbsp;
-                  {consoleOptionsShowHide}
-                </dt>
-                <VmConsoles vm={vm} onConsole={onConsole} onRDP={onRDP} usbFilter={config.get('usbFilter')} />
-                <ConsoleOptions options={optionsJS} onSave={onConsoleOptionsSave} open={this.state.openConsoleSettings} />
+                <dl className={sharedStyle['vm-properties']}>
+                  <dt><span className='pficon pficon-screen' />
+                    &nbsp;
+                    <FieldHelp content={consolesHelp} text={msg.consoles()} />
+                    &nbsp;
+                    {consoleOptionsShowHide}
+                  </dt>
+                  <VmConsoles vm={vm} onConsole={onConsole} onRDP={onRDP} usbFilter={config.get('usbFilter')} />
+                  <ConsoleOptions options={optionsJS} onSave={onConsoleOptionsSave} open={this.state.openConsoleSettings} />
 
-                <dt><span className='fa fa-database' />
-                  &nbsp;
-                  <FieldHelp content={msg.storageConnectedToVm()} text={msg.disks()} />
-                  &nbsp;
-                </dt>
-                {noDisks}
-                {disksElement}
-              </dl>
-            </div>
-          </DetailContainer>
+                  <dt><span className='fa fa-database' />
+                    &nbsp;
+                    <FieldHelp content={msg.storageConnectedToVm()} text={msg.disks()} />
+                    &nbsp;
+                  </dt>
+                  {noDisks}
+                  {disksElement}
+                </dl>
+              </div>
+            </DetailContainer>
+          </div>
         </div>
       </div>
     )

--- a/src/components/VmDetail/style.css
+++ b/src/components/VmDetail/style.css
@@ -60,13 +60,11 @@
 }
 
 .vms-nav-expanded {
-    padding-left: 200px;
-    transition: padding-left .5s;
+    padding-left: 0;
 }
 
 .vms-nav-collapsed {
-    padding-left: 2em;
-    transition: padding-left .5s;
+    padding-left: 30px;
 }
 
 .vm-flag-container {
@@ -93,4 +91,17 @@ dd.console-box {
 .vm-name {
     align-self: center;
     margin-left: 20px;
+}
+
+.main-container {
+    display: flex;
+    align-items: stretch;
+    height: 100%;
+}
+
+.vm-detail-main {
+    flex-grow: 1;
+    flex-shrink: 1;
+    transition: padding-left .5s;
+    overflow: auto;
 }

--- a/src/components/VmDialog/style.css
+++ b/src/components/VmDialog/style.css
@@ -30,7 +30,7 @@
     /* Ugly hack, but so far better than increase complexity via Toolbar component since buttons relies on VmDialog's state*/
     position: absolute;
     right: 10px;
-    top: 6em;
+    top: 45px;
 }
 
 .vm-dialog-buttons button {

--- a/src/components/VmsList/Vms.js
+++ b/src/components/VmsList/Vms.js
@@ -36,6 +36,7 @@ class Vms extends React.Component {
         loadMore={this.loadMore}
         hasMore={vms.get('areAllPagesLoaded')}
         loader={<div className={style['loaderBox']}><div className={style['loader']} /></div>}
+        useWindow={false}
       >
         <div>
           <ScrollPositionHistory uniquePrefix='vms-list'>

--- a/src/components/VmsListNavigation/index.js
+++ b/src/components/VmsListNavigation/index.js
@@ -15,7 +15,7 @@ const VmsListNavigation = ({ selectedVm, vms, expanded, toggleExpansion, onUpdat
   }
 
   const toggleExpandButton = (
-    <div className={style['toggle-expand-button']}>
+    <div className={`${style['toggle-expand-button']} ${expanded ? style['toggle-expand-button-expanded'] : ''}`}>
       <a href='#' onClick={toggleExpansion}>
         <span className={`fa ${expanded ? 'fa-angle-double-left' : 'fa-angle-double-right'}`} />
       </a>
@@ -55,15 +55,18 @@ const VmsListNavigation = ({ selectedVm, vms, expanded, toggleExpansion, onUpdat
   }
 
   return (
-    <InfiniteScroll
-      loadMore={loadMore}
-      hasMore={vms.get('areAllPagesLoaded')}
-      >
-      <div className={`${style['main-container']} ${expanded ? style['expanded'] : ''}`}>
-        {toggleExpandButton}
-        {list}
+    <div className={`${style['main-container']} ${expanded ? style['expanded'] : ''}`}>
+      {toggleExpandButton}
+      <div className={style['scrolling-viewport']}>
+        <InfiniteScroll
+          loadMore={loadMore}
+          hasMore={vms.get('areAllPagesLoaded')}
+          useWindow={false}
+          >
+          {list}
+        </InfiniteScroll>
       </div>
-    </InfiniteScroll>
+    </div>
   )
 }
 VmsListNavigation.propTypes = {

--- a/src/components/VmsListNavigation/style.css
+++ b/src/components/VmsListNavigation/style.css
@@ -1,28 +1,46 @@
 .main-container {
-    height: 100%;
-    width: 3em;
-    position: fixed;
-    z-index: 1000;
-    top: 115px;
-    left: 200px;
-    background-color: rgba(255, 255, 255, 0.15);
-    padding-top: 1em;
-    -webkit-transition: 0.5s;
-    transition: 0.5s;
-    border: 1px solid #cecccc;
-    padding-bottom: 145px;
+    flex-shrink: 0;
+    flex-basis: 0;
+    transition: flex-basis 0.5s;
+    position: relative;
+    border-right: solid thin #ccc;
 }
 
 .expanded {
-    width: 200px;
+    flex-basis: 200px;
 }
 
 .toggle-expand-button {
-    text-align: right;
-    padding-right: 1em;
-    padding-left: 0.4em;
-    margin-top: -0.5em;
-    font-size: x-large;
+    position: absolute;
+    left: 100%;
+    top: 0;
+    background-color: #bbb;
+    border-radius: 0 0 4px 0;
+    font-size: large;
+}
+
+.toggle-expand-button-expanded {
+    left: auto;
+    right: 0;
+    border-radius: 0 0 0 4px;
+}
+
+.toggle-expand-button a {
+    padding: 0 .5em;
+    text-align: center;
+    display: inline-block;
+}
+
+.toggle-expand-button a {
+    color: #363636;
+}
+
+.scrolling-viewport {
+    overflow: auto;
+    position: relative;
+    margin-top: 30px;
+    height: calc(100% - 30px)
+
 }
 
 .ul-menu-cust {

--- a/src/components/sharedStyle.css
+++ b/src/components/sharedStyle.css
@@ -25,11 +25,24 @@
     border-bottom: solid gray;
     padding-left: 15px;
     margin-bottom: 5px;
+
+    flex-shrink: 0;
 }
 
-.navbar-top-offset {
-    padding-top: 29px;
-    margin-left: 200px;
+.page-router {
+    position: absolute;
+    top: 29px;
+    left: 200px;
+    bottom: 0;
+    right: 0;
+
+    display: flex;
+    flex-direction: column;
+}
+
+.page-router-render-component {
+    flex-grow: 1;
+    overflow: hidden;
 }
 
 /* For VmDetail and VmDialog */


### PR DESCRIPTION
If content of VM detail is wider than bounding box, then only vm detail
itself is scrolled horizontally, not breadcrumb and toolbar.

List of VMs and VM details don't clash when page vertically scrolled.

When page scrolled vertically VMs list moves properly.

Closes  #249, closes  #248.

![image](https://user-images.githubusercontent.com/5278760/27487552-5d02d5c8-5834-11e7-956a-898a63375df4.png)
![image](https://user-images.githubusercontent.com/5278760/27487559-60c93e5e-5834-11e7-9b12-92a89e311830.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/256)
<!-- Reviewable:end -->
