### PR TITLE
Stuck popup fix

### DIFF
--- a/src/components/FieldHelp/index.js
+++ b/src/components/FieldHelp/index.js
@@ -6,35 +6,37 @@ import { OverlayTrigger, Popover } from 'react-bootstrap'
 import style from './style.css'
 
 /**
- * Renders small blue info icon.
- * Text (help) is displayed on click.
+ * Renders underlined `text` with `tooltip`.
+ * A popover is shown consisting of `title` and `content` on click.
  */
-const FieldHelp = ({
-  title, // help title
-  content, // help content
-  text, // field description
-  tooltip = 'Click for help',
-  children,
-  }) => {
-  const popover = (
-    <Popover id='popover-positioned-top' title={title}>
-      {content}
-    </Popover>)
+class FieldHelp extends React.Component {
 
-  return (
-    <OverlayTrigger trigger='click' rootClose placement='top' overlay={popover}>
-      <div role='button' title={tooltip} className={text && style['field-text']}>
-        {text}
-        {children}
-      </div>
-    </OverlayTrigger>
-  )
+  render () {
+    console.log('help component', this)
+
+    const tooltip = this.props.tooltip || 'Click for help'
+
+    const popover = (
+      <Popover id='popover-positioned-top' title={this.props.title}>
+        {this.props.content}
+      </Popover>)
+
+    return (
+      <OverlayTrigger trigger='click' rootClose placement='top' overlay={popover} container={this}>
+        <div role='button' title={tooltip} className={this.props.text && style['field-text']} style={{ position: 'relative' }}>
+          {this.props.text}
+          {this.props.children}
+        </div>
+      </OverlayTrigger>
+    )
+  }
 }
+
 FieldHelp.propTypes = {
-  title: PropTypes.string,
-  content: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  text: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  tooltip: PropTypes.string,
+  title: PropTypes.string,                                            // popover title
+  content: PropTypes.oneOfType([PropTypes.string, PropTypes.object]), // popover content
+  text: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),    // decorated text
+  tooltip: PropTypes.string,                                          // tooltip shown when hovering the text
   children: PropTypes.any,
 }
 

--- a/src/components/VmDetail/style.css
+++ b/src/components/VmDetail/style.css
@@ -8,7 +8,6 @@
     width: 200px;
     min-height: 26px;
     white-space: nowrap;
-    overflow: hidden;
     text-overflow: ellipsis;
     color: #888;
     font-weight: normal;

--- a/src/index-nomodules.css
+++ b/src/index-nomodules.css
@@ -69,3 +69,7 @@ div.toolbar-pf {
   margin-left: -2px !important;
   margin-right: 0;
 }
+
+.popover {
+  min-width: 120px;
+}


### PR DESCRIPTION
Problem: Popovers from react-bootstrap library used in FieldHelp
component was not moving when pane were scrolled. It was caused by the
library creating popover div tags at the end of the document i.e.
outside of the scrolled area.

Solution: Following guide [1] the OverlayTrigger component is passed a
'container' property that set element into which the popover is
rendered. Plus css adjustments.

[1]: https://react-bootstrap.github.io/components.html#popovers-positioned-scrolling

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/392)
<!-- Reviewable:end -->
