### PR TITLE
CI: Travis node version update: [4,6] -> [6,8]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 script: npm run build
 node_js:
- - "4"
  - "6"
+ - "8"


### PR DESCRIPTION
Node 4 is already in maintenance mode.
https://github.com/nodejs/Release#release-schedule1

There is Node 6 in Cent OS so I guess it's safe to upgrade.