### PR TITLE
Fix the green for 'Up' on VmStatusIcon to be PF green

### DIFF
--- a/src/components/VmStatusIcon/style.css
+++ b/src/components/VmStatusIcon/style.css
@@ -1,3 +1,3 @@
 .green {
-    color: #24d011;
+    color: #3B9D2E;
 }


### PR DESCRIPTION
We had the wrong color green for the Running/Up status icon.

Still waiting to hear if the Off/Down status icon should be red (the specific pf-red) instead of black.