### PR TITLE
Compatibility with headless VMs

### DIFF
--- a/src/ovirtapi.js
+++ b/src/ovirtapi.js
@@ -173,7 +173,7 @@ OvirtApi = {
       cdrom: {},
       sessions: [],
       display: {
-        smartcardEnabled: vm['display']['smartcard_enabled'] ? vm['display']['smartcard_enabled'] === 'true' : false,
+        smartcardEnabled: vm.display && vm.display.smartcard_enabled ? vm.display.smartcard_enabled === 'true' : false,
       },
     }
     if (getSubResources) {


### PR DESCRIPTION
There were an error while parsing `smartcard_enabled` property when
`vm.display` property was missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/444)
<!-- Reviewable:end -->
