### PR TITLE
Developer tooling convenience changes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+#
+# eslint to ignore config, script and build output
+#
+build/*
+config/*
+scripts/*

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babel-preset-react": "6.24.1",
     "babel-runtime": "6.26.0",
     "case-sensitive-paths-webpack-plugin": "1.1.4",
-    "chalk": "1.1.3",
+    "chalk": "2.4.1",
     "connect-history-api-fallback": "1.5.0",
     "copy-webpack-plugin": "3.0.1",
     "css-loader": "0.24.0",
@@ -94,7 +94,6 @@
     "react-router-navigation-prompt": "1.6.3",
     "react-test-renderer": "16.4.0",
     "redux": "4.0.0",
-    "redux-devtools-extension": "2.13.2",
     "redux-saga": "0.16.0"
   },
   "resolutions": {

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -57,11 +57,15 @@ function setupCompiler(port, protocol) {
     var hasErrors = stats.hasErrors();
     var hasWarnings = stats.hasWarnings();
     if (!hasErrors && !hasWarnings) {
-      console.log(chalk.green('Compiled successfully!'));
+      const userInfo = JSON.parse(env['window.userInfo'])
+      console.log(chalk`{green Compiled successfully!}`);
+      console.log();
+      console.log(chalk`oVirt user: {yellow ${userInfo.userName}}, oVirt userId: {yellow ${userInfo.userId}}`);
+      console.log(chalk`oVirt SSO token: {yellow ${userInfo.ssoToken}}`)
       console.log();
       console.log('The app is running at:');
       console.log();
-      console.log('  ' + chalk.cyan(protocol + '://localhost:' + port + '/'));
+      console.log(chalk`  {cyan ${protocol}://localhost:${port}/}`);
       console.log();
       return;
     }
@@ -79,7 +83,7 @@ function setupCompiler(port, protocol) {
       'Warning in ' + formatMessage(message)
     );
     if (hasErrors) {
-      console.log(chalk.red('Failed to compile.'));
+      console.log(chalk`{red Failed to compile.}`);
       console.log();
       if (formattedErrors.some(isLikelyASyntaxError)) {
         // If there are any syntax errors, show just them.
@@ -95,7 +99,7 @@ function setupCompiler(port, protocol) {
       return;
     }
     if (hasWarnings) {
-      console.log(chalk.yellow('Compiled with warnings.'));
+      console.log(chalk`{yellow Compiled with warnings.`);
       console.log();
       formattedWarnings.forEach(message => {
         console.log(message);
@@ -103,8 +107,8 @@ function setupCompiler(port, protocol) {
       });
       // Teach some ESLint tricks.
       console.log('You may use special comments to disable some warnings.');
-      console.log('Use ' + chalk.yellow('// eslint-disable-next-line') + ' to ignore the next line.');
-      console.log('Use ' + chalk.yellow('/* eslint-disable */') + ' to ignore all warnings in a file.');
+      console.log(chalk`Use {yellow // eslint-disable-next-line} to ignore the next line.`);
+      console.log(chalk`Use {yellow /* eslint-disable */} to ignore all warnings in a file.`);
     }
   });
 }
@@ -141,12 +145,10 @@ function onProxyError(proxy) {
   return function(err, req, res){
     var host = req.headers && req.headers.host;
     console.log(
-      chalk.red('Proxy error:') + ' Could not proxy request ' + chalk.cyan(req.url) +
-      ' from ' + chalk.cyan(host) + ' to ' + chalk.cyan(proxy) + '.'
+      chalk`{red Proxy error:} Could not proxy request {cyan ${req.url}} from {cyan ${host}} to {cyan ${proxy}}.`
     );
     console.log(
-      'See https://nodejs.org/api/errors.html#errors_common_system_errors for more information (' +
-      chalk.cyan(err.code) + ').'
+      chalk`See https://nodejs.org/api/errors.html#errors_common_system_errors for more information ({cyan ${err.code}}).`
     );
     console.log();
 
@@ -167,9 +169,9 @@ function addMiddleware(devServer) {
   var proxy = process.env.ENGINE_URL || require(paths.appPackageJson).proxy;
   if (proxy) {
     if (typeof proxy !== 'string') {
-      console.log(chalk.red('When specified, "proxy" in package.json must be a string.'));
-      console.log(chalk.red('Instead, the type of "proxy" was "' + typeof proxy + '".'));
-      console.log(chalk.red('Either remove "proxy" from package.json, or make it a string.'));
+      console.log(chalk`{red When specified, "proxy" in package.json must be a string.}`);
+      console.log(chalk`{red Instead, the type of "proxy" was "${typeof proxy}".}`);
+      console.log(chalk`{red Either remove "proxy" from package.json, or make it a string.}`);
       process.exit(1);
     }
 
@@ -257,7 +259,7 @@ function runDevServer(port, protocol) {
     }
 
     clearConsole();
-    console.log(chalk.cyan('Starting server...'));
+    console.log(chalk`{cyan Starting server...}`);
     console.log();
     openBrowser(port, protocol);
   });
@@ -285,8 +287,8 @@ detect(DEFAULT_PORT).then(port => {
 
   clearConsole();
   var question =
-    chalk.yellow('Something is already running on port ' + DEFAULT_PORT + '.') +
-    '\n\nWould you like to run the app on another port instead?';
+    chalk`{yellow Something is already running on port ${DEFAULT_PORT}.}
+          \n\nWould you like to run the app on another port instead?`;
 
   prompt(question, true).then(shouldChangePort => {
     if (shouldChangePort) {
@@ -313,7 +315,7 @@ function getUserInfo (protocol, port) {
    * engine_URL - is oVirt engine URL.
    *
    * If userId will be null, then feature `Options` and SSH Public Key will
-   * be disabled and hidden. 
+   * be disabled and hidden.
    * @type {String}
    */
   var username = readlineSync.question(`oVirt user (${DEFAULT_USER}): `, {
@@ -345,7 +347,7 @@ function getUserInfo (protocol, port) {
       if (body.access_token) {
         const apiRootUrl = `${engineUrl}/api/`
         request(apiRootUrl,
-                { json: true, strictSSL: false, headers: { Authorization: `Bearer ${body.access_token}` } }, 
+                { json: true, strictSSL: false, headers: { Authorization: `Bearer ${body.access_token}` } },
                 (apiRootError, apiRootResponse, apiRootBody) => {
                   let userId = undefined
 

--- a/src/reducers/utils.js
+++ b/src/reducers/utils.js
@@ -1,6 +1,6 @@
 import { Map } from 'immutable'
 import { logDebug } from '../helpers'
-import { UPDATE_ICONS } from '../constants'
+import { UPDATE_ICONS, REMOVE_ACTIVE_REQUEST, DELAYED_REMOVE_ACTIVE_REQUEST, ADD_ACTIVE_REQUEST } from '../constants'
 
 /**
  * Takes initial state of the reducer and a map of action handlers and returns a redux-compatible reducer.
@@ -44,7 +44,9 @@ export const actionReducer = (initialState, handlers, verbose) => (state = initi
       }
     }
 
-    logDebug('Reducing action:', actionJson)
+    if (![ ADD_ACTIVE_REQUEST, REMOVE_ACTIVE_REQUEST, DELAYED_REMOVE_ACTIVE_REQUEST ].includes(action.type)) {
+      logDebug('Reducing action:', actionJson)
+    }
   }
 
   if (action.type in handlers) {

--- a/src/store.js
+++ b/src/store.js
@@ -7,11 +7,10 @@ import AppConfiguration from './config'
 import reducers from './reducers'
 
 const composeEnhancers =
-  process.env.NODE_ENV !== 'production' &&
-  typeof window === 'object' &&
-  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
-    ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
-    : compose
+  (process.env.NODE_ENV !== 'production' && window && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+    actionsBlacklist: ['ADD_ACTIVE_REQUEST', 'REMOVE_ACTIVE_REQUEST', 'DELAYED_REMOVE_ACTIVE_REQUEST'],
+  })) ||
+  compose
 
 export default function configureStore () {
   const sagaMiddleware = createSagaMiddleware({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1570,7 +1570,15 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@1.1.3, chalk@^1.1.3:
+chalk@2.4.1, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.2, chalk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -1579,14 +1587,6 @@ chalk@1.1.3, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
-
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.2, chalk@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
 
 chalk@~0.4.0:
   version "0.4.0"
@@ -6080,10 +6080,6 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
-
-redux-devtools-extension@2.13.2:
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.2.tgz#e0f9a8e8dfca7c17be92c7124958a3b94eb2911d"
 
 redux-saga@0.16.0:
   version "0.16.0"


### PR DESCRIPTION
 - Use **redux-devtools** hook (without the npm package) to hook the devtools and blacklist the ***_ACTIVE_REQUEST** actions from the redux browser extension. Now devs can see the actions they care about.

 - Reduce action logging on the browser console by ignoring ***_ACTIVE_REQUEST** actions.

 - Remove `redux-devtools-extension` since it isn't needed.

 - Upgrade `chalk` so string tagged template literals can be used (in the dev server and build scripts).

 - Dev server start script now prints out the user / user id and sso token used to connect to the REST api.

 - `.eslintignore` so vscode's eslint plugin won't lint the build, config and script files.