### PR TITLE
 Boot menu configuration added

### DIFF
--- a/src/components/VmDetail/index.js
+++ b/src/components/VmDetail/index.js
@@ -260,6 +260,10 @@ class VmDetail extends Component {
                   </dt>
                   {noDisks}
                   {disksElement}
+                  <dt>
+                    <FieldHelp content={msg.bootMenuTooltip()} text={msg.bootMenu()} />
+                  </dt>
+                  <dd>{vm.get('bootMenuEnabled') ? msg.on() : msg.off()}</dd>
                 </dl>
               </div>
             </DetailContainer>

--- a/src/components/VmDialog/index.js
+++ b/src/components/VmDialog/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 import { connect } from 'react-redux'
 import { Redirect, Prompt, Link } from 'react-router-dom'
+import Switch from 'react-bootstrap-switch'
 
 import { logDebug, generateUnique, templateNameRenderer } from '../../helpers'
 
@@ -65,6 +66,7 @@ class VmDialog extends React.Component {
       osId: undefined,
       saved: false,
       isChanged: false,
+      bootMenuEnabled: false,
     }
 
     this.closeDialog = this.closeDialog.bind(this)
@@ -88,6 +90,7 @@ class VmDialog extends React.Component {
     this.onChangeVmMemory = this.onChangeVmMemory.bind(this)
     this.onChangeVmCpu = this.onChangeVmCpu.bind(this)
     this.onChangeCD = this.onChangeCD.bind(this)
+    this.onChangeBootMenuEnabled = this.onChangeBootMenuEnabled.bind(this)
   }
 
   componentWillMount () {
@@ -112,6 +115,7 @@ class VmDialog extends React.Component {
             id: null,
           },
         },
+        bootMenuEnabled: vm.get('bootMenuEnabled'),
       })
     }
     setTimeout(() => this.initDefaults(), 0)
@@ -193,6 +197,7 @@ class VmDialog extends React.Component {
           'threads': '1',
         },
       },
+      bootMenuEnabled: this.state.bootMenuEnabled,
       'status': this.props.vm ? this.props.vm.get('status') : '',
     }
   }
@@ -328,6 +333,10 @@ class VmDialog extends React.Component {
     }
 
     // fire external data retrieval here if needed after Cluster change
+  }
+
+  onChangeBootMenuEnabled (switchComponent, value) {
+    this.setState({ bootMenuEnabled: value })
   }
 
   /**
@@ -557,6 +566,18 @@ class VmDialog extends React.Component {
                   items={files}
                   idPrefix='select-changecd'
                   />
+              </dd>
+
+              <dt>
+                <FieldHelp content={msg.bootMenuTooltip()} text={msg.bootMenu()} />
+              </dt>
+              <dd>
+                <Switch
+                  animate
+                  bsSize='mini'
+                  value={!!this.state.bootMenuEnabled}
+                  onChange={this.onChangeBootMenuEnabled}
+                />
               </dd>
 
             </dl>

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -200,7 +200,10 @@ export const messages = {
   changeCd: 'Change CD.',
   updateVm: 'Update VM',
   createVm: 'Create VM',
-
+  on: 'On',
+  off: 'Off',
+  bootMenu: 'Boot Menu',
+  bootMenuTooltip: 'Boot menu allows to select bootable device. It is accessible from a console.',
 }
 
 export type MessageIdType = $Keys<typeof messages>

--- a/src/ovirtapi.js
+++ b/src/ovirtapi.js
@@ -178,6 +178,7 @@ OvirtApi = {
       display: {
         smartcardEnabled: vm.display && vm.display.smartcard_enabled ? vm.display.smartcard_enabled === 'true' : false,
       },
+      bootMenuEnabled: vm.bios && vm.bios.boot_menu && vm.bios.boot_menu.enabled === 'true',
     }
     if (getSubResources) {
       if (vm.disk_attachments && vm.disk_attachments.disk_attachment) {
@@ -247,6 +248,12 @@ OvirtApi = {
       os: vm.os && vm.os.type ? {
         type: vm.os.type,
       } : undefined,
+
+      bios: {
+        boot_menu: {
+          enabled: vm.bootMenuEnabled,
+        },
+      },
     }
   },
 


### PR DESCRIPTION
VM detail shows a boot menu. VM dialog allows to switch it on/off.

Boot menu interval is expected to be around 30 seconds so there should
be no need for "Start paused" functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/493)
<!-- Reviewable:end -->
