### PR TITLE
flow eslint: semis prohibited after types

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -89,7 +89,7 @@ module.exports = {
     'flowtype/require-valid-file-annotation': 2,
     'flowtype/semi': [
       2,
-      'always'
+      'never'
     ],
     'flowtype/space-after-type-colon': [
       2,

--- a/src/ovirtapi.js
+++ b/src/ovirtapi.js
@@ -7,10 +7,10 @@ import { Exception } from './exceptions'
 import Selectors from './selectors'
 import AppConfiguration from './config'
 
-type VmIdType = { vmId: string };
-type PoolIdType = { poolId: string };
-type InputRequestType = { url: string, input: string, contentType?: string };
-type VmType = { vm: Object };
+type VmIdType = { vmId: string }
+type PoolIdType = { poolId: string }
+type InputRequestType = { url: string, input: string, contentType?: string }
+type VmType = { vm: Object }
 
 const zeroUUID: string = '00000000-0000-0000-0000-000000000000'
 


### PR DESCRIPTION
Semicolons prohibited after type definitions to unify rules with
standard JavaScript code.