### PR TITLE
ux-redesign: Base VM Details page with stub cards

### DIFF
--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
+import { RouterPropTypeShapes } from '../../propTypeShapes'
 import VmActions from '../VmActions'
 
 const VmDetailToolbar = ({ match, vms }) => {
@@ -13,11 +14,7 @@ const VmDetailToolbar = ({ match, vms }) => {
 
 VmDetailToolbar.propTypes = {
   vms: PropTypes.object.isRequired,
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      id: PropTypes.string.isRequired,
-    }).isRequired,
-  }).isRequired,
+  match: RouterPropTypeShapes.match.isRequired,
 }
 
 const VmDetailToolbarConnected = connect(
@@ -35,11 +32,7 @@ const PoolDetailToolbar = ({ match, vms }) => {
 
 PoolDetailToolbar.propTypes = {
   vms: PropTypes.object.isRequired,
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      id: PropTypes.string.isRequired,
-    }).isRequired,
-  }).isRequired,
+  match: RouterPropTypeShapes.match.isRequired,
 }
 
 const PoolDetailToolbarConnected = connect(

--- a/src/components/VmDetails/BaseCard.js
+++ b/src/components/VmDetails/BaseCard.js
@@ -27,33 +27,10 @@ import CardEditButton from './CardEditButton'
  *  - When in edit state, user clicks the __Cancel__ button -> onCancel() is called
  *  - When in edit state, user clicks the __Save__ button -> onSave() is called
  *
- * If any of the event handlers return null, the card will not transition its edit state.
+ * If any of the event handlers return false, the card will not transition its edit state.
  * This allows data validation or async operation completion.
  */
 class BaseCard extends React.Component {
-  static propTypes = {
-    title: PropTypes.string,
-    icon: PropTypes.shape({
-      type: PropTypes.string.isRequired,
-      name: PropTypes.string.isRequired,
-    }),
-    itemCount: PropTypes.number,
-
-    editMode: PropTypes.bool,
-    editable: PropTypes.bool,
-    editTooltip: PropTypes.string,
-
-    onStartEdit: PropTypes.func,
-    onCancel: PropTypes.func,
-    onSave: PropTypes.func,
-    children: PropTypes.func,
-  }
-  static defaultProps = {
-    onStartEdit: noop,
-    onCancel: noop,
-    onSave: noop,
-  }
-
   constructor (props) {
     super(props)
     this.state = {
@@ -99,7 +76,7 @@ class BaseCard extends React.Component {
       <Card className={style['base-card']} {...excludeKeys(this.props, this.propTypeKeys)}>
         {hasHeading && (
           <CardHeading className={style['base-card-heading']}>
-            {editable && <CardEditButton tooltip={editTooltip} enabled={editing} onClick={this.clickEdit} />}
+            {editable && <CardEditButton tooltip={editTooltip} editEnabled={editing} onClick={this.clickEdit} />}
             <CardTitle>
               {hasIcon && <Icon type={icon.type} name={icon.name} className={style['base-card-title-icon']} />}
               {title}
@@ -110,7 +87,7 @@ class BaseCard extends React.Component {
 
         <CardBody className={style['base-card-body']}>
           {(!hasHeading && editable) && (
-            <CardEditButton tooltip={editTooltip} enabled={editing} onClick={this.clickEdit} />
+            <CardEditButton tooltip={editTooltip} editEnabled={editing} onClick={this.clickEdit} />
           )}
 
           {children({ isEditing: editing })}
@@ -125,6 +102,28 @@ class BaseCard extends React.Component {
       </Card>
     )
   }
+}
+BaseCard.propTypes = {
+  title: PropTypes.string,
+  icon: PropTypes.shape({
+    type: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+  }),
+  itemCount: PropTypes.number,
+
+  editMode: PropTypes.bool,
+  editable: PropTypes.bool,
+  editTooltip: PropTypes.string,
+
+  onStartEdit: PropTypes.func,
+  onCancel: PropTypes.func,
+  onSave: PropTypes.func,
+  children: PropTypes.func,
+}
+BaseCard.defaultProps = {
+  onStartEdit: noop,
+  onCancel: noop,
+  onSave: noop,
 }
 
 export default BaseCard

--- a/src/components/VmDetails/BaseCard.js
+++ b/src/components/VmDetails/BaseCard.js
@@ -1,0 +1,130 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {
+  Badge,
+  Button,
+  Card,
+  CardHeading,
+  CardTitle,
+  CardBody,
+  CardFooter,
+  Icon,
+  noop,
+  excludeKeys,
+} from 'patternfly-react'
+
+import style from './style.css'
+import CardEditButton from './CardEditButton'
+
+/**
+ * Base VM details card.  Support common layouts and view vs edit modes.
+ *
+ * Specifying __editMode__ allows the containing component to control the card's
+ * edit state.  Leave __editMode__ undefined to allow the card to control itself.
+ *
+ * When the user interacts with the card, the card will fire event handler:
+ *  - When in non-edit state, user clicks the __Edit__ icon -> onStartEdit() is called
+ *  - When in edit state, user clicks the __Cancel__ button -> onCancel() is called
+ *  - When in edit state, user clicks the __Save__ button -> onSave() is called
+ *
+ * If any of the event handlers return null, the card will not transition its edit state.
+ * This allows data validation or async operation completion.
+ */
+class BaseCard extends React.Component {
+  static propTypes = {
+    title: PropTypes.string,
+    icon: PropTypes.shape({
+      type: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    }),
+    itemCount: PropTypes.number,
+
+    editMode: PropTypes.bool,
+    editable: PropTypes.bool,
+    editTooltip: PropTypes.string,
+
+    onStartEdit: PropTypes.func,
+    onCancel: PropTypes.func,
+    onSave: PropTypes.func,
+    children: PropTypes.func,
+  }
+  static defaultProps = {
+    onStartEdit: noop,
+    onCancel: noop,
+    onSave: noop,
+  }
+
+  constructor (props) {
+    super(props)
+    this.state = {
+      edit: props.editMode,
+    }
+    this.propTypeKeys = Object.keys(BaseCard.propTypes)
+  }
+
+  clickEdit = () => {
+    if (this.props.onStartEdit() !== false) {
+      this.setState({ edit: true })
+    }
+  }
+
+  clickCancel = () => {
+    if (this.props.onCancel() !== false) {
+      this.setState({ edit: false })
+    }
+  }
+
+  clickSave = () => {
+    if (this.props.onSave() !== false) {
+      this.setState({ edit: false })
+    }
+  }
+
+  render () {
+    const {
+      title = undefined,
+      icon = undefined,
+      itemCount = undefined,
+      editMode = undefined,
+      editable = true,
+      editTooltip,
+      children = noop,
+    } = this.props
+    const editing = editMode === undefined ? this.state.edit : editMode
+    const hasHeading = !!title
+    const hasBadge = itemCount !== undefined
+    const hasIcon = icon && icon.type && icon.name
+
+    return (
+      <Card className={style['base-card']} {...excludeKeys(this.props, this.propTypeKeys)}>
+        {hasHeading && (
+          <CardHeading className={style['base-card-heading']}>
+            {editable && <CardEditButton tooltip={editTooltip} enabled={editing} onClick={this.clickEdit} />}
+            <CardTitle>
+              {hasIcon && <Icon type={icon.type} name={icon.name} className={style['base-card-title-icon']} />}
+              {title}
+              {hasBadge && <Badge className={style['base-card-item-count-badge']}>{itemCount}</Badge>}
+            </CardTitle>
+          </CardHeading>
+        )}
+
+        <CardBody className={style['base-card-body']}>
+          {(!hasHeading && editable) && (
+            <CardEditButton tooltip={editTooltip} enabled={editing} onClick={this.clickEdit} />
+          )}
+
+          {children({ isEditing: editing })}
+        </CardBody>
+
+        {editing && (
+          <CardFooter className={style['base-card-footer']}>
+            <Button bsStyle='primary' onClick={this.clickSave}><Icon type='fa' name='check' /></Button>
+            <Button onClick={this.clickCancel}><Icon type='pf' name='close' /></Button>
+          </CardFooter>
+        )}
+      </Card>
+    )
+  }
+}
+
+export default BaseCard

--- a/src/components/VmDetails/CardEditButton.js
+++ b/src/components/VmDetails/CardEditButton.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {
+  Icon,
+} from 'patternfly-react'
+
+import style from './style.css'
+
+/**
+ * Render the edit icon/button to enable/disable the editing of the content of a card.
+ */
+class CardEditButton extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      enabled: props.enabled,
+    }
+  }
+
+  static getDerivedStateFromProps (props, state) {
+    if (state.enabled !== props.enabled) {
+      return { enabled: props.enabled }
+    }
+
+    return null
+  }
+
+  render () {
+    const { tooltip, onClick } = this.props
+    const { enabled } = this.state
+
+    const classes = `${style['card-edit-button']} ${style[enabled ? 'card-edit-button-enabled' : 'card-edit-button-disabled']}`
+    const myClick = enabled
+      ? () => {}
+      : () => {
+        onClick({ enabled: !enabled })
+        this.setState({ enabled: !enabled })
+      }
+
+    return (
+      <a title={tooltip} onClick={myClick} className={classes}>
+        <Icon type='pf' name='edit' />
+      </a>
+    )
+  }
+}
+CardEditButton.propTypes = {
+  tooltip: PropTypes.string,
+  enabled: PropTypes.bool,
+  onClick: PropTypes.func,
+}
+CardEditButton.defaultProps = {
+  tooltip: '',
+  enabled: false,
+  onClick: () => {},
+}
+
+export default CardEditButton

--- a/src/components/VmDetails/CardEditButton.js
+++ b/src/components/VmDetails/CardEditButton.js
@@ -2,43 +2,49 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {
   Icon,
+  noop,
 } from 'patternfly-react'
 
 import style from './style.css'
 
 /**
- * Render the edit icon/button to enable/disable the editing of the content of a card.
+ * Render the edit icon/button to enable the editing of the content of a card.
+ *
+ * Once enabled, no user interaction can disable it. The containing component will
+ * need other ways to disable/cancel an edit and update this button to be !enabled.
  */
 class CardEditButton extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
-      enabled: props.enabled,
+      editEnabled: props.editEnabled,
     }
   }
 
   static getDerivedStateFromProps (props, state) {
-    if (state.enabled !== props.enabled) {
-      return { enabled: props.enabled }
+    if (state.editEnabled !== props.editEnabled) {
+      return { editEnabled: props.editEnabled }
     }
 
     return null
   }
 
-  render () {
-    const { tooltip, onClick } = this.props
-    const { enabled } = this.state
+  enableEditHandler = () => {
+    if (!this.state.editEnabled) {
+      this.props.onClick({ editEnabled: true })
+      this.setState({ editEnabled: true })
+    }
+  }
 
-    const classes = `${style['card-edit-button']} ${style[enabled ? 'card-edit-button-enabled' : 'card-edit-button-disabled']}`
-    const myClick = enabled
-      ? () => {}
-      : () => {
-        onClick({ enabled: !enabled })
-        this.setState({ enabled: !enabled })
-      }
+  render () {
+    const { tooltip } = this.props
+    const { editEnabled } = this.state
+
+    const classes = `${style['card-edit-button']} ${style[editEnabled ? 'card-edit-button-enabled' : 'card-edit-button-disabled']}`
+    const myClick = editEnabled ? noop : this.enableEditHandler
 
     return (
-      <a title={tooltip} onClick={myClick} className={classes}>
+      <a title={tooltip} onClick={(e) => { e.preventDefault(); myClick() }} className={classes}>
         <Icon type='pf' name='edit' />
       </a>
     )
@@ -46,13 +52,13 @@ class CardEditButton extends React.Component {
 }
 CardEditButton.propTypes = {
   tooltip: PropTypes.string,
-  enabled: PropTypes.bool,
+  editEnabled: PropTypes.bool,
   onClick: PropTypes.func,
 }
 CardEditButton.defaultProps = {
   tooltip: '',
-  enabled: false,
-  onClick: () => {},
+  editEnabled: false,
+  onClick: noop,
 }
 
 export default CardEditButton

--- a/src/components/VmDetails/GridComponents.js
+++ b/src/components/VmDetails/GridComponents.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import styles from './style.css'
+
+/*
+ * Adapt flex-box based grid for the layout. It is much easier to work with
+ * than bootstrap3/patternfly grids.
+ */
+const Grid = ({ className = '', children, ...props }) => {
+  const cn = `${styles['grid-container']} ${className}`
+  return <div className={cn} {...props}>{children}</div>
+}
+Grid.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+}
+
+const Row = ({ className = '', children, ...props }) => {
+  const cn = `${styles['grid-row']} ${className}`
+  return <div className={cn} {...props}>{children}</div>
+}
+Row.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+}
+
+const Col = ({ className = '', cols = -1, style, children, content = 'expand', ...props }) => {
+  const cn = `${styles['grid-column']} ${className}`
+  const widthPercent = cols * 100 / 12
+  const col = cols <= 0 ? {} : {
+    flex: `0 0 ${widthPercent}%`,
+    maxWidth: `${widthPercent}%`,
+  }
+  return (
+    <div
+      column-content={content}
+      className={cn}
+      style={{ ...col, ...style }}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+Col.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  cols: PropTypes.number,
+  style: PropTypes.object,
+  content: PropTypes.oneOf(['expand', 'auto']),
+}
+
+export {
+  Grid,
+  Row,
+  Col,
+}

--- a/src/components/VmDetails/cards/DetailsCard.js
+++ b/src/components/VmDetails/cards/DetailsCard.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import BaseCard from '../BaseCard'
+import style from '../style.css'
+
+/**
+ * Specific information and details of the VM (status, uptime, IP, FQDN
+ * host, cluster, data center, template, CD, ??could-init??
+ */
+const DetailsCard = ({ vm, onEditChange }) => {
+  return (
+    <BaseCard
+      title='Details'
+      editTooltip={`Edit details for ${vm.get('id')}`}
+      onStartEdit={() => { onEditChange(true) }}
+      onCancel={() => { onEditChange(false) }}
+      onSave={() => { onEditChange(false) }}
+    >
+      {({ isEditing }) => {
+        return (
+          <div>
+            <p className={style['demo-text']}>Details details of {vm.get('name')}</p>
+
+            {isEditing && (
+              <p className={style['demo-text']}>EDITING</p>
+            )}
+          </div>
+        )
+      }}
+    </BaseCard>
+  )
+}
+DetailsCard.propTypes = {
+  vm: PropTypes.object.isRequired,
+  onEditChange: PropTypes.func.isRequired,
+}
+
+export default DetailsCard

--- a/src/components/VmDetails/cards/DisksCard.js
+++ b/src/components/VmDetails/cards/DisksCard.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import BaseCard from '../BaseCard'
+import style from '../style.css'
+
+/**
+ * List of disks attached a VM
+ */
+const DisksCard = ({ vm, onEditChange }) => {
+  return (
+    <BaseCard
+      icon={{ type: 'pf', name: 'storage-domain' }}
+      title='Disks'
+      editTooltip={`Edit Disks for ${vm.get('id')}`}
+      itemCount={vm.get('disks').size}
+      onStartEdit={() => { onEditChange(true) }}
+      onCancel={() => { onEditChange(false) }}
+      onSave={() => { onEditChange(false) }}
+    >
+      {({ isEditing }) => {
+        return (
+          <div>
+            <p className={style['demo-text']}>
+              Disks for {vm.get('name')}
+            </p>
+
+            {isEditing && (
+              <p className={style['demo-text']}>EDITING</p>
+            )}
+          </div>
+        )
+      }}
+    </BaseCard>
+  )
+}
+DisksCard.propTypes = {
+  vm: PropTypes.object.isRequired,
+  onEditChange: PropTypes.func.isRequired,
+}
+
+export default DisksCard

--- a/src/components/VmDetails/cards/NicsCard.js
+++ b/src/components/VmDetails/cards/NicsCard.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import BaseCard from '../BaseCard'
+import style from '../style.css'
+
+/**
+ * List of NICs connected to a VM
+ */
+const NicsCard = ({ vm, onEditChange }) => {
+  return (
+    <BaseCard
+      icon={{ type: 'pf', name: 'network' }}
+      title='Network Interfaces'
+      editTooltip={`Edit NICs for ${vm.get('id')}`}
+      itemCount={vm.get('nics').size}
+      onStartEdit={() => { onEditChange(true) }}
+      onCancel={() => { onEditChange(false) }}
+      onSave={() => { onEditChange(false) }}
+    >
+      {({ isEditing }) => {
+        return (
+          <div>
+            <p className={style['demo-text']}>
+              NICs for {vm.get('name')}
+            </p>
+
+            {isEditing && (
+              <p className={style['demo-text']}>EDITING</p>
+            )}
+          </div>
+        )
+      }}
+    </BaseCard>
+  )
+}
+NicsCard.propTypes = {
+  vm: PropTypes.object.isRequired,
+  onEditChange: PropTypes.func.isRequired,
+}
+
+export default NicsCard

--- a/src/components/VmDetails/cards/OverviewCard.js
+++ b/src/components/VmDetails/cards/OverviewCard.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { Checkbox } from 'patternfly-react'
+import BaseCard from '../BaseCard'
+import style from '../style.css'
+
+/**
+ * Overview of the VM (icon, OS type, name, state, description)
+ */
+const OverviewCard = ({ vm, onEditChange }) => {
+  const handleCheckbox = (e) => {
+    onEditChange(true, e.target.checked)
+  }
+
+  return (
+    <BaseCard
+      editTooltip={`Edit overview for ${vm.get('id')}`}
+      onStartEdit={() => { onEditChange(true) }}
+      onCancel={() => { onEditChange(false) }}
+      onSave={() => { onEditChange(false) }}
+    >
+      {({ isEditing }) => {
+        return (
+          <div>
+            <p className={style['demo-text']} style={{ marginRight: '25px' }}>
+              Overview content for {vm.get('name')} <br />
+            </p>
+
+            {isEditing && (
+              <div>
+                <p className={style['demo-text']}>EDITING 1</p>
+                <Checkbox onChange={handleCheckbox}>Check to mark the edit dirty.</Checkbox>
+              </div>
+            )}
+          </div>
+        )
+      }}
+    </BaseCard>
+  )
+}
+OverviewCard.propTypes = {
+  vm: PropTypes.object.isRequired,
+  onEditChange: PropTypes.func.isRequired,
+}
+
+export default OverviewCard

--- a/src/components/VmDetails/cards/SnapshotsCard.js
+++ b/src/components/VmDetails/cards/SnapshotsCard.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import BaseCard from '../BaseCard'
+import style from '../style.css'
+
+/**
+ * List of Snapshots taken of a VM
+ */
+const SnapshotsCard = ({ vm, onEditChange }) => {
+  const snapshots = vm.get('snapshots', []) // TODO: sort as necessary
+
+  return (
+    <BaseCard
+      icon={{ type: 'pf', name: 'virtual-machine' }}
+      title='Snapshots'
+      editTooltip={`Edit snaphots for ${vm.get('id')}`}
+      itemCount={snapshots.size}
+      onStartEdit={() => { onEditChange(true) }}
+      onCancel={() => { onEditChange(false) }}
+      onSave={() => { onEditChange(false) }}
+    >
+      {({ isEditing }) => {
+        if (isEditing) {
+          return (
+            <div>
+              <p className={style['demo-text']}>Snapshots for {vm.get('name')}</p>
+              <p className={style['demo-text']}>EDITING</p>
+            </div>
+          )
+        } else {
+          return (
+            <div>
+              <p className={style['demo-text']}>Snapshots for {vm.get('name')}</p>
+            </div>
+          )
+        }
+      }}
+    </BaseCard>
+  )
+}
+SnapshotsCard.propTypes = {
+  vm: PropTypes.object.isRequired,
+  onEditChange: PropTypes.func.isRequired,
+}
+
+export default SnapshotsCard

--- a/src/components/VmDetails/cards/UtilizationCard.js
+++ b/src/components/VmDetails/cards/UtilizationCard.js
@@ -1,0 +1,182 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import BaseCard from '../BaseCard'
+// import style from '../style.css'
+
+import {
+  CardTitle,
+  CardBody,
+  CardGrid,
+  Row,
+  Col,
+  UtilizationCard as PFUtilizationCard,
+  UtilizationCardDetails,
+  UtilizationCardDetailsCount,
+  UtilizationCardDetailsDesc,
+  UtilizationCardDetailsLine1,
+  UtilizationCardDetailsLine2,
+  DonutChart,
+  SparklineChart,
+} from 'patternfly-react'
+
+/**
+ * VM dashboard style Utilization charts (CPU, Memory, Network)
+ */
+const UtilizationCard = ({ vm, onEditChange }) => (
+  <BaseCard title='Utilization' editable={false}>{({ isEditing }) => (
+    <CardGrid style={{ maxWidth: '100%' }}>
+      <Row>
+        <Col md={3}>
+          <PFUtilizationCard>
+            <CardTitle>CPU</CardTitle>
+            <CardBody>
+              <UtilizationCardDetails>
+                <UtilizationCardDetailsCount>58%</UtilizationCardDetailsCount>
+                <UtilizationCardDetailsDesc>
+                  <UtilizationCardDetailsLine1>Available</UtilizationCardDetailsLine1>
+                  <UtilizationCardDetailsLine2>of 100%</UtilizationCardDetailsLine2>
+                </UtilizationCardDetailsDesc>
+              </UtilizationCardDetails>
+              <DonutChart
+                id='donut-chart-cpu'
+                data={{
+                  columns: [['Used', 42], ['Available', 58]],
+                  groups: [['used', 'available']],
+                  colors: { Used: '#cc0000', Avaliable: '#3f9c35' },
+                }}
+                title={{ type: 'max' }}
+              />
+              {/* tooltip={{contents: pfGetUtilizationDonutTooltipContents()}} */}
+              {/* TODO: Tooltip on the donut chart! */}
+
+              <SparklineChart
+                id='line-chart-cpu'
+                data={{
+                  columns: [
+                    ['%', 11, 12, 13, 55, 92, 76, 76, 42, 42, 42, 36, 1, 1, 100],
+                  ],
+                  type: 'area',
+                }}
+              />
+            </CardBody>
+          </PFUtilizationCard>
+        </Col>
+
+        <Col md={3}>
+          <PFUtilizationCard>
+            <CardTitle>Memory</CardTitle>
+            <CardBody>
+              <UtilizationCardDetails>
+                <UtilizationCardDetailsCount>4.6</UtilizationCardDetailsCount>
+                <UtilizationCardDetailsDesc>
+                  <UtilizationCardDetailsLine1>Available</UtilizationCardDetailsLine1>
+                  <UtilizationCardDetailsLine2>of 15.4 GiB</UtilizationCardDetailsLine2>
+                </UtilizationCardDetailsDesc>
+              </UtilizationCardDetails>
+              <DonutChart
+                id='donut-chart-cpu'
+                data={{
+                  columns: [['Used', (4.6 / 15.4)], ['Available', 15.4]],
+                  groups: [['used', 'available']],
+                  colors: { Used: '#cc0000', Avaliable: '#3f9c35' },
+                }}
+                title={{ type: 'max' }}
+              />
+              {/* tooltip={{contents: pfGetUtilizationDonutTooltipContents()}} */}
+              {/* TODO: Tooltip on the donut chart! */}
+
+              <SparklineChart
+                id='line-chart-cpu'
+                data={{
+                  columns: [
+                    ['%', 11, 12, 13, 55, 92, 76, 76, 42, 42, 42, 36, 1, 1, 100],
+                  ],
+                  type: 'area',
+                }}
+              />
+            </CardBody>
+          </PFUtilizationCard>
+        </Col>
+
+        <Col md={3}>
+          <PFUtilizationCard>
+            <CardTitle>Networking</CardTitle>
+            <CardBody>
+              <UtilizationCardDetails>
+                <UtilizationCardDetailsCount>15</UtilizationCardDetailsCount>
+                <UtilizationCardDetailsDesc>
+                  <UtilizationCardDetailsLine1>Available</UtilizationCardDetailsLine1>
+                  <UtilizationCardDetailsLine2>of 100Mbps</UtilizationCardDetailsLine2>
+                </UtilizationCardDetailsDesc>
+              </UtilizationCardDetails>
+              <DonutChart
+                id='donut-chart-cpu'
+                data={{
+                  columns: [['Used', 15], ['Available', 85]],
+                  groups: [['used', 'available']],
+                  colors: { Used: '#cc0000', Avaliable: '#3f9c35' },
+                }}
+                title={{ type: 'max' }}
+              />
+              {/* tooltip={{contents: pfGetUtilizationDonutTooltipContents()}} */}
+              {/* TODO: Tooltip on the donut chart! */}
+
+              <SparklineChart
+                id='line-chart-cpu'
+                data={{
+                  columns: [
+                    ['%', 11, 12, 13, 55, 92, 76, 76, 42, 42, 42, 36, 1, 1, 100],
+                  ],
+                  type: 'area',
+                }}
+              />
+            </CardBody>
+          </PFUtilizationCard>
+        </Col>
+
+        <Col md={3}>
+          <PFUtilizationCard>
+            <CardTitle>Disk</CardTitle>
+            <CardBody>
+              <UtilizationCardDetails>
+                <UtilizationCardDetailsCount>19</UtilizationCardDetailsCount>
+                <UtilizationCardDetailsDesc>
+                  <UtilizationCardDetailsLine1>Available</UtilizationCardDetailsLine1>
+                  <UtilizationCardDetailsLine2>of 50GiB</UtilizationCardDetailsLine2>
+                </UtilizationCardDetailsDesc>
+              </UtilizationCardDetails>
+              <DonutChart
+                id='donut-chart-cpu'
+                data={{
+                  columns: [['Used', 19], ['Available', 31]],
+                  groups: [['used', 'available']],
+                  colors: { Used: '#cc0000', Avaliable: '#3f9c35' },
+                }}
+                title={{ type: 'max' }}
+              />
+              {/* tooltip={{contents: pfGetUtilizationDonutTooltipContents()}} */}
+              {/* TODO: Tooltip on the donut chart! */}
+
+              <SparklineChart
+                id='line-chart-cpu'
+                data={{
+                  columns: [
+                    ['%', 11, 12, 13, 55, 92, 76, 76, 42, 42, 42, 36, 1, 1, 100],
+                  ],
+                  type: 'area',
+                }}
+              />
+            </CardBody>
+          </PFUtilizationCard>
+        </Col>
+      </Row>
+    </CardGrid>
+  )}</BaseCard>
+)
+UtilizationCard.propTypes = {
+  vm: PropTypes.object.isRequired,
+  onEditChange: PropTypes.func.isRequired,
+}
+
+export default UtilizationCard

--- a/src/components/VmDetails/index.js
+++ b/src/components/VmDetails/index.js
@@ -1,0 +1,92 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Alert, Card, CardBody } from 'patternfly-react'
+
+import styles from './style.css'
+
+import NavigationPrompt from 'react-router-navigation-prompt'
+import NavigationConfirmationModal from '../NavigationConfirmationModal'
+
+import { Grid, Row, Col } from './GridComponents'
+import DetailsCard from './cards/DetailsCard'
+import DisksCard from './cards/DisksCard'
+import NicsCard from './cards/NicsCard'
+import OverviewCard from './cards/OverviewCard'
+import SnapshotsCard from './cards/SnapshotsCard'
+import UtilizationCard from './cards/UtilizationCard'
+
+/**
+ * UX Redesign base component for the VM details card page.
+ *
+ * NOTE: I'm ignoring Pools and Pool VMs on purpose right now.
+ */
+class VmDetailsContainer extends React.Component {
+  constructor (props) {
+    super(props)
+    this.trackEdits = { // changes to a card's edit state don't require a re-render here
+      edit: {},
+    }
+    this.state = {
+      anyDirtyEdit: false,
+    }
+  }
+
+  handleEditChange (card, isEdit, isDirty = false) {
+    const cardEdit = this.trackEdits.edit[card] || {}
+    cardEdit.edit = isEdit
+    cardEdit.dirty = isDirty
+
+    const edit = { ...this.trackEdits.edit, [card]: cardEdit }
+    const anyDirtyEdit = Object.entries(edit).reduce((acc, [card, value]) => acc || !!value.dirty, false)
+
+    console.debug(`card "${card}" \u2192 isEdit? ${isEdit}, isDirty? ${isDirty} ∴ edit`, edit, 'anyDirtyEdit?', anyDirtyEdit)
+    this.trackEdits = { edit, anyDirtyEdit }
+    if (!anyDirtyEdit !== !this.state.anyDirtyEdit) {
+      this.setState({ anyDirtyEdit })
+    }
+  }
+
+  render () {
+    const { vm } = this.props
+
+    return (
+      <Grid className={`route-page-component ${styles['details-container']}`}>
+        <NavigationPrompt when={this.state.anyDirtyEdit}>
+          {({ isActive, onConfirm, onCancel }) => (
+            <NavigationConfirmationModal show={isActive} onYes={onConfirm} onNo={onCancel} />
+          )}
+        </NavigationPrompt>
+
+        {vm.get('nextRunExists') &&
+          <Row>
+            <Col>
+              <Card>
+                <CardBody>
+                  <Alert type='info' style={{ margin: '0' }}>This VM has pending configurations changes that will be applied once the VM is shutdown (or rebooted).</Alert>
+                </CardBody>
+              </Card>
+            </Col>
+          </Row>
+        }
+
+        <Row>
+          <Col cols={4}><OverviewCard vm={vm} onEditChange={(isEdit, isDirty) => this.handleEditChange('over', isEdit, isDirty)} /></Col>
+          <Col cols={5}><DetailsCard vm={vm} onEditChange={(isEdit, isDirty) => this.handleEditChange('detail', isEdit, isDirty)} /></Col>
+          <Col cols={3}><SnapshotsCard vm={vm} onEditChange={(isEdit, isDirty) => this.handleEditChange('snap', isEdit, isDirty)} /></Col>
+        </Row>
+        <Row>
+          <Col cols={9}><UtilizationCard vm={vm} onEditChange={(isEdit, isDirty) => this.handleEditChange('util', isEdit, isDirty)} /></Col>
+          <Col cols={3}>
+            <NicsCard vm={vm} onEditChange={(isEdit, isDirty) => this.handleEditChange('nic', isEdit, isDirty)} />
+            <DisksCard vm={vm} onEditChange={(isEdit, isDirty) => this.handleEditChange('disk', isEdit, isDirty)} />
+          </Col>
+        </Row>
+      </Grid>
+    )
+  }
+}
+VmDetailsContainer.propTypes = {
+  vm: PropTypes.object,
+}
+
+export default VmDetailsContainer

--- a/src/components/VmDetails/style.css
+++ b/src/components/VmDetails/style.css
@@ -1,0 +1,110 @@
+/* ---> GridComponents styles (Grid, Row, Col) */
+.grid-container { /* bootstrap4 .container-fluid (different padding/margins) */
+  width: 100%;
+  padding-right: 25px;
+  padding-left: 25px;
+  margin: 0 auto;
+}
+
+.grid-row { /* bootstrap4 .row */
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: -20px;
+  margin-left: -20px;
+}
+
+.grid-column { /* bootstrap4 .col & .col-md */
+  position: relative;
+  width: 100%;
+  min-height: 1px;
+  padding-right: 20px;
+  padding-left: 20px;
+
+  flex: 1 1 0; /* grow shrink basis */
+  max-width: 100%;
+  /*
+    if the component specifies a column span X, it will override
+    flex and max-width so the col takes X/12 columns
+  */
+
+  display: flex;
+  flex-direction: column;
+}
+
+.grid-column[column-content="expand"] > :global(*) {
+  /* all children takes equal amount of available space */
+  flex: 1 0;
+}
+
+/* ---> VmDetailsContainer (index.js) styles */
+.details-container {
+  padding-top: 20px;
+}
+
+/* ---> CardEditButton styles */
+.card-edit-button {
+  float: right;
+  margin-top: 15px;
+  width: 25px;
+  height: 25px;
+  border: none;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.base-card-body .card-edit-button {
+  margin-top: -5px;
+}
+
+.card-edit-button:hover {
+  text-decoration: none;
+}
+
+.card-edit-button-disabled {
+  color: darkgrey;
+}
+
+.card-edit-button-enabled {
+  color: black;
+}
+
+/* ---> BaseCard styles */
+.base-card {
+  display: flex;
+  flex-direction: column;
+}
+
+.base-card-heading {
+  flex-shrink: 0;
+  margin-bottom: 0;
+}
+
+.base-card-title-icon {
+  margin-right: 6px; /* match the left margin on .badge */
+  vertical-align: top;
+}
+
+.base-card-item-count-badge {
+  vertical-align: top;
+}
+
+.base-card-body {
+  flex: 1 0 0;
+}
+
+.base-card-footer {
+  flex-shrink: 0;
+}
+
+
+/* TODO: Temporary style for filler text. Remove once it isn't needed. */
+.demo-text {
+  padding: 5px;
+  color: black;
+  background-color: #00adef;
+  text-align: center;
+  font-family: 'Comic Sans MS';
+  font-weight: bold;
+}

--- a/src/index-nomodules.css
+++ b/src/index-nomodules.css
@@ -86,6 +86,19 @@ body {
   height: 28px;
 }
 
+.card-pf .card-pf-footer {
+  background-color: inherit;
+  padding-top: 10px;
+
+  display: flex;
+  flex-direction: row-reverse;
+}
+
+.card-pf .card-pf-footer button {
+  margin-left: 5px;
+  height: 28px;
+  width: 28px;
+}
 
 .bootstrap-switch-container .bootstrap-switch-label {
   height: 27px !important;

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,7 +3,7 @@ import React from 'react'
 import AddVmButton from './components/VmDialog/AddVmButton'
 import PageRouter from './components/PageRouter'
 import { VmDetailToolbar, PoolDetailToolbar } from './components/Toolbar'
-import { PoolDetailPage, VmDetailPage, VmDialogPage, VmsPage } from './components/Pages'
+import { PoolDetailsPage, VmDetailsPage, VmEditPage, VmCreatePage, VmsPage } from './components/Pages'
 
 import { msg } from './intl'
 
@@ -34,7 +34,7 @@ export default function getRoutes (vms) {
         path: '/vm/add',
         exact: true,
         title: () => msg.addNewVm(),
-        component: VmDialogPage,
+        component: VmCreatePage,
         toolbars: [], // TODO: Recently not used. When needed, see VmDialog/style.css - .vm-dialog-buttons
         closeable: true,
       },
@@ -42,13 +42,13 @@ export default function getRoutes (vms) {
       {
         path: '/vm/:id',
         title: (match, vms) => vms.getIn(['vms', match.params.id, 'name']) || match.params.id,
-        component: VmDetailPage,
+        component: VmDetailsPage,
         toolbars: [(match) => (<VmDetailToolbar match={match} key='vmaction' />)],
         routes: [
           {
             path: '/vm/:id/edit',
             title: (match) => msg.edit() || match.params.id,
-            component: VmDialogPage,
+            component: VmEditPage,
             toolbars: [], // TODO: Recently not used. When needed, see VmDialog/style.css - .vm-dialog-buttons
             closeable: true,
           },
@@ -58,7 +58,7 @@ export default function getRoutes (vms) {
       {
         path: '/pool/:id',
         title: (match, vms) => vms.getIn(['pools', match.params.id, 'name']) || match.params.id,
-        component: PoolDetailPage,
+        component: PoolDetailsPage,
         toolbars: [(match) => (<PoolDetailToolbar match={match} key='poolaction' />)],
       },
     ],


### PR DESCRIPTION
 - Use flex-box to layout the grid (created grid components to mimic bootstrap4 / patternfly4 style grids). These new grid components may be used in other places as well.

 - All of the cards use `BaseCard` to keep common layout and edit logic

 - `BaseCard` edit state is controllable if needed and its event handlers can be aborted to prevent transition the edit state.

 - The page supports tracking the edit and dirty edit state of any component cards (via `onStartEdit` of `BaseCard` and `handleEditChange` of `VmDetailsContainer`).  Card are responsible to notify the layout page via the `onEditChange` callback about its **Edit** state and if any changes have been made on the Edit that need to be saved (**Dirty Edit**).

 - If any card reports **Dirty Edit**, the page will confirm prompt any navigation (or reload) request.

 - Cards in this commit are placeholders. View and edit details to follow in later commits.

---

As of the last edit, the pre-work PRs needed for this PR have all been merged:
 - #659 &rarr; getRoutes() to fix breadcrumb titles
 - #678 &rarr; flex-box layout
 - #679 &rarr; refactor `ovritapi`
 - #690 &rarr; better handling for "deep fetch" / linked / sub VM resources
