### PR TITLE
ux-redesign: refactor getRoutes() route title functions

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -36,7 +36,7 @@ const NoLogin = () => {
  * Main App component. Wrap the main react-router components together with
  * the various dialogs and error messages that may be needed.
  */
-const App = ({ history, vms, config, appReady }) => {
+const App = ({ history, config, appReady }) => {
   if (!config.get('loginToken')) { // login is missing
     return (
       <Grid fluid>
@@ -45,13 +45,11 @@ const App = ({ history, vms, config, appReady }) => {
     )
   }
 
-  const routes = getRoutes(vms)
-
   return (
     <ConnectedRouter history={history}>
       <React.Fragment>
         <VmsPageHeader title={fixedStrings.BRAND_NAME + ' ' + msg.vmPortal()} />
-        { appReady && renderRoutes(routes) }
+        { appReady && renderRoutes(getRoutes()) }
         <LoadingData />
         <OvirtApiCheckFailed />
         <TokenExpired />
@@ -62,14 +60,12 @@ const App = ({ history, vms, config, appReady }) => {
 App.propTypes = {
   history: PropTypes.object.isRequired,
 
-  vms: PropTypes.object.isRequired,
   config: PropTypes.object.isRequired,
   appReady: PropTypes.bool.isRequired,
 }
 
 export default connect(
   (state) => ({
-    vms: state.vms,
     config: state.config,
     appReady: state.config.get('isFilterChecked'), // When is the app ready to display data components?
   })

--- a/src/components/Breadcrumb/index.js
+++ b/src/components/Breadcrumb/index.js
@@ -1,20 +1,27 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
+import { connect } from 'react-redux'
 import { msg } from '../../intl'
 import style from '../sharedStyle.css'
 
-const buildPath = (route) => {
-  let res = []
-  for (let i in route) {
-    if (typeof route[i].route.title === 'function') {
-      res.push({ title: route[i].route.title(route[i].match), url: route[i].match.url })
-    } else {
-      if (typeof route[i].route.title === 'string') {
-        res.push({ title: route[i].route.title, url: route[i].match.url })
-      }
+const buildPath = (vms, branches) => {
+  const res = []
+
+  for (const branch of branches) {
+    if (typeof branch.route.title === 'function') {
+      res.push({
+        title: branch.route.title(branch.match, vms),
+        url: branch.match.url,
+      })
+    } else if (typeof branch.route.title === 'string') {
+      res.push({
+        title: branch.route.title,
+        url: branch.match.url,
+      })
     }
   }
+
   return res
 }
 
@@ -23,20 +30,19 @@ const root = {
   url: '/',
 }
 
-const Breadcrumb = ({ branches }) => {
-  const crumbs = [ root, ...buildPath(branches) ]
+const Breadcrumb = ({ vms, branches }) => {
+  const crumbs = [ root, ...buildPath(vms, branches) ]
   const idPrefix = `breadcrumb`
-  // const noExactMatch = branches.length === 1 && !branches[0].route.path
 
   return (
     <ol className={`breadcrumb ${style['breadcrumb']}`}>
       {crumbs.map((path, index, array) =>
         (index === (array.length - 1)) ? (
-          <li key={path.url} className='active' id={`${idPrefix}-last-${index}`}>
+          <li key={`${index}-${path.url}`} className='active' id={`${idPrefix}-last-${index}`}>
             {path.title}
           </li>
         ) : (
-          <li key={path.url}>
+          <li key={`${index}-${path.url}`}>
             <Link to={path.url} id={`${idPrefix}-link-${index}`}>{path.title}</Link>
           </li>
         )
@@ -46,6 +52,11 @@ const Breadcrumb = ({ branches }) => {
 }
 Breadcrumb.propTypes = {
   branches: PropTypes.array.isRequired,
+  vms: PropTypes.object.isRequired,
 }
 
-export default Breadcrumb
+export default connect(
+  state => ({
+    vms: state.vms,
+  })
+)(Breadcrumb)

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,6 +4,7 @@ import AddVmButton from './components/VmDialog/AddVmButton'
 import PageRouter from './components/PageRouter'
 import { VmDetailToolbar, PoolDetailToolbar } from './components/Toolbar'
 import { PoolDetailPage, VmDetailPage, VmDialogPage, VmsPage } from './components/Pages'
+
 import { msg } from './intl'
 
 /**
@@ -26,21 +27,21 @@ export default function getRoutes (vms) {
         path: '/',
         exact: true,
         component: VmsPage,
-        toolbars: [(match) => (<AddVmButton key='addbutton' id={`route-add-vm`} />)],
+        toolbars: [() => (<AddVmButton key='addbutton' id={`route-add-vm`} />)],
       },
 
       {
         path: '/vm/add',
         exact: true,
-        title: (match) => msg.addNewVm(),
+        title: () => msg.addNewVm(),
         component: VmDialogPage,
-        toolbars: [], // Recently not used. When needed, see VmDialog/style.css - .vm-dialog-buttons
+        toolbars: [], // TODO: Recently not used. When needed, see VmDialog/style.css - .vm-dialog-buttons
         closeable: true,
       },
 
       {
         path: '/vm/:id',
-        title: (match) => vms.getIn(['vms', match.params.id, 'name']) || match.params.id,
+        title: (match, vms) => vms.getIn(['vms', match.params.id, 'name']) || match.params.id,
         component: VmDetailPage,
         toolbars: [(match) => (<VmDetailToolbar match={match} key='vmaction' />)],
         routes: [
@@ -48,7 +49,7 @@ export default function getRoutes (vms) {
             path: '/vm/:id/edit',
             title: (match) => msg.edit() || match.params.id,
             component: VmDialogPage,
-            toolbars: [], // Recently not used. When needed, see VmDialog/style.css - .vm-dialog-buttons
+            toolbars: [], // TODO: Recently not used. When needed, see VmDialog/style.css - .vm-dialog-buttons
             closeable: true,
           },
         ],
@@ -56,7 +57,7 @@ export default function getRoutes (vms) {
 
       {
         path: '/pool/:id',
-        title: (match) => vms.getIn(['pools', match.params.id, 'name']) || match.params.id,
+        title: (match, vms) => vms.getIn(['pools', match.params.id, 'name']) || match.params.id,
         component: PoolDetailPage,
         toolbars: [(match) => (<PoolDetailToolbar match={match} key='poolaction' />)],
       },


### PR DESCRIPTION
A route's title function is now passed __vms__ as the second argument.

With the `ConnectedRouter` in place, passing __vms__ to `getRoutes()` was rendering the route but not changing the render when __vms__ is updated. The route doesn't change even if the __vms__ does, so titles would not get updated.

The only need for __vms__ in `getRoutes()` is to pull a VM's name for the route's title used by `Breadcrumb`. On a browser page reload for any route that uses __vms__ (VM/Pool Details and Edit), the Breadcrumb will render the VM/Pool ID initially. However, it didn't get updated to the VM/Pool name since getRoutes() was holding on to an old copy of __vms__. Pushing the __vms__ to the `title` functions ensures the correct copy of __vms__ is used every time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/659)
<!-- Reviewable:end -->
