### PR TITLE
fix: cluster can be in no datacenter

### DIFF
--- a/src/ovirtapi.js
+++ b/src/ovirtapi.js
@@ -385,7 +385,7 @@ OvirtApi = {
     return {
       id: cluster.id,
       name: cluster.name,
-      dataCenterId: cluster.data_center.id,
+      dataCenterId: cluster.data_center && cluster.data_center.id,
 
       memoryPolicy: {
         overCommitPercent: cluster['memory_policy'] && cluster['memory_policy']['over_commit'] && cluster['memory_policy']['over_commit']['percent'] ? cluster['memory_policy']['over_commit']['percent'] : 100,


### PR DESCRIPTION
If the cluster was in no DC, web-ui crashed.
Since it is a valid case, made it possible.

fixes #576

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/577)
<!-- Reviewable:end -->
