### PR TITLE
make about box logo absolutely positioned

### DIFF
--- a/branding/brand.css
+++ b/branding/brand.css
@@ -128,7 +128,7 @@ over) by other installed brands.
     display: block;
     background-size: contain;
     background-repeat: no-repeat;
-    float: right;
-    position: relative;
-    top: 140px;
+    position: absolute;
+    bottom: 25px;
+    right: 25px;
 }

--- a/branding/style.css
+++ b/branding/style.css
@@ -5,11 +5,6 @@ put anything here that should override styles
 from brand.css.
 *********************************************/
 
-.obrand_aboutApplicationLogo {
-    position: unset;
-    float: right;
-}
-
 #about-modal a {
     color: #ffffff;
 }


### PR DESCRIPTION
Make about box logo absolutely positioned in the bottom
right of the about box. This fixes the issue where new
or longer strings in the about box caused the logo to
be mis-positioned.

See also: https://gerrit.ovirt.org/#/c/83929/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/402)
<!-- Reviewable:end -->
