### PR TITLE
Dev server proxy fix

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -198,21 +198,6 @@ function addMiddleware(devServer) {
   // `proxy` lets you to specify a fallback server during development.
   // Every unrecognized request will be forwarded to it.
   var proxy = process.env.ENGINE_URL || require(paths.appPackageJson).proxy;
-  devServer.use(historyApiFallback({
-    // Paths with dots should still use the history fallback.
-    // See https://github.com/facebookincubator/create-react-app/issues/387.
-    disableDotRule: true,
-    // For single page apps, we generally want to fallback to /index.html.
-    // However we also want to respect `proxy` for API calls.
-    // So if `proxy` is specified, we need to decide which fallback to use.
-    // We use a heuristic: if request `accept`s text/html, we pick /index.html.
-    // Modern browsers include text/html into `accept` header when navigating.
-    // However API calls like `fetch()` won’t generally accept text/html.
-    // If this heuristic doesn’t work well for you, don’t use `proxy`.
-    htmlAcceptHeaders: proxy ?
-      ['text/html'] :
-      ['text/html', '*/*']
-  }));
   if (proxy) {
     if (typeof proxy !== 'string') {
       console.log(chalk.red('When specified, "proxy" in package.json must be a string.'));


### PR DESCRIPTION
Till now if dev server was asked for any url with header 'Accepts'
containing 'text/html' then 'index.html' was returned. I was intended to
workaround missing history api on older browsers.

This change should allow to passthrough requests to engine branding
servlet at `${AppConfiguration.applicationContext}/theme-resource`.

This patch is part of branding effort.