### PR TITLE
Use ovirt-engine-nodejs-modules 1.1.0

### DIFF
--- a/ovirt-web-ui.spec.in
+++ b/ovirt-web-ui.spec.in
@@ -25,7 +25,7 @@ BuildRequires: ovirt-engine-nodejs = 8.0.0
 BuildRequires: ovirt-engine-yarn = 0.24.4
 
 # contains ovirt-ui-components-0.2.5
-BuildRequires: ovirt-engine-nodejs-modules = 1.0.20
+BuildRequires: ovirt-engine-nodejs-modules = 1.1.0
 
 %description
 This package provides new VM Portal for %{product}, so far as technical preview.


### PR DESCRIPTION
Due to parallel change in cockpit-ovirt/vdsm subproject, there will
be change in the minor version of ovirt-engine-nodejs-modules

Depends on: https://gerrit.ovirt.org/#/c/80623/