### PR TITLE
Enable source maps for webpack dev mode

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -13,11 +13,11 @@ var webpackConfigCommons = require('./webpack.config.commons')
 // It is focused on developer experience and fast rebuilds.
 // The production configuration is different and lives in a separate file.
 module.exports = {
-  // This makes the bundle appear split into separate modules in the devtools.
-  // We don't use source maps here because they can be confusing:
-  // https://github.com/facebookincubator/create-react-app/issues/343#issuecomment-237241875
-  // You may want 'cheap-module-source-map' instead if you prefer source maps.
-  devtool: 'eval',
+  // Integrate https://github.com/facebook/create-react-app/pull/924 here.
+  // You may want 'eval' instead if you prefer to see the compiled output in DevTools.
+  // See the discussion in https://github.com/facebookincubator/create-react-app/issues/343.
+  devtool: 'cheap-module-source-map',
+
   // These are the "entry points" to our application.
   // This means they will be the "root" imports that are included in JS bundle.
   // The first two entry points enable "hot" CSS and auto-refreshes for JS.


### PR DESCRIPTION
Following along with https://github.com/facebook/create-react-app/pull/924, enable source maps by default.  This lets us see the actual code in chrome and firefox dev tools.  Without the source maps, you view the transpiled code in dev tools.