### PR TITLE
Enable access to the pre-redesign VM detail page

### DIFF
--- a/src/components/DetailContainer.js
+++ b/src/components/DetailContainer.js
@@ -5,10 +5,8 @@ import sharedStyle from './sharedStyle.css'
 
 const DetailContainer = ({ children, ...props }) => {
   return (
-    <div className='detail-container'>
-      <div className={`container-fluid ${sharedStyle['move-left-detail']} ${sharedStyle['detail-z-index']}`} {...props}>
-        {children}
-      </div>
+    <div className={`container-fluid ${sharedStyle['move-left-detail']} ${sharedStyle['detail-z-index']}`} {...props}>
+      {children}
     </div>
   )
 }

--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -5,15 +5,17 @@ import { connect } from 'react-redux'
 import { RouterPropTypeShapes } from '../../propTypeShapes'
 import VmActions from '../VmActions'
 
-const VmDetailToolbar = ({ match, vms }) => {
+const VmDetailToolbar = ({ match, vms, includeLegacyDetails = false }) => {
   if (vms.getIn(['vms', match.params.id])) {
-    return (<VmActions vm={vms.getIn(['vms', match.params.id])} />)
+    return (<VmActions vm={vms.getIn(['vms', match.params.id])} includeLegacyDetails={includeLegacyDetails} />)
   }
   return null
 }
 
 VmDetailToolbar.propTypes = {
   vms: PropTypes.object.isRequired,
+  includeLegacyDetails: PropTypes.bool,
+
   match: RouterPropTypeShapes.match.isRequired,
 }
 

--- a/src/components/VmDetail/index.js
+++ b/src/components/VmDetail/index.js
@@ -158,7 +158,7 @@ class VmDetail extends Component {
     }
 
     return (
-      <div className={style['main-container']} data-thisisvmdetail>
+      <div className={`detail-container ${style['main-container']}`} data-thisisvmdetail>
         <VmsListNavigation selectedVm={vm} expanded={this.state.vmsNavigationExpanded} toggleExpansion={this.toggleVmsNavExpansion} />
         <div className={style['vm-detail-main']} container='true'>
           <div className={this.state.vmsNavigationExpanded ? style['vms-nav-expanded'] : style['vms-nav-collapsed']}>

--- a/src/components/VmDialog/index.js
+++ b/src/components/VmDialog/index.js
@@ -572,7 +572,7 @@ class VmDialog extends React.Component {
       : null
 
     return (
-      <DetailContainer>
+      <div className='detail-container'><DetailContainer>
         <h1 className={style['header']} id={`${idPrefix}-${isEdit ? 'edit' : 'create'}-title`}>
           <VmIcon icon={icon} missingIconClassName='pficon pficon-virtual-machine' />
           &nbsp;{dialogHeader}
@@ -783,7 +783,7 @@ class VmDialog extends React.Component {
           </div>
         </form>
 
-      </DetailContainer>
+      </DetailContainer></div>
     )
   }
 }

--- a/src/components/VmsListNavigation/index.js
+++ b/src/components/VmsListNavigation/index.js
@@ -41,7 +41,7 @@ const VmsListNavigation = ({ selectedVm, vms, expanded, toggleExpansion, loadAno
 
       return (
         <li role='presentation' className={style['item']} key={vm.get('id')}>
-          <Link to={`/vm/${vm.get('id')}`} className={style['item-link']}>
+          <Link to={`/vm-legacy/${vm.get('id')}`} className={style['item-link']}>
             <span className={style['item-text']} id={`${idPrefix}-item-${vm.get('name')}`}>{vm.get('name')}</span>
           </Link>
         </li>

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,7 +3,7 @@ import React from 'react'
 import AddVmButton from './components/VmDialog/AddVmButton'
 import PageRouter from './components/PageRouter'
 import { VmDetailToolbar, PoolDetailToolbar } from './components/Toolbar'
-import { PoolDetailsPage, VmDetailsPage, VmEditPage, VmCreatePage, VmsPage } from './components/Pages'
+import { PoolDetailsPage, VmDetailsPage, VmEditPage, VmCreatePage, VmsPage, LegacyVmDetailsPage } from './components/Pages'
 
 import { msg } from './intl'
 
@@ -43,7 +43,7 @@ export default function getRoutes (vms) {
         path: '/vm/:id',
         title: (match, vms) => vms.getIn(['vms', match.params.id, 'name']) || match.params.id,
         component: VmDetailsPage,
-        toolbars: [(match) => (<VmDetailToolbar match={match} key='vmaction' />)],
+        toolbars: [(match) => (<VmDetailToolbar match={match} key='vmaction' includeLegacyDetails />)],
         routes: [
           {
             path: '/vm/:id/edit',
@@ -53,6 +53,13 @@ export default function getRoutes (vms) {
             closeable: true,
           },
         ],
+      },
+
+      {
+        path: '/vm-legacy/:id',
+        title: (match, vms) => vms.getIn(['vms', match.params.id, 'name']) || match.params.id,
+        component: LegacyVmDetailsPage,
+        toolbars: [(match) => (<VmDetailToolbar match={match} key='vmaction' />)],
       },
 
       {


### PR DESCRIPTION
 - With incremental releases planned (after each agile sprint), not all
   of the previous functionality will be available

 - Enable navigation to the pre-redesign / legacy VM detail page from
   the current VM details page

 - This allows access to the old Console, Disks, Nics and Snapshots
   functionality

Solves #718