### PR TITLE
Fixed bug with delayed switch in Cloud-Init enable, also Hostname and…

### DIFF
--- a/src/components/VmDialog/index.js
+++ b/src/components/VmDialog/index.js
@@ -97,6 +97,8 @@ class VmDialog extends React.Component {
     this.onChangeVmCpu = this.onChangeVmCpu.bind(this)
     this.onChangeCD = this.onChangeCD.bind(this)
     this.onChangeBootMenuEnabled = this.onChangeBootMenuEnabled.bind(this)
+
+    this.handleCloudInitChange = this.handleCloudInitChange.bind(this)
   }
 
   componentWillMount () {
@@ -414,6 +416,14 @@ class VmDialog extends React.Component {
     this.setState(stateChange)
   }
 
+  handleCloudInitChange (key) {
+    return (value) => {
+      this.setState((prevState) => {
+        return { cloudInit: Object.assign({}, prevState.cloudInit, { [key]: value }) }
+      })
+    }
+  }
+
   render () {
     const { icons, vmDialog, clusters, templates, operatingSystems, storages, previousPath } = this.props
     const vm = this.props.vm
@@ -611,10 +621,9 @@ class VmDialog extends React.Component {
                 enabled={this.state.cloudInit.enabled}
                 hostName={this.state.cloudInit.hostName}
                 sshAuthorizedKeys={this.state.cloudInit.sshAuthorizedKeys}
-                onEnabledChange={value => this.setState(state => { state.cloudInit.enabled = value })}
-                onHostNameChange={value => this.setState(state => { state.cloudInit.hostName = value })}
-                onSshAuthorizedKeysChange={value =>
-                  this.setState(state => { state.cloudInit.sshAuthorizedKeys = value })}
+                onEnabledChange={this.handleCloudInitChange('enabled')}
+                onHostNameChange={this.handleCloudInitChange('hostName')}
+                onSshAuthorizedKeysChange={this.handleCloudInitChange('sshAuthorizedKeys')}
               />
 
             </dl>


### PR DESCRIPTION
… SSH Keys typing delay

Bug: When click on Cloud-Init enable switch it has very long delay, problem was in function that putting as parameter in setState function.
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/546

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/559)
<!-- Reviewable:end -->
