### PR TITLE
Add utilities for number unit conversion and rounding

### DIFF
--- a/src/utils/round.js
+++ b/src/utils/round.js
@@ -1,0 +1,10 @@
+/*
+ * Round a number to the specified precision (negative precision is tens places,
+ * 0 is to an integer, positive precision is to decimal places).
+ */
+export function round (number, precision = 0) {
+  const factor = Math.pow(10, precision)
+  const temp = number * factor
+  const roundedTemp = Math.round(temp)
+  return roundedTemp / factor
+}

--- a/src/utils/round.test.js
+++ b/src/utils/round.test.js
@@ -1,0 +1,29 @@
+/* eslint-env jest */
+import { round } from './round'
+
+describe('rounding precision tests', function () {
+  it('rounding to tens', function () {
+    expect(round(12344, -1)).toEqual(12340)
+    expect(round(12345, -1)).toEqual(12350)
+    expect(round(12344, -2)).toEqual(12300)
+    expect(round(12354, -2)).toEqual(12400)
+    expect(round(12445, -3)).toEqual(12000)
+    expect(round(12545, -3)).toEqual(13000)
+  })
+
+  it('rounding to integer', function () {
+    expect(round(12345)).toEqual(12345)
+    expect(round(12345, 0)).toEqual(12345)
+    expect(round(12345.4, 0)).toEqual(12345)
+    expect(round(12345.5, 0)).toEqual(12346)
+  })
+
+  it('rounding to decimals', function () {
+    expect(round(1.2345, 1)).toEqual(1.2)
+    expect(round(1.2567, 1)).toEqual(1.3)
+    expect(round(1.2345, 2)).toEqual(1.23)
+    expect(round(1.2356, 2)).toEqual(1.24)
+    expect(round(1.2344, 3)).toEqual(1.234)
+    expect(round(1.2345, 3)).toEqual(1.235)
+  })
+})

--- a/src/utils/storage-conversion.js
+++ b/src/utils/storage-conversion.js
@@ -1,0 +1,56 @@
+// @flow
+import { convertValue as convertUnits } from './unit-conversion'
+
+export const storageUnitTable = [
+  { unit: 'TiB' },
+  { unit: 'GiB', factor: 1024 },
+  { unit: 'MiB', factor: 1024 },
+  { unit: 'KiB', factor: 1024 },
+  { unit: 'B', factor: 1024 },
+]
+
+type UnitType = 'TiB' | 'GiB' | 'MiB' | 'KiB' | 'B'
+
+/**
+ * Scale a single value, of the given unit, such that the new value, with a new unit,
+ * falls in the range 0.1 .. 1024.
+ */
+export function convertValue (unit: UnitType, value: number): {
+  unit: UnitType,
+  value: number
+} {
+  return convertUnits(storageUnitTable, unit, value, 0.1, 1024)
+}
+
+/**
+ * Scale an array of values, of the given unit, together such that the new values, with
+ * a new unit, fall in the range 0.1 .. 1024 as close as possible.  Numbers that have
+ * a large difference will not scale much.  A __0__ value will not prevent the other
+ * numbers from scaling.
+ */
+export function convertValues (unit: UnitType, value: Array<number>): {
+  unit: UnitType,
+  value: Array<number>
+} {
+  return convertUnits(storageUnitTable, unit, value, 0.1, 1024)
+}
+
+/**
+ * Scale a map of values, of the given unit, together such that the new values, with
+ * a new unit, fall in the range 0.1 .. 1024 as close as possible.  Numbers that have
+ * a large difference will not scale much.  A __0__ value will not prevent the other
+ * numbers from scaling.
+ */
+export function convertValueMap (unit: UnitType, valueMap: { [string]: number }): {
+  unit: UnitType,
+  value: { [string]: number }
+} {
+  const keys: Array<string> = Object.keys(valueMap)
+  const values: Array<number> = keys.map(key => valueMap[key])
+
+  const { unit: newUnit, value: converted } = convertUnits(storageUnitTable, unit, values, 0.1, 1024)
+
+  const result = { ...valueMap }
+  keys.forEach((key, index) => { result[key] = converted[index] })
+  return { unit: newUnit, value: result }
+}

--- a/src/utils/storage-conversion.test.js
+++ b/src/utils/storage-conversion.test.js
@@ -1,0 +1,61 @@
+import * as Storage from './storage-conversion'
+
+describe('storage size conversions', () => {
+  test('single value, start from byte (B)', () => {
+    const results = Storage.convertValue('B', 1024 * 1024 * 1024)
+    expect(results).toEqual({ unit: 'GiB', value: 1 })
+  })
+
+  test('paired values, start from byte (B)', () => {
+    const results = Storage.convertValues('B', [ 3 * 1024 * 1024, 7.5 * 1024 * 1024 ])
+    expect(results).toEqual({ unit: 'MiB', value: [ 3, 7.5 ] })
+  })
+
+  test('value map, start from byte (B)', () => {
+    const results = Storage.convertValueMap('B', {
+      a: 47185920,
+      b: 367001600,
+      c: 9663676416,
+    })
+    expect(results).toEqual({
+      unit: 'MiB',
+      value: {
+        a: 45,
+        b: 350,
+        c: 9216,
+      },
+    })
+  })
+
+  test('set of values to scale up (higher magnitude), one as 0 the rest are large', () => {
+    const results = Storage.convertValues('B', [
+      0,
+      2.5 * (1024 ** 3),
+      5 * (1024 ** 3),
+    ])
+    expect(results).toEqual({
+      unit: 'GiB',
+      value: [
+        0,
+        2.5,
+        5,
+      ],
+    })
+  })
+
+  test('set of values to be scaled down (lower magnitude)', () => {
+    const results = Storage.convertValues('GiB', [
+      0,
+      0.0123,
+      0.0456,
+    ])
+    expect(results).toEqual({
+      unit: 'MiB',
+      value: [
+        0,
+        0.0123 * 1024,
+        0.0456 * 1024,
+      ],
+    })
+  })
+})

--- a/src/utils/unit-conversion.js
+++ b/src/utils/unit-conversion.js
@@ -1,0 +1,40 @@
+// adapted from: https://github.com/oVirt/ovirt-engine-dashboard/blob/master/src/utils/unit-conversion.js
+
+export function convertValue (unitTable = [], unit, value, minThreshold = 0.1, maxThreshold = 1024) {
+  let newUnit = unit
+  let newValue
+  if (Array.isArray(value)) {
+    newValue = value.slice(0)
+  } else if (!Number.isNaN(value)) {
+    newValue = [ value ]
+  } else {
+    throw new TypeError('value must be a number or an array')
+  }
+
+  const availableUnits = unitTable.map((obj) => obj.unit)
+  if (availableUnits.includes(unit)) {
+    const reversedUnitTable = unitTable.slice(0).reverse()
+
+    // scale all values down (coarse to fine), but only if they can all scale with the minThreshold
+    unitTable.forEach((obj, index) => {
+      const leMinThreshold = newValue.reduce((res, val) => res && (val === 0 || val <= minThreshold), true)
+      if (newUnit === obj.unit && leMinThreshold && index + 1 < unitTable.length) {
+        const nextObj = unitTable[index + 1]
+        newUnit = nextObj.unit
+        newValue = newValue.map((val) => val * nextObj.factor)
+      }
+    })
+
+    // scale each value up (fine to coarse), but only if they can all scale with the maxThreshold
+    reversedUnitTable.forEach((obj, index) => {
+      const geMaxThreshold = newValue.reduce((res, val) => res && (val === 0 || val >= maxThreshold), true)
+      if (newUnit === obj.unit && geMaxThreshold && index + 1 < reversedUnitTable.length) {
+        const nextObj = reversedUnitTable[index + 1]
+        newUnit = nextObj.unit
+        newValue = newValue.map((val) => val / obj.factor)
+      }
+    })
+  }
+
+  return { unit: newUnit, value: Array.isArray(value) ? newValue : newValue[0] }
+}

--- a/src/utils/unit-conversion.test.js
+++ b/src/utils/unit-conversion.test.js
@@ -1,0 +1,73 @@
+/* eslint-env jest */
+// adapted from: https://github.com/oVirt/ovirt-engine-dashboard/blob/master/src/utils/unit-conversion-test.js
+
+import { storageUnitTable } from './storage-conversion'
+import { convertValue } from './unit-conversion'
+
+describe('convertValue', function () {
+  it('scales down the unit when value is too small', function () {
+    expect(convertValue(storageUnitTable, 'TiB', 0.001)).toEqual({
+      unit: 'GiB', value: 0.001 * 1024,
+    })
+    expect(convertValue(storageUnitTable, 'TiB', 0.000001)).toEqual({
+      unit: 'MiB', value: 0.000001 * (1024 ** 2),
+    })
+    expect(convertValue(storageUnitTable, 'GiB', 0.001)).toEqual({
+      unit: 'MiB', value: 0.001 * 1024,
+    })
+  })
+
+  it('scales down the unit when value is too small (custom minimum thresholds)', function () {
+    expect(convertValue(storageUnitTable, 'TiB', 0.0499, 0.05)).toEqual({
+      unit: 'GiB', value: 0.0499 * 1024,
+    })
+    expect(convertValue(storageUnitTable, 'TiB', 0.051, 0.05)).toEqual({
+      unit: 'TiB', value: 0.051,
+    })
+  })
+
+  it('scales up the unit when value is too big', function () {
+    expect(convertValue(storageUnitTable, 'MiB', 10000)).toEqual({
+      unit: 'GiB', value: 10000 / 1024,
+    })
+    expect(convertValue(storageUnitTable, 'MiB', 10000000)).toEqual({
+      unit: 'TiB', value: 10000000 / (1024 ** 2),
+    })
+    expect(convertValue(storageUnitTable, 'GiB', 10000)).toEqual({
+      unit: 'TiB', value: 10000 / 1024,
+    })
+  })
+
+  it('returns the same unit and value when unit is not in the table', function () {
+    expect(convertValue(storageUnitTable, 'foo', 1)).toEqual({
+      unit: 'foo', value: 1,
+    })
+  })
+
+  it('scale all values down 1 unit', function () {
+    expect(convertValue(storageUnitTable, 'TiB', [ 0.0123, 0.0456 ])).toEqual({
+      unit: 'GiB',
+      value: [ 0.0123 * 1024, 0.0456 * 1024 ],
+    })
+  })
+
+  it('scale all values up 2 units', function () {
+    expect(convertValue(storageUnitTable, 'MiB', [ (1 * (1024 ** 2)), (2 * (1024 ** 2)) ])).toEqual({
+      unit: 'TiB',
+      value: [ 1, 2 ],
+    })
+  })
+
+  it('no scaling, 1 value in the array is in range', function () {
+    expect(convertValue(storageUnitTable, 'TiB', [ 1.01, 0.02 ])).toEqual({
+      unit: 'TiB',
+      value: [ 1.01, 0.02 ],
+    })
+  })
+
+  it('returns the same unit and values when unit is not in the table', function () {
+    expect(convertValue(storageUnitTable, 'foo', [ 1, 2, 3 ])).toEqual({
+      unit: 'foo', value: [ 1, 2, 3 ],
+    })
+  })
+})


### PR DESCRIPTION
Borrowed the __rounding__ and __unit-conversion__ functions from __ovirt-engine-ui-extensions__ to support dealing with memory/storage values on the display in a consistent way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/673)
<!-- Reviewable:end -->
