### PR TITLE
flow: allow unannotated arrow functions

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -75,11 +75,14 @@ module.exports = {
       2,
       'comma'
     ],
-    'flowtype/require-parameter-type': 2,
+    'flowtype/require-parameter-type': [2, {
+      'excludeArrowFunctions': true
+    }],
     'flowtype/require-return-type': [
       2,
       'always',
       {
+        'excludeArrowFunctions': true,
         'annotateUndefined': 'never'
       }
     ],


### PR DESCRIPTION
I believe it's not necessary to type-annotate all arrow functions like
for example parameters of Array.prototype.{map,filter}.