### PR TITLE
Guest OS name labels added

### DIFF
--- a/src/components/VmDetail/index.js
+++ b/src/components/VmDetail/index.js
@@ -32,6 +32,7 @@ import VmConsoles from './VmConsoles'
 
 import { userFormatOfBytes, VmIcon } from 'ovirt-ui-components'
 import Selectors from '../../selectors'
+import { getOsHumanName } from '../utils'
 
 function rephraseVmType (vmType) {
   const types = {
@@ -132,7 +133,7 @@ class VmDetail extends Component {
     }
     const icon = icons.get(iconId)
     const disks = vm.get('disks')
-    const os = Selectors.getOperatingSystemByName(vm.getIn(['os', 'type']))
+    const osName = getOsHumanName(vm.getIn(['os', 'type']))
     const cluster = Selectors.getClusterById(vm.getIn(['cluster', 'id']))
     const template = Selectors.getTemplateById(vm.getIn(['template', 'id']))
 
@@ -213,7 +214,7 @@ class VmDetail extends Component {
                   <dt>
                     <FieldHelp content={msg.operatingSystemInstalledOnVm()} text={msg.operatingSystem()} />
                   </dt>
-                  <dd>{os ? os.get('description') : vm.getIn(['os', 'type'])}</dd>
+                  <dd>{osName}</dd>
 
                   <dt>
                     <FieldHelp content={msg.typeOfWorkloadVmConfigurationIsOptimizedFor()} text={msg.optimizedFor()} />

--- a/src/components/VmsList/Vm.js
+++ b/src/components/VmsList/Vm.js
@@ -16,6 +16,8 @@ import { VmIcon, VmStatusIcon } from 'ovirt-ui-components'
 
 import { startVm } from '../../actions/index'
 
+import { getOsHumanName } from '../utils'
+
 /**
  * Single icon-card in the list
  */
@@ -34,6 +36,7 @@ class Vm extends React.Component {
     }
     const icon = icons.get(iconId)
     const isSelected = vm.get('id') === visibility.get('selectedVmDetail')
+    const osName = getOsHumanName(vm.getIn(['os', 'type']))
 
     return (
       <div className={`col-xs-12 col-sm-6 col-md-4 col-lg-3 ${isSelected ? style['selectedVm'] : ''}`}>
@@ -44,6 +47,9 @@ class Vm extends React.Component {
                 <VmIcon icon={icon} className={style['card-pf-icon']}
                   missingIconClassName='fa fa-birthday-cake card-pf-icon-circle' />
               </Link>
+              <div>
+                <span className={style['operating-system-label']}>{osName}</span>
+              </div>
             </div>
             <h2 className='card-pf-title text-center'>
               <NavLink to={`/vm/${vm.get('id')}`} className={style['vm-detail-link']}>

--- a/src/components/VmsList/style.css
+++ b/src/components/VmsList/style.css
@@ -89,3 +89,16 @@
 .card-icon {
     text-align: center;
 }
+
+.operating-system-label {
+    display: inline-block;
+    font-size: 10px;
+    height: 18px;
+    padding: 0 6px;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: #363636;
+    background-color: #ededed;
+    min-width: 100px;
+    margin: 2px auto;
+}

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -1,0 +1,12 @@
+// @flow
+
+import Selectors from '../selectors'
+
+/**
+ * @param osName guest OS code name, e.g. 'rhel_7x64'
+ * @return human friendly guest OS name, e.g. 'Red Hat Enterprise Linux 7.x x64'
+ */
+export function getOsHumanName (osName: string): string {
+  const os = Selectors.getOperatingSystemByName(osName)
+  return os && os.get('description') || osName
+}


### PR DESCRIPTION
WIP

It allows us to switch to icons per OS family (OS version is not
contained in the graphics).

![os-labels-poc](https://user-images.githubusercontent.com/5278760/31083820-05f614a8-a793-11e7-9a56-61683b3db346.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/350)
<!-- Reviewable:end -->
