### PR TITLE
Fix word break in korean language.

### DIFF
--- a/src/components/VmUserMessages/style.css
+++ b/src/components/VmUserMessages/style.css
@@ -30,6 +30,10 @@
     margin-bottom: 0;
 }
 
+.no-messages h1 {
+    white-space: nowrap;
+}
+
 .contact-admin {
     padding: 6px 15px;
 }


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/594

Korean:
![image](https://user-images.githubusercontent.com/3332176/39814113-56858adc-5393-11e8-90a1-b3bc9d565754.png)

English:
![image](https://user-images.githubusercontent.com/3332176/39814129-657829d2-5393-11e8-986d-7f91e581aa73.png)

Japanese:
![image](https://user-images.githubusercontent.com/3332176/39814138-733f8f7e-5393-11e8-8a3f-7aa13ae69dda.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/595)
<!-- Reviewable:end -->
