### PR TITLE
fix the render of the console button list on the VmDetail component

### DIFF
--- a/src/components/VmActions/ConsoleButton.js
+++ b/src/components/VmActions/ConsoleButton.js
@@ -55,7 +55,6 @@ class ConsoleButton extends React.Component {
       actionDisabled = false,
       shortTitle,
       tooltip = '',
-      button,
       className,
     } = this.props
 
@@ -92,7 +91,7 @@ class ConsoleButton extends React.Component {
 
     if (actionDisabled) {
       return (
-        <button className={`${button} ${style['disabled-button']}`} disabled='disabled' id={`${idPrefix}-disabled`}>
+        <button className={`${className} ${style['disabled-button']}`} disabled='disabled' id={`${idPrefix}-disabled`}>
           <span data-toggle='tooltip' data-placement='left' title={tooltip}>
             {shortTitle}
           </span>
@@ -101,8 +100,8 @@ class ConsoleButton extends React.Component {
     }
 
     return (
-      <span className={style['full-button']}>
-        <a href='#' className={`${button} ${style['link']}`} id={shortTitle} onClick={this.consoleConfirmationAboutToOpen}>
+      <span className={`${style['full-button']}`}>
+        <a href='#' className={`${style['link']} ${className}`} id={shortTitle} onClick={this.consoleConfirmationAboutToOpen}>
           <span data-toggle='tooltip' data-placement='left' title={tooltip}>
             {shortTitle}
           </span>
@@ -120,7 +119,6 @@ ConsoleButton.propTypes = {
   actionDisabled: PropTypes.bool,
   shortTitle: PropTypes.string.isRequired,
   tooltip: PropTypes.string,
-  button: PropTypes.string.isRequired,
   className: PropTypes.string.isRequired,
 
   consoleId: PropTypes.string, // eslint-disable-line react/no-unused-prop-types

--- a/src/components/VmActions/index.js
+++ b/src/components/VmActions/index.js
@@ -152,8 +152,9 @@ class VmActions extends React.Component {
           actionDisabled={isPool || !canConsole(status) || vm.getIn(['actionInProgress', 'getConsole'])}
           shortTitle={msg.console()}
           tooltip={consoleProtocol}
-          button='btn btn-default'
-          className='pficon pficon-screen'
+
+          className={isOnCard ? 'pficon pficon-screen' : 'btn btn-default'}
+
           vm={vm}
         />
 

--- a/src/components/VmDetail/VmConsoles.js
+++ b/src/components/VmDetail/VmConsoles.js
@@ -23,15 +23,15 @@ const VmConsoles = ({ vm }) => {
       <dd className={style['console-box']}>
         {
           vmConsoles.map(c => (
-            <ConsoleButton
-              vm={vm}
-              consoleId={c.get('id')}
-              key={c.get('id')}
-              button=''
-              className='pficon pficon-screen'
-              tooltip={`Open ${c.get('protocol').toUpperCase()} console`} // TODO: l10n
-              shortTitle={c.get('protocol').toUpperCase()}
-            />
+            <span className={style['left-delimiter']} key={c.get('id')}>
+              <ConsoleButton
+                vm={vm}
+                consoleId={c.get('id')}
+                className=''
+                tooltip={`Open ${c.get('protocol').toUpperCase()} console`} // TODO: l10n
+                shortTitle={c.get('protocol').toUpperCase()}
+              />
+            </span>
           ))
         }
 

--- a/src/components/VmDetail/style.css
+++ b/src/components/VmDetail/style.css
@@ -24,6 +24,7 @@
 }
 
 .left-delimiter {
+    margin-left: 0;
     padding: 0 13px 0 0;
 }
 


### PR DESCRIPTION
On the VM detail page, the button are now rendered with separators
both when the VM `canConsole()` and it can't `canConsole()`.
