### PR TITLE
ux-redesign: fix PageRouter previousPath bug when reloading edit page

### DIFF
--- a/src/components/PageRouter.js
+++ b/src/components/PageRouter.js
@@ -53,7 +53,7 @@ class PageRouter extends React.Component {
       updates.closeable = !!updates.branch.route.closeable
 
       updates.currentPath = newPath
-      if (previousPath !== currentPath) {
+      if (currentPath && (previousPath !== currentPath)) {
         updates.previousPath = currentPath
       }
     }


### PR DESCRIPTION
If the user reloads/refreshes the VM edit page, the `PageRouter` component had a bug that would push a __null__ to __previousPage__ and prevent the edit component from rendering.  A truthy check on the previous path fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/657)
<!-- Reviewable:end -->
