### PR TITLE
Fixed bug with VM detail leading after refresh

### DIFF
--- a/src/components/Pages/index.js
+++ b/src/components/Pages/index.js
@@ -10,8 +10,21 @@ import { selectVmDetail, selectPoolDetail, getISOStorages } from '../../actions/
 import Selectors from '../../selectors'
 
 class VmDetailPage extends React.Component {
+  constructor (props) {
+    super(props)
+    this.requestSent = false
+  }
+
   componentWillMount () {
     if (Selectors.isFilterChecked()) {
+      this.props.getVms({ vmId: this.props.match.params.id })
+    }
+  }
+
+  componentWillUpdate () {
+    const vmInStore = this.props.vms.getIn(['vms', this.props.match.params.id])
+    if (!vmInStore && Selectors.isFilterChecked() && !this.requestSent) {
+      this.requestSent = true
       this.props.getVms({ vmId: this.props.match.params.id })
     }
   }
@@ -44,11 +57,25 @@ VmDetailPage.propTypes = {
 }
 
 class PoolDetailPage extends React.Component {
+  constructor (props) {
+    super(props)
+    this.requestSent = false
+  }
+
   componentWillMount () {
     if (Selectors.isFilterChecked()) {
       this.props.getPools({ poolId: this.props.match.params.id })
     }
   }
+
+  componentWillUpdate () {
+    const poolInStore = this.props.vms.getIn(['pools', this.props.match.params.id, 'vm'])
+    if (!poolInStore && Selectors.isFilterChecked() && !this.requestSent) {
+      this.requestSent = true
+      this.props.getPools({ poolId: this.props.match.params.id })
+    }
+  }
+
   render () {
     let { match, vms, config } = this.props
     if (vms.getIn(['pools', match.params.id, 'vm'])) {


### PR DESCRIPTION
Bug: If open detail of VM that is not on first page, and refresh it, it'll leads to main page.
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/491

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/497)
<!-- Reviewable:end -->
