### PR TITLE
Fix the checks for hooking redux devtools extension in dev mode

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -7,9 +7,12 @@ import AppConfiguration from './config'
 import reducers from './reducers'
 
 const composeEnhancers =
-  (process.env.NODE_ENV !== 'production' && window && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
-    actionsBlacklist: ['ADD_ACTIVE_REQUEST', 'REMOVE_ACTIVE_REQUEST', 'DELAYED_REMOVE_ACTIVE_REQUEST'],
-  })) ||
+  (process.env.NODE_ENV !== 'production' &&
+   window &&
+   typeof window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ === 'function' &&
+   window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+     actionsBlacklist: ['ADD_ACTIVE_REQUEST', 'REMOVE_ACTIVE_REQUEST', 'DELAYED_REMOVE_ACTIVE_REQUEST'],
+   })) ||
   compose
 
 export default function configureStore () {


### PR DESCRIPTION
A missing check for the presence of the redux devtools extension compose
hook function was preventing the app from loading when the extension
was not installed on the browser and the app is running for the webpack
dev server. The check has been added and the app will run from the dev
server without the extension installed and active on the browser.

Fixes #688 