### PR TITLE
Space Console-Edit button without important

### DIFF
--- a/src/components/VmActions/index.js
+++ b/src/components/VmActions/index.js
@@ -208,9 +208,11 @@ class VmActions extends React.Component {
           usbFilter={config.get('usbFilter')}
           vm={vm} />
 
+        <span className={style['button-spacer']} />
+
         <LinkButton isOnCard={isOnCard}
           shortTitle={msg.edit()}
-          button={`btn btn-default ${style['margin-left-link']}`}
+          button='btn btn-default'
           className={`pficon pficon-edit ${style['action-link']}`}
           tooltip={msg.editVm()} to={`/vm/${vm.get('id')}/edit`}
           id={`action-${vm.get('name')}-edit`} />

--- a/src/components/VmActions/style.css
+++ b/src/components/VmActions/style.css
@@ -37,6 +37,7 @@
     margin-left: 0!important;
 }
 
-.margin-left-link {
-	margin-left: 15px!important;
+.button-spacer {
+    width: 10px;
+    display: inline-block;
 }


### PR DESCRIPTION
I believe space between Console and Edit buttons is not important enough
to deserve `!impornant` and there is more readable solution.

Relates to #380

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/427)
<!-- Reviewable:end -->
