### PR TITLE
ovirt-engine-nodejs-modules required >= 1.2.2

### DIFF
--- a/ovirt-web-ui.spec.in
+++ b/ovirt-web-ui.spec.in
@@ -24,8 +24,7 @@ BuildArch: noarch
 BuildRequires: ovirt-engine-nodejs = 8.0.0
 BuildRequires: ovirt-engine-yarn = 0.24.4
 
-# contains ovirt-ui-components-0.2.6
-BuildRequires: ovirt-engine-nodejs-modules = 1.2.0
+BuildRequires: ovirt-engine-nodejs-modules >= 1.2.2
 
 %description
 This package provides new VM Portal for %{product}, so far as technical preview.


### PR DESCRIPTION
Due to https://github.com/oVirt/ovirt-web-ui/pull/439

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/440)
<!-- Reviewable:end -->
