### PR TITLE
Fix of sorting of VMs in left vertical panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "recursive-readdir": "2.0.0",
     "request": "~2.79.0",
     "rimraf": "2.6.1",
+    "string-natural-compare": "2.0.2",
     "strip-ansi": "3.0.1",
     "style-loader": "0.13.1",
     "url-loader": "0.5.7",
@@ -69,7 +70,6 @@
     "whatwg-fetch": "1.0.0"
   },
   "dependencies": {
-    "alphanum-sort": "1.0.2",
     "bootstrap-select": "1.12.4",
     "bootstrap-switch": "3.3.4",
     "immutable": "3.8.1",

--- a/src/components/VmsListNavigation/index.js
+++ b/src/components/VmsListNavigation/index.js
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom'
 import { connect } from 'react-redux'
 import { getByPage, getConsoleOptions, selectVmDetail } from '../../actions/index'
 import InfiniteScroll from 'react-infinite-scroller'
-import sort from 'alphanum-sort'
+import naturalCompare from 'string-natural-compare'
 
 import style from './style.css'
 
@@ -33,7 +33,8 @@ const VmsListNavigation = ({ selectedVm, vms, expanded, toggleExpansion, onUpdat
   const emptyList = (<div />)
   let list = null
   if (expanded) {
-    const sortedVms = sort(vms.get('vms').toArray())
+    const sortedVms = vms.get('vms')
+      .sort((vmA, vmB) => naturalCompare.caseInsensitive(vmA.get('name'), vmB.get('name')))
     list = (
       <ul className={`menu ${style['ul-menu-cust']}`} role='menu' aria-labelledby='dropdownMenu1'>
         {sortedVms.map(vm => {


### PR DESCRIPTION
Problem: VMs were sorted according to their immutablejs Map
representation instead of according to their names. Oddly enough it
worked pretty well :D

Fix: VMs sorted according to their names. Sorted library replaced -
previous library was a bit clumsy to use in comparator function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/428)
<!-- Reviewable:end -->
