### PR TITLE
Bump v1.2.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ AC_PREREQ(2.60)
 
 define([VERSION_MAJOR], [1])
 define([VERSION_MINOR], [2])
-define([VERSION_FIX], [0])
+define([VERSION_FIX], [1])
 define([VERSION_NUMBER], VERSION_MAJOR[.]VERSION_MINOR[.]VERSION_FIX)
 define([VERSION_RELEASE], [1])
 

--- a/ovirt-web-ui.spec.in
+++ b/ovirt-web-ui.spec.in
@@ -56,6 +56,12 @@ make install DESTDIR=%{buildroot}
 %{_sysconfdir}/ovirt-web-ui/branding/00-ovirt.brand
 
 %changelog
+* Wed Aug 16 2017 Marek Libra <mlibra@redhat.com> - 1.2.1
+- noarch rpm
+- minor fixes, runtime dependencies generally updated
+- usb-filter in .vv file
+- basics for internationalization, but translation missing
+
 * Wed Aug 2 2017 Marek Libra <mlibra@redhat.com> - 1.2.0
 - branding
 - infinite scroller for VMS list


### PR DESCRIPTION
- noarch rpm
- minor fixes, runtime dependencies generally updated
- usb-filter in .vv file
- basics for internationalization, but translation missing
