### PR TITLE
Fixed bug with "Loading..." message when SSH key is empty.

### DIFF
--- a/src/components/OptionsDialog/sagas.js
+++ b/src/components/OptionsDialog/sagas.js
@@ -10,8 +10,13 @@ function* saveSSHKey (sagas, action) {
 function* getSSHKey (sagas, action) {
   yield put(setUnloaded())
   const result = yield sagas.callExternalAction('getSSHKey', Api.getSSHKey, action)
-  if (!result.error && result.ssh_public_key && result.ssh_public_key.length > 0) {
+  if (result.error) {
+    return
+  }
+  if (result.ssh_public_key && result.ssh_public_key.length > 0) {
     yield put(setSSHKey(Api.SSHKeyToInternal({ sshKey: result.ssh_public_key[0] })))
+  } else {
+    yield put(setSSHKey(Api.SSHKeyToInternal({ sshKey: '' })))
   }
 }
 


### PR DESCRIPTION
Bug: If there is no SSH key saved for user, then in OptionDialog "Loading..." message doesn't disappear
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/505

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/519)
<!-- Reviewable:end -->
