### PR TITLE
Storage domain in multiple data centers - fix

### DIFF
--- a/src/sagas.js
+++ b/src/sagas.js
@@ -577,12 +577,12 @@ function* fetchAllAttachedStorageDomains (action) {
  */
 function mergeStorageDomains (storageDomainsInternal) {
   const idToStorageDomain = storageDomainsInternal.reduce((accum, storageDomain) => {
-    const isNew = !(storageDomain.id in accum)
-    if (isNew) {
+    const existingStorageDomain = accum[storageDomain.id]
+    if (!existingStorageDomain) {
       accum[storageDomain.id] = storageDomain
       return accum
     }
-    Object.assign(accum[storageDomain.id].status, storageDomain.status)
+    Object.assign(existingStorageDomain.statusPerDataCenter, storageDomain.statusPerDataCenter)
     return accum
   }, {})
   const mergedStorageDomains = Object.values(idToStorageDomain)


### PR DESCRIPTION
Status of storage domain that is attached to multiple data centers is
correctly merged. Previously it failed with 'Cannot convert undefined or
null to object'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/578)
<!-- Reviewable:end -->
