### PR TITLE
New VM id generation fix

### DIFF
--- a/src/components/VmDialog/index.js
+++ b/src/components/VmDialog/index.js
@@ -384,7 +384,7 @@ class VmDialog extends React.Component {
     const { icons, vmDialog, clusters, templates, operatingSystems, storages } = this.props
     const vm = this.props.vm
     const isoStorages = storages.get('storages').filter(v => v.get('type') === 'iso')
-    const idPrefix = `vmdialog-${vm.get('name')}`
+    const idPrefix = `vmdialog-${vm ? vm.get('name') : '_new'}`
 
     let files = { '': { id: '', value: '[Eject]' } }
 


### PR DESCRIPTION
New VM page failed during loading since `VmDialog.props.vm` was
undefined.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/406)
<!-- Reviewable:end -->
