### PR TITLE
`yarn start` will open browser in ENV var BROWSER or system default

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -126,7 +126,11 @@ function openBrowser(port, protocol) {
   }
   // Fallback to opn
   // (It will always open new tab)
-  opn(protocol + '://localhost:' + port + '/').catch(err => {
+  const options = {}
+  if (process.env.BROWSER) {
+    options.app = process.env.BROWSER
+  }
+  opn(protocol + '://localhost:' + port + '/', options).catch(err => {
     // ignore errors - can happen when starting the server in docker container
   })
 }


### PR DESCRIPTION
This lets a developer use a command like this and select the browser they want to be auto-opened:

```
  
ENGINE_URL=htts://engine/ovirt-engine BROWSER=google-chrome yarn start
```