### PR TITLE
Fixed bug with suspend confirmation popover

### DIFF
--- a/src/components/VmActions/index.js
+++ b/src/components/VmActions/index.js
@@ -154,6 +154,11 @@ class VmActions extends React.Component {
       consoleProtocol = 'Console in use'
     }
 
+    const handleSuspend = (close) => () => {
+      this.props.onSuspend()
+      close()
+    }
+
     const idPrefix = `vmaction-${vm.get('name')}`
     return (
       <div className={`actions-line ${isOnCard ? 'card-pf-items text-center' : style['left-padding']}`}>
@@ -174,7 +179,7 @@ class VmActions extends React.Component {
           tooltip={msg.suspendVm()}
           id={`${idPrefix}-button-suspend`}
           popover={({ close }) => <Confirmation text={msg.suspendVmQuestion()}
-            okButton={{ label: msg.yes(), click: this.props.onSuspend }}
+            okButton={{ label: msg.yes(), click: handleSuspend(close) }}
             cancelButton={{ label: msg.cancel(), click: () => { close() } }}
             uniqueId={vm.get('name')} />} />
 


### PR DESCRIPTION
Bug: After clicking on Suspend action of VM, appear confirmation popover and if click on 'Yes' it doesn't disappear.
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/515

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/521)
<!-- Reviewable:end -->
