### PR TITLE
Locale language-country separator may be '_' too

### DIFF
--- a/src/intl/index.js
+++ b/src/intl/index.js
@@ -47,7 +47,7 @@ function getBrowserLocale (): ?string {
 }
 
 function getLocaleFromUrl (): ?string {
-  const localeMatch = /locale=([\w-]{2,})/.exec(window.location.search)
+  const localeMatch = /locale=(\w{2}([-_]\w{2})?)/.exec(window.location.search)
   if (localeMatch === null) {
     return null
   }
@@ -56,7 +56,7 @@ function getLocaleFromUrl (): ?string {
 }
 
 function coerceToSupportedLocale (locale: string): ?string {
-  if (locale === 'en' || locale.startsWith('en-')) {
+  if (/^en/.test(locale)) {
     return 'en'
   }
   if (getSupportedTranslatedLocales().has(locale)) {
@@ -79,7 +79,7 @@ function getSupportedTranslatedLanguageOnlyLocales (): {[string]: string} {
 }
 
 function getLocaleLanguage (locale: string): string {
-  return locale.split('-')[0]
+  return locale.split(/[-_]/)[0]
 }
 
 /**


### PR DESCRIPTION
Since engine uses '_' (underscore) separator.

fixes #437

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/438)
<!-- Reviewable:end -->
