### PR TITLE
Fix expired token error message to be fully visible

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -78,13 +78,13 @@ const App = ({ vms, visibility, config }) => {
       <div>
         <VmsPageHeader page={vms.get('page')} title={fixedStrings.BRAND_NAME + ' ' + msg.vmPortal()} />
         <VerticalMenu menuItems={menu} /> { /* Disabled, to enable search for left sidebar menu */ }
-        <TokenExpired />
         <LoadingData />
         {renderRoutes(routes)}
         {detailToRender}
         <AboutDialog />
         <OptionsDialog userId={config.getIn(['user', 'id'])} />
         <OvirtApiCheckFailed />
+        <TokenExpired />
       </div>
     </Router>
   )

--- a/src/components/ErrorAlert.js
+++ b/src/components/ErrorAlert.js
@@ -1,25 +1,21 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const ErrorAlert = ({ id, message, dangerouslySetInnerHTML }) => {
+const ErrorAlert = ({ id, message, children }) => {
   return (
     <div className='alert alert-danger'>
       <span className='pficon pficon-error-circle-o' />
-      {message && (
-        <strong id={id}>{message}</strong>
-      )}
-      {dangerouslySetInnerHTML && (
-        <span id={id} dangerouslySetInnerHTML={dangerouslySetInnerHTML} />
-      )}
+      <span id={id}>
+        {message && (<strong>{message}</strong>)}
+        {children}
+      </span>
     </div>
   )
 }
 ErrorAlert.propTypes = {
   id: PropTypes.string.isRequired,
   message: PropTypes.string,
-  dangerouslySetInnerHTML: PropTypes.shape({
-    __html: PropTypes.any.isRequired,
-  }),
+  children: PropTypes.node,
 }
 
 export default ErrorAlert

--- a/src/components/ErrorAlert.js
+++ b/src/components/ErrorAlert.js
@@ -1,17 +1,25 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const ErrorAlert = ({ message, id }) => {
-  return message ? (
+const ErrorAlert = ({ id, message, dangerouslySetInnerHTML }) => {
+  return (
     <div className='alert alert-danger'>
       <span className='pficon pficon-error-circle-o' />
-      <strong id={id}>{message}</strong>
+      {message && (
+        <strong id={id}>{message}</strong>
+      )}
+      {dangerouslySetInnerHTML && (
+        <span id={id} dangerouslySetInnerHTML={dangerouslySetInnerHTML} />
+      )}
     </div>
-  ) : null
+  )
 }
 ErrorAlert.propTypes = {
+  id: PropTypes.string.isRequired,
   message: PropTypes.string,
-  id: PropTypes.string,
+  dangerouslySetInnerHTML: PropTypes.shape({
+    __html: PropTypes.any.isRequired,
+  }),
 }
 
 export default ErrorAlert

--- a/src/components/OvirtApiCheckFailed.js
+++ b/src/components/OvirtApiCheckFailed.js
@@ -22,14 +22,15 @@ const OvirtApiCheckFailed = ({ config }) => {
   const version = major ? `${major}.${minor}` : `"${msg.unknown()}"`
 
   const required = `${Product.ovirtApiVersionRequired.major}.${Product.ovirtApiVersionRequired.minor}`
-  const message = msg.htmlUnsupportedOvirtVersionFoundButVersionAtLeastRequired({
+  const htmlMessage = msg.htmlUnsupportedOvirtVersionFoundButVersionAtLeastRequired({
     version,
     productName: fixedStrings.BRAND_NAME,
     requiredVersion: required,
   })
+  const message = (<span dangerouslySetInnerHTML={{ __html: htmlMessage }} />)
 
   return (
-    <ErrorAlert id='ovirtapi-check-failed' dangerouslySetInnerHTML={{ __html: message }} />
+    <ErrorAlert id='ovirtapi-check-failed'>{message}</ErrorAlert>
   )
 }
 OvirtApiCheckFailed.propTypes = {

--- a/src/components/OvirtApiCheckFailed.js
+++ b/src/components/OvirtApiCheckFailed.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux'
 import Product from '../version'
 import { msg } from '../intl'
 import { fixedStrings } from '../branding'
+import ErrorAlert from './ErrorAlert'
 
 const OvirtApiCheckFailed = ({ config }) => {
   const oVirtApiVersion = config.get('oVirtApiVersion')
@@ -21,14 +22,14 @@ const OvirtApiCheckFailed = ({ config }) => {
   const version = major ? `${major}.${minor}` : `"${msg.unknown()}"`
 
   const required = `${Product.ovirtApiVersionRequired.major}.${Product.ovirtApiVersionRequired.minor}`
+  const message = msg.htmlUnsupportedOvirtVersionFoundButVersionAtLeastRequired({
+    version,
+    productName: fixedStrings.BRAND_NAME,
+    requiredVersion: required,
+  })
 
   return (
-    <div className='alert alert-danger'>
-      <span className='pficon pficon-error-circle-o' />
-      <span
-        id='ovirtapi-check-failed'
-        dangerouslySetInnerHTML={{ __html: msg.htmlUnsupportedOvirtVersionFoundButVersionAtLeastRequired({ version, productName: fixedStrings.BRAND_NAME, requiredVersion: required }) }} />
-    </div>
+    <ErrorAlert id='ovirtapi-check-failed' dangerouslySetInnerHTML={{ __html: message }} />
   )
 }
 OvirtApiCheckFailed.propTypes = {

--- a/src/components/VmDialog/index.js
+++ b/src/components/VmDialog/index.js
@@ -466,11 +466,14 @@ class VmDialog extends React.Component {
     const iconId = vm && vm.getIn(['icons', 'small', 'id'])
     const icon = iconId && icons.get(iconId)
 
-    const title = isEdit ? (
-      <h1 className={style['header']} id={`${idPrefix}-edit-title`}>
-        <VmIcon icon={icon} missingIconClassName='pficon pficon-virtual-machine' className={sharedStyle['vm-detail-icon']} />
-        &nbsp;{vm.get('name')} - {msg.edit()}
-      </h1>) : (
+    const title = isEdit
+      ? (
+        <h1 className={style['header']} id={`${idPrefix}-edit-title`}>
+          <VmIcon icon={icon} missingIconClassName='pficon pficon-virtual-machine' className={sharedStyle['vm-detail-icon']} />
+          &nbsp;{vm.get('name')} - {msg.edit()}
+        </h1>
+      )
+      : (
         <h1 id={`${idPrefix}-create-title`}>{msg.createANewVm()}</h1>
       )
 
@@ -487,7 +490,7 @@ class VmDialog extends React.Component {
     return (
       <DetailContainer>
         {title}
-        <ErrorAlert message={this.getLatestUserMessage()} id={`${idPrefix}-erroralert`} />
+        {this.getLatestUserMessage() && (<ErrorAlert message={this.getLatestUserMessage()} id={`${idPrefix}-erroralert`} />)}
         <br />
         <form>
           <Prompt

--- a/src/index-nomodules.css
+++ b/src/index-nomodules.css
@@ -44,8 +44,9 @@ div.toolbar-pf {
 }
 
 .alert {
-  top: 30px;
-  margin-left: 201px;
+  margin-top: 30px;
+  margin-left: 30px;
+  margin-right: 30px;
   z-index: 100;
 }
 

--- a/src/index-nomodules.css
+++ b/src/index-nomodules.css
@@ -46,6 +46,7 @@ div.toolbar-pf {
 .alert {
   top: 30px;
   margin-left: 201px;
+  z-index: 100;
 }
 
 .bootstrap-switch-container .bootstrap-switch-label {


### PR DESCRIPTION
Due to the way the PageRouter is laid out, the token error message
would display beneath and only be partially visible.  This is fixed
twice by setting the z-index on .alert to be higher, and by moving
the tag below the PageRouter in the App's dom.  Both changes will
make sure the alerts are not hidden.

Refactored OvirtApiCheckFailed to use ErrorAlert, allowing future
changes to error alerts to be done in one place.

Resolves issue #395

![screenshot-2018-5-1 vm portal](https://user-images.githubusercontent.com/3985964/39482360-bbdac5d0-4d3c-11e8-8941-08a1413892c5.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/586)
<!-- Reviewable:end -->
