### PR TITLE
Fix of flow type error regarding getElementById

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ function renderApp () {
         <App />
       </IntlProvider>
     </Provider>,
-    document.getElementById('root')
+    (document.getElementById('root'): any)
   )
 }
 


### PR DESCRIPTION
I guess we are pretty sure `#root` div is there.

```
Error: src/index.js:45
 45:     (document.getElementById('root'))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ null. This type is incompatible with the expected param type of
 17:     container: Element,
                    ^^^^^^^ Element. See lib: /tmp/flow/flowlib_2cca3f39/react-dom.js:17
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/401)
<!-- Reviewable:end -->
