### PR TITLE
Readable style names in dev mode

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -111,7 +111,7 @@ module.exports = {
       {
         test: /\.css$/,
         exclude: /(node_modules)|(-nomodules\.css$)/,
-        loader: 'style!css?modules!postcss',
+        loader: 'style!css?modules&localIdentName=[path][name]__[local]--[hash:base64:10]!postcss',
       },
 
       // plain css for stylesheets of dependencies and local with '-nomodules.css' suffix


### PR DESCRIPTION
'module' option of css webpack loader replaces style class names by
hashes. This makes DOM tree hard to read.

Additional option 'localIdentName' sets format of style class names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/393)
<!-- Reviewable:end -->
