### PR TITLE
VmDetail space for JA and DE texts

### DIFF
--- a/src/components/VmDetail/style.css
+++ b/src/components/VmDetail/style.css
@@ -5,7 +5,7 @@
 .vm-detail-container dt {
     clear: left;
     float: left;
-    width: 200px;
+    width: 250px;
     min-height: 26px;
     white-space: nowrap;
     text-overflow: ellipsis;


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1526389

---
![image](https://user-images.githubusercontent.com/5278760/37466250-9364b88a-285d-11e8-8d72-b8b54000fa26.png)
---
![image](https://user-images.githubusercontent.com/5278760/37466282-a4e8cefc-285d-11e8-859b-349ca11105c5.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/527)
<!-- Reviewable:end -->
