### PR TITLE
Fix InfiniteScroller, saga deprecation and Fragment key console warnings

### DIFF
--- a/src/components/VmDetail/index.js
+++ b/src/components/VmDetail/index.js
@@ -314,20 +314,16 @@ class VmDetail extends Component {
                     <FieldHelp content={msg.bootSequenceTooltip()} text={msg.bootSequence()} />
                   </dt>
                   <dd />
-                  <div>
-                    {
-                      vm.getIn(['os', 'bootDevices']).map((device, key) =>
-                        <React.Fragment>
-                          <dt className={style['field-shifted']}>
-                            <FieldHelp content={msg[`${sequence[key]}DeviceTooltip`]()} text={msg[`${sequence[key]}Device`]()} />
-                          </dt>
-                          <dd>
-                            {msg[`${device}Boot`]()}
-                          </dd>
-                        </React.Fragment>
-                      )
-                    }
-                  </div>
+                  {vm.getIn(['os', 'bootDevices']).map((device, key) =>
+                    <React.Fragment key={key}>
+                      <dt className={style['field-shifted']}>
+                        <FieldHelp content={msg[`${sequence[key]}DeviceTooltip`]()} text={msg[`${sequence[key]}Device`]()} />
+                      </dt>
+                      <dd>
+                        {msg[`${device}Boot`]()}
+                      </dd>
+                    </React.Fragment>
+                  )}
                   <dt>
                     <FieldHelp content={msg.cloudInitTooltip()} text={msg.cloudInit()} />
                   </dt>

--- a/src/components/VmsList/Vms.js
+++ b/src/components/VmsList/Vms.js
@@ -47,7 +47,7 @@ class Vms extends React.Component {
       <InfiniteScroll
         loadMore={this.loadMore}
         hasMore={vms.get('notAllPagesLoaded')}
-        loader={<div className={style['loaderBox']}><div className={style['loader']} /></div>}
+        loader={<div key='infinite-scroll-loader' className={style['loaderBox']}><div className={style['loader']} /></div>}
         useWindow={false}
       >
         <div>

--- a/src/sagas.js
+++ b/src/sagas.js
@@ -726,7 +726,7 @@ let sagasFunctions = {
 }
 
 export function* rootSaga () {
-  yield [
+  yield all([
     takeEvery(LOGIN, login),
     takeEvery(LOGOUT, logout),
     takeLatest(CHECK_TOKEN_EXPIRED, doCheckTokenExpired),
@@ -774,5 +774,5 @@ export function* rootSaga () {
     ...newVmDialogSagas,
 
     ...SagasWorkers(sagasFunctions),
-  ]
+  ])
 }


### PR DESCRIPTION
1. Fixes https://github.com/oVirt/ovirt-web-ui/issues/562 as per https://github.com/CassetteRocks/react-infinite-scroller/issues/133. Added `key={0}` to the loader and the InfiniteScroller warning went away.

2. Added an `all([])` wrapper around the rootSaga to resolve the deprecation warning.

3. Refactored `VmDetail/index.js` to add `key={0}` to the `React.Fragment` use as it was causing a warning similar to InfiniteScroller's warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/616)
<!-- Reviewable:end -->
