### PR TITLE
reattach VmDialog's sagas to the root saga so VM edits get saved

### DIFF
--- a/src/sagas.js
+++ b/src/sagas.js
@@ -4,6 +4,7 @@ import Selectors from './selectors'
 import AppConfiguration from './config'
 import { flatMap } from './utils'
 
+import vmEditSagas from './components/VmDialog/sagas'
 import vmDisksSagas from './components/VmDisks/sagas'
 import newDiskDialogSagas from './components/NewDiskDialog/sagas'
 import vmSnapshotsSagas from './components/VmSnapshots/sagas'
@@ -834,6 +835,7 @@ export function* rootSaga () {
     takeEvery(DELAYED_REMOVE_ACTIVE_REQUEST, delayedRemoveActiveRequest),
 
     // Sagas from Components
+    ...vmEditSagas,
     ...vmDisksSagas,
     ...newDiskDialogSagas,
     ...vmSnapshotsSagas,


### PR DESCRIPTION
In PR #651, I missed refactoring `VmDialog`'s sagas the same way as `VmDisks`, `NewDiskDialog` and `VmSnapshots`.  As a result, the VM Edit page will not currently save any changes.  This PR re-links the `VmDialog` sagas back to the root saga so they can be executed and edits committed.

Fixes #684

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/ovirt-web-ui/683)
<!-- Reviewable:end -->
