### PR TITLE
Update VmsList Vm and Pool to share some styles with VmDetails

### DIFF
--- a/src/components/VmsList/Pool.js
+++ b/src/components/VmsList/Pool.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Link, withRouter } from 'react-router-dom'
 
+import sharedStyle from '../sharedStyle.css'
 import style from './style.css'
 
 import VmActions from '../VmActions'
@@ -13,6 +14,7 @@ import VmStatusIcon from '../VmStatusIcon'
 import { startPool } from '../../actions'
 
 import { getOsHumanName } from '../utils'
+import { enumMsg } from '../../intl'
 
 /**
  * Single icon-card in the list for a Pool
@@ -20,6 +22,7 @@ import { getOsHumanName } from '../utils'
 const Pool = ({ pool, icons, onStart }) => {
   const idPrefix = `pool-${pool.get('name')}`
   const state = pool.get('status')
+  const stateValue = enumMsg('VmStatus', state)
   const osName = getOsHumanName(pool.getIn(['vm', 'os', 'type']))
   const iconId = pool.getIn(['vm', 'icons', 'large', 'id'])
   const icon = icons.get(iconId)
@@ -28,7 +31,7 @@ const Pool = ({ pool, icons, onStart }) => {
     <div className={`col-xs-12 col-sm-6 col-md-4 col-lg-3`}>
       <div className='card-pf card-pf-view card-pf-view-select card-pf-view-single-select'>
         <div>
-          <span className={style['operating-system-label']}>{ osName }</span>
+          <span className={sharedStyle['operating-system-label']}>{ osName }</span>
         </div>
         <div className='card-pf-body'>
           <div className={`card-pf-top-element ${style['card-icon']}`}>
@@ -38,12 +41,15 @@ const Pool = ({ pool, icons, onStart }) => {
             </Link>
           </div>
 
-          <h2 className='card-pf-title text-center'>
+          <h2 className={`card-pf-title text-center ${style['status-height']}`}>
             <Link to={`/pool/${pool.get('id')}`} className={style['vm-detail-link']}>
               <p className={`${style['vm-name']} ${style['crop']}`} title={pool.get('name')} data-toggle='tooltip' id={`${idPrefix}-status-name`}>
-                <VmStatusIcon state={state} />&nbsp;{pool.get('name')}
+                {pool.get('name')}
               </p>
             </Link>
+            <p className={`${style['vm-status']}`} id={`${idPrefix}-status`}>
+              <VmStatusIcon state={state} />&nbsp;{stateValue}
+            </p>
           </h2>
 
           <VmActions isOnCard vm={pool.get('vm')} onStart={onStart} pool={pool} />

--- a/src/components/VmsList/Vm.js
+++ b/src/components/VmsList/Vm.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Link, withRouter } from 'react-router-dom'
 
+import sharedStyle from '../sharedStyle.css'
 import style from './style.css'
 
 import VmActions from '../VmActions'
@@ -29,7 +30,7 @@ const Vm = ({ vm, icons, os, onStart }) => {
     <div className={`col-xs-12 col-sm-6 col-md-4 col-lg-3`}>
       <div className='card-pf card-pf-view card-pf-view-select card-pf-view-single-select'>
         <div>
-          <span className={style['operating-system-label']}>{osName}</span>
+          <span className={sharedStyle['operating-system-label']}>{osName}</span>
         </div>
         <div className='card-pf-body'>
           <div className={`card-pf-top-element ${style['card-icon']}`}>

--- a/src/components/VmsList/style.css
+++ b/src/components/VmsList/style.css
@@ -99,21 +99,6 @@
     justify-content: space-between;
 }
 
-.operating-system-label {
-    display: inline-block;
-    font-size: 10px;
-    height: 18px;
-    padding: 0 6px;
-    text-transform: uppercase;
-    font-weight: 700;
-    color: #363636;
-    background-color: #ededed;
-    min-width: 100px;
-    margin: -2px -2px 2px auto;
-    float: right;
-    text-align: center;
-}
-
 .status-height {
     margin-top: 5px !important;
 }

--- a/src/components/sharedStyle.css
+++ b/src/components/sharedStyle.css
@@ -40,6 +40,22 @@
   z-index: 1050;
 }
 
+/* For Toast Notifications */
 .toast-margin-top {
     margin-top: 0;
+}
+
+/* For VM Card List and VM Details Overview Card */
+.operating-system-label {
+  font-size: 10px;
+  height: 18px;
+  padding: 0 6px;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: #363636;
+  background-color: #ededed;
+  min-width: 100px;
+  margin: -2px -2px 2px auto;
+  float: right;
+  text-align: center;
 }


### PR DESCRIPTION
 - Moved '.operating-system-label' CSS class from **VmsList/style.css**
   to **sharedStyles.css** so it can be shared between the VmsList VM
   card and the VmDetails OverviewCard

 - Fixed the render of `Pool` so the pool name appears above the state
   just like the `Vm` cards