### PR TITLE
Fix of scrolling of the grid on Webkit browsers

### DIFF
--- a/src/components/sharedStyle.css
+++ b/src/components/sharedStyle.css
@@ -44,6 +44,7 @@
 .page-router-render-component {
     flex-grow: 1;
     overflow: hidden;
+    height: 100%;
 }
 
 /* For VmDetail and VmDialog */


### PR DESCRIPTION
Problem: There was no scrollbar / no possibility to scroll on Webkit
like browsers - reproduced on Chrome, Chrome for Android and iOS Safari.
It was caused by missing height specification of last (third) element of
PageRouter component. Thus value '100%' of 'height' CSS property of its
child resolved to 'auto' instead to its actual height.

From MDN [1]:
If the height of the containing block is not specified explicitly (i.e.,
it depends on content height), and this element is not absolutely
positioned, the value computes to auto.

[1]: https://developer.mozilla.org/en-US/docs/Web/CSS/height

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/407)
<!-- Reviewable:end -->
