### PR TITLE
 Adapt sub-resource/deep fetch handling for VM resources

### DIFF
--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -123,21 +123,9 @@ const VM = {
       },
       bootMenuEnabled: vm.bios && vm.bios.boot_menu && convertBool(vm.bios.boot_menu.enabled),
       cloudInit: CloudInit.toInternal({ vm }),
-
-      // TODO: Should snapshots be part of 'subResources'?
-      snapshots: vm.snapshots && vm.snapshots.snapshot ? vm.snapshots.snapshot.map((snapshot) => Snapshot.toInternal({ snapshot })) : [],
     }
 
     if (includeSubResources) {
-      if (vm.disk_attachments && vm.disk_attachments.disk_attachment) {
-        for (let i in vm.disk_attachments.disk_attachment) {
-          parsedVm.disks.push(DiskAttachment.toInternal({
-            attachment: vm.disk_attachments.disk_attachment[i],
-            disk: vm.disk_attachments.disk_attachment[i].disk,
-          }))
-        }
-      }
-
       if (vm.cdroms && vm.cdroms.cdrom) {
         parsedVm.cdrom = CdRom.toInternal({ cdrom: vm.cdroms.cdrom[0] })
       }
@@ -146,12 +134,26 @@ const VM = {
         parsedVm.consoles = VmConsoles.toInternal({ consoles: vm.graphics_consoles })
       }
 
+      if (vm.disk_attachments && vm.disk_attachments.disk_attachment) {
+        parsedVm.disks = vm.disk_attachments.disk_attachment.map(
+          attachment => DiskAttachment.toInternal({ attachment, disk: attachment.disk })
+        )
+      }
+
+      if (vm.nics && vm.nics.nic) {
+        parsedVm.nics = vm.nics.nic.map(
+          nic => Nic.toInternal({ nic })
+        )
+      }
+
       if (vm.sessions && vm.sessions.session) {
         parsedVm.sessions = VmSessions.toInternal({ sessions: vm.sessions })
       }
 
-      if (vm.nics && vm.nics.nic) {
-        parsedVm.nics = vm.nics.nic.map((nic: Object): Object => Nic.toInternal({ nic }))
+      if (vm.snapshots && vm.snapshots.snapshot) {
+        parsedVm.snapshots = vm.snapshots.snapshot.map(
+          snapshot => Snapshot.toInternal({ snapshot })
+        )
       }
     }
 
@@ -559,7 +561,7 @@ const VmConsoles = {
         id: c.id,
         protocol: c.protocol,
       }
-    }).sort((a: Object, b: Object): number => b.protocol.length - a.protocol.length) // Hack: 'VNC' is shorter then 'SPICE'
+    }).sort((a: Object, b: Object): number => b.protocol.length - a.protocol.length) // Hack: VNC is shorter then SPICE
   },
 
   toApi: undefined,

--- a/src/reducers/vms.js
+++ b/src/reducers/vms.js
@@ -37,10 +37,13 @@ const initialState = Immutable.fromJS({
   notAllPagesLoaded: true,
 })
 
+const EMPTY_MAP = Immutable.fromJS({})
+const EMPTY_ARRAY = Immutable.fromJS([])
+
 const vms = actionReducer(initialState, {
   [UPDATE_VMS] (state, { payload: { vms, copySubResources, page } }) {
-    const emptyMap = Map()
     const updates = {}
+
     vms.forEach(vm => {
       if (!state.getIn(['vms', vm.id])) {
         state = state.set('notAllPagesLoaded', true)
@@ -48,15 +51,16 @@ const vms = actionReducer(initialState, {
       updates[vm.id] = vm
 
       if (copySubResources) {
-        updates[vm.id].disks = state.getIn(['vms', vm.id, 'disks'], emptyMap).toJS()
-        updates[vm.id].consoles = state.getIn(['vms', vm.id, 'consoles'], emptyMap).toJS()
         updates[vm.id].cdrom = state.getIn(['vms', vm.id, 'cdrom'], Immutable.fromJS({ file: { id: '' } })).toJS()
-        updates[vm.id].nics = state.getIn(['vms', vm.id, 'nics'], Immutable.fromJS([])).toJS()
-        updates[vm.id].snapshots = state.getIn(['vms', vm.id, 'snapshots'], Immutable.fromJS([])).toJS()
+        updates[vm.id].consoles = state.getIn(['vms', vm.id, 'consoles'], EMPTY_ARRAY).toJS()
+        updates[vm.id].disks = state.getIn(['vms', vm.id, 'disks'], EMPTY_ARRAY).toJS()
+        updates[vm.id].nics = state.getIn(['vms', vm.id, 'nics'], EMPTY_ARRAY).toJS()
+        updates[vm.id].sessions = state.getIn(['vms', vm.id, 'sessions'], EMPTY_ARRAY).toJS()
+        updates[vm.id].snapshots = state.getIn(['vms', vm.id, 'snapshots'], EMPTY_ARRAY).toJS()
       }
     })
-    const imUpdates = Immutable.fromJS(updates)
-    let st = state.mergeIn(['vms'], imUpdates)
+
+    let st = state.mergeIn(['vms'], Immutable.fromJS(updates))
     if (page) {
       st = st.set('page', page)
     }
@@ -203,7 +207,7 @@ const vms = actionReducer(initialState, {
     return state.set('notAllPagesLoaded', value)
   },
   [LOGOUT] (state) { // see the config() reducer
-    return state.set('vms', Immutable.fromJS({}))
+    return state.set('vms', EMPTY_MAP)
   },
 })
 


### PR DESCRIPTION
This PR builds on PR #679. ~~Until #679 is merged, its commit is included in this PR.~~

VM sub-resources are the part of the VM in the REST API that require either a follow-up fetch request or a `?follow=linkItem1,linkItem2,linkItem3` deep fetch.

Updated **sagas.js**:
 - the "deep fetch" additional list is shared across all uses
 - `fetchSingleVm` will have the `updateVms` action copy the VM sub resources as appropriate (this allows deep fetch details to be copied forward when the VM is updated by a shallow fetch from the background data refresh task)

Updated the base VM transform (**ovirtapi/transform.js**) to handle all sub-resources consistently. This allows the VM reducer to properly carry forward the sub-resources after a shallow fetch.

Updated **reducers/vms.js** to handle the deep fetch data (the resources retained when _copySubResources_ is _true_) consistently.
