### PR TITLE
enhanced browser console logging

### DIFF
--- a/src/components/VmDialog/index.js
+++ b/src/components/VmDialog/index.js
@@ -7,7 +7,8 @@ import { Link } from 'react-router-dom'
 import NavigationPrompt from 'react-router-navigation-prompt'
 import Switch from 'react-bootstrap-switch'
 
-import { logDebug, generateUnique, templateNameRenderer } from '../../helpers'
+import logger from '../../logger'
+import { generateUnique, templateNameRenderer } from '../../helpers'
 import { isRunning, getVmIconId, isValidOsIcon } from '../utils'
 
 import style from './style.css'
@@ -193,7 +194,7 @@ class VmDialog extends React.Component {
       'max': this.state.memory * MAX_VM_MEMORY_FACTOR,
       'guaranteed': Math.round(guaranteed),
     }
-    logDebug('getMemoryPolicy() resulting memory_policy: ', memoryPolicy)
+    logger.log('getMemoryPolicy() resulting memory_policy: ', memoryPolicy)
 
     return memoryPolicy
   }
@@ -465,13 +466,13 @@ class VmDialog extends React.Component {
       const clustersList = clusters.toList()
       const def = (clustersList.filter(item => item.get('name') === defaultClusterName).first()) || clustersList.first()
       stateChange.clusterId = def ? def.get('id') : undefined
-      logDebug(`VmDialog initDefaults(): Setting initial value for clusterId = ${this.state.clusterId} to ${stateChange.clusterId}`)
+      logger.log(`VmDialog initDefaults(): Setting initial value for clusterId = ${this.state.clusterId} to ${stateChange.clusterId}`)
     }
 
     if (!this.getTemplate()) {
       const def = templates.get(zeroUID) || this.props.templates.toList().first()
       stateChange.templateId = def ? def.get('id') : undefined
-      logDebug(`VmDialog initDefaults(): Setting initial value for templateId = ${this.state.templateId} to ${stateChange.templateId}`)
+      logger.log(`VmDialog initDefaults(): Setting initial value for templateId = ${this.state.templateId} to ${stateChange.templateId}`)
     }
 
     if (!this.getOS()) {
@@ -483,7 +484,7 @@ class VmDialog extends React.Component {
           id: os.getIn(['icons', 'large', 'id']),
         }
       }
-      logDebug(`VmDialog initDefaults(): Setting initial value for osId = ${this.state.osId} to ${stateChange.osId}`)
+      logger.log(`VmDialog initDefaults(): Setting initial value for osId = ${this.state.osId} to ${stateChange.osId}`)
     }
 
     this.setState(stateChange)

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,7 @@
 import $ from 'jquery'
 
-import { setLogDebug, getURLQueryParameterByName } from './helpers'
+import { getURLQueryParameterByName } from './helpers'
+import { setLogDebug } from './logger'
 
 const CONFIG_URL = '/ovirt-engine/web-ui/ovirt-web-ui.config'
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,36 +1,18 @@
 import { Blob } from 'blob-util'
 import { locale as appLocale } from './intl'
-
-let logDebugEnabled = true
-
-/**
- * @param enabled true if logDebug() shall write messages to the console
- */
-export function setLogDebug (enabled) {
-  logDebugEnabled = enabled
-}
+import logger from './logger'
 
 /**
  * Write DEBUG log message to console
  * @param msg
  */
-export function logDebug (msg, ...params) {
-  if (logDebugEnabled) {
-    if (params) {
-      console.log(msg, ...params)
-    } else {
-      console.log(msg)
-    }
-  }
-}
+export const logDebug = logger.log
 
 /**
  * Write ERROR log message to console
  * @param msg
  */
-export function logError (...messages) {
-  console.error(...messages)
-}
+export const logError = logger.error
 
 // "payload":{"message":"Not Found","shortMessage":"LOGIN failed","type":404,"action":{"type":"LOGIN","payload":{"credentials":{"username":"admin@internal","password":"admi"}}}}}
 export function hidePassword ({ action, param }) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,18 +1,5 @@
 import { Blob } from 'blob-util'
 import { locale as appLocale } from './intl'
-import logger from './logger'
-
-/**
- * Write DEBUG log message to console
- * @param msg
- */
-export const logDebug = logger.log
-
-/**
- * Write ERROR log message to console
- * @param msg
- */
-export const logError = logger.error
 
 // "payload":{"message":"Not Found","shortMessage":"LOGIN failed","type":404,"action":{"type":"LOGIN","payload":{"credentials":{"username":"admin@internal","password":"admi"}}}}}
 export function hidePassword ({ action, param }) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,16 @@
 // @flow
-/* eslint-disable import/first */
-
 /**
-  Flow agreement:
-  For simple types, like number, boolean, string and etc.: use lower-case,
-  For complex types, like Object, Array and etc.: use first letter in upper-case
-**/
+ Flow agreement:
+ For simple types, like number, boolean, string and etc.: use lower-case,
+ For complex types, like Object, Array and etc.: use first letter in upper-case
+ **/
+
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
 import { IntlProvider } from 'react-intl'
+
+import logger from './logger'
 
 // TODO: Look at this WRT patternfly-react CSS!!!!!!!
 import 'patternfly/dist/css/patternfly.css'
@@ -22,7 +23,7 @@ import configureStore from './store'
 import Selectors from './selectors'
 import AppConfiguration, { readConfiguration } from './config'
 import { loadStateFromLocalStorage } from './storage'
-import { logDebug, logError, valuesOfObject } from './helpers'
+import { valuesOfObject } from './helpers'
 import { rootSaga } from './sagas'
 import {
   login,
@@ -34,8 +35,6 @@ import {
 import OvirtApi from './ovirtapi'
 
 import App from './App'
-
-// eslint-disable "import/first": off
 
 // Patternfly dependencies
 // jQuery needs to be globally available (webpack.ProvidePlugin can be also used for this)
@@ -67,7 +66,7 @@ function renderApp (store: Object) {
  */
 function fetchToken (): { token: string, username: string, domain: string, userId: string } {
   const userInfo = window.userInfo
-  logDebug(`SSO userInfo: ${JSON.stringify(userInfo)}`)
+  logger.log(`SSO userInfo: ${JSON.stringify(userInfo)}`)
 
   if (userInfo) {
     return {
@@ -91,7 +90,7 @@ function loadPersistedState (store: Object) {
 
   if (icons) {
     const iconsArray = valuesOfObject(icons)
-    console.log(`loadPersistedState: ${iconsArray.length} icons loaded`)
+    logger.log(`loadPersistedState: ${iconsArray.length} icons loaded`)
     store.dispatch(updateIcons({ icons: iconsArray }))
   }
 }
@@ -122,7 +121,7 @@ function initializeApiListener (store: Object) {
 }
 
 function onResourcesLoaded () {
-  console.log(`Current configuration: ${JSON.stringify(AppConfiguration)}`)
+  logger.log(`Current configuration: ${JSON.stringify(AppConfiguration)}`)
 
   addBrandedResources()
 
@@ -140,7 +139,7 @@ function onResourcesLoaded () {
   if (token) {
     store.dispatch(login({ username, token, userId }))
   } else {
-    logError('Missing SSO Token!')
+    logger.error('Missing SSO Token!')
   }
 }
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,32 @@
+let isDebugEnabled = true
+
+export function setLogDebug (enabled) {
+  isDebugEnabled = enabled
+}
+
+const noop = function () {}
+
+/*
+ * Functions bound to the real console object, in the correct context for generating
+ * appropriate file/line numbers.  Also provide the first few arguments to the real
+ * function calls to add pretty line prefixes.
+ */
+const consoleFunctions = {
+  log: window.console.log.bind(window.console, '%c debug %c', 'font-weight: bold; background-color: #21409a; color: white;', ''),
+  info: window.console.info.bind(window.console, '%c info %c', 'font-weight: bold; background-color: #01acac; color: white;', ''),
+  warn: window.console.warn.bind(window.console, '%c warn %c', 'font-weight: bold; background-color: #f8a51b; color: white;', ''),
+  error: window.console.error.bind(window.console, '%c error %c', 'font-weight: bold; background-color: #ed403c; color: white;', ''),
+}
+
+function attachLoggers (object) {
+  return Object.defineProperties(window.console, {
+    'log': { get () { return isDebugEnabled ? consoleFunctions.log : noop } },
+    'info': { get () { return isDebugEnabled ? consoleFunctions.info : noop } },
+    'warn': { get () { return isDebugEnabled ? consoleFunctions.warn : noop } },
+    'error': { get () { return isDebugEnabled ? consoleFunctions.error : noop } },
+  })
+}
+
+attachLoggers(window.console)
+
+export default attachLoggers({})

--- a/src/optionsManager.js
+++ b/src/optionsManager.js
@@ -1,5 +1,5 @@
 import { saveToLocalStorage, loadFromLocalStorage, removeFromLocalStorage } from './storage'
-import { logDebug } from './helpers'
+import logger from './logger'
 
 export default {
   loadConsoleOptions ({ vmId }) {
@@ -10,7 +10,7 @@ export default {
     try {
       options = (optionsJson && JSON.parse(optionsJson)) || {}
     } catch (e) {
-      logDebug('Unable to parse consoleOptions from local storrage: ', optionsJson)
+      logger.log('Unable to parse consoleOptions from local storage: ', optionsJson)
       options = {}
     }
 

--- a/src/ovirtapi/index.js
+++ b/src/ovirtapi/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { logDebug } from '../helpers'
+import logger from '../logger'
 import Selectors from '../selectors'
 import AppConfiguration from '../config'
 
@@ -163,7 +163,7 @@ const OvirtApi = {
   addNewVm ({ vm, transformInput = false }: VmType): Promise<Object> {
     assertLogin({ methodName: 'addNewVm' })
     const input = JSON.stringify(transformInput ? OvirtApi.internalVmToOvirt({ vm }) : vm)
-    logDebug(`OvirtApi.addNewVm(): ${input}`)
+    logger.log(`OvirtApi.addNewVm(): ${input}`)
 
     return httpPost({
       url: `${AppConfiguration.applicationContext}/api/vms`,
@@ -173,7 +173,7 @@ const OvirtApi = {
   editVm ({ vm, transformInput = false }: VmType): Promise<Object> {
     assertLogin({ methodName: 'editVm' })
     const input = JSON.stringify(transformInput ? OvirtApi.internalVmToOvirt({ vm }) : vm)
-    logDebug(`OvirtApi.editVm(): ${input}`)
+    logger.log(`OvirtApi.editVm(): ${input}`)
 
     return httpPut({
       url: `${AppConfiguration.applicationContext}/api/vms/${vm.id}`,
@@ -212,7 +212,7 @@ const OvirtApi = {
   addNewSnapshot ({ vmId, snapshot }: { vmId: string, snapshot: Object }): Promise<Object> {
     assertLogin({ methodName: 'addNewSnapshot' })
     const input = JSON.stringify(OvirtApi.internalSnapshotToOvirt({ snapshot }))
-    logDebug(`OvirtApi.addNewSnapshot(): ${input}`)
+    logger.log(`OvirtApi.addNewSnapshot(): ${input}`)
     return httpPost({
       url: `${AppConfiguration.applicationContext}/api/vms/${vmId}/snapshots`,
       input,
@@ -311,7 +311,7 @@ const OvirtApi = {
   changeCD ({ cdrom, vmId, running }: { cdrom: Object, vmId: string, running: boolean }): Promise<Object> {
     assertLogin({ methodName: 'changeCD' })
     const input = JSON.stringify(OvirtApi.internalCDRomToOvirt({ cdrom }))
-    logDebug(`OvirtApi.changeCD(): ${input}`)
+    logger.log(`OvirtApi.changeCD(): ${input}`)
     return httpPut({
       url: `${AppConfiguration.applicationContext}/api/vms/${vmId}/cdroms/${zeroUUID}?current=${running ? 'true' : 'false'}`,
       input,
@@ -320,7 +320,7 @@ const OvirtApi = {
   addNicToVm ({ nic, vmId }: { nic: Object, vmId: string }): Promise<Object> {
     assertLogin({ methodName: 'addNicToVm' })
     const input = JSON.stringify(OvirtApi.internalNicToOvirt({ nic }))
-    logDebug(`OvirtApi.addNicToVm(): ${input}`)
+    logger.log(`OvirtApi.addNicToVm(): ${input}`)
     return httpPost({
       url: `${AppConfiguration.applicationContext}/api/vms/${vmId}/nics`,
       input,
@@ -443,18 +443,18 @@ function getOptionWithoutDefault (optionName: string, version: string): Promise<
           .map(valueAndVersion => valueAndVersion.value)[0]
       } catch (error) {
         if (error instanceof TypeError) {
-          logDebug(`Response to getting option '${optionName}' has unexpected format:`, response)
+          logger.log(`Response to getting option '${optionName}' has unexpected format:`, response)
         }
         throw error
       }
       if (result === undefined) {
-        logDebug(`Config option '${optionName}' was not found for version '${version}'.`)
+        logger.log(`Config option '${optionName}' was not found for version '${version}'.`)
         return null
       }
       return result
     }, error => {
       if (error.status === 404) {
-        logDebug(`Config option '${optionName}' doesn't exist in any version.`)
+        logger.log(`Config option '${optionName}' doesn't exist in any version.`)
         return null
       }
       throw error

--- a/src/ovirtapi/transport.js
+++ b/src/ovirtapi/transport.js
@@ -3,7 +3,7 @@
 import $ from 'jquery'
 import AppConfiguration from '../config'
 import { Exception } from '../exceptions'
-import { logDebug } from '../helpers'
+import logger from '../logger'
 import Selectors from '../selectors'
 
 //
@@ -58,7 +58,7 @@ type InputRequestType = { url: string, input: string, contentType?: string }
 type DeleteRequestType = { url: string, custHeaders?: Object }
 
 function httpGet ({ url, custHeaders = {} }: GetRequestType): Promise<Object> {
-  logDebug(`_httpGet start: url="${url}"`)
+  logger.log(`_httpGet start: url="${url}"`)
   const requestId = notifyStart('GET', url)
   const headers = Object.assign({
     'Authorization': `Bearer ${_getLoginToken()}`,
@@ -66,7 +66,7 @@ function httpGet ({ url, custHeaders = {} }: GetRequestType): Promise<Object> {
     'Filter': Selectors.getFilter(),
     'Accept': 'application/json',
   }, custHeaders)
-  logDebug(`_httpGet: url="${url}", headers="${JSON.stringify(headers)}"`)
+  logger.log(`_httpGet: url="${url}", headers="${JSON.stringify(headers)}"`)
 
   return $.ajax(url, {
     type: 'GET',
@@ -77,7 +77,7 @@ function httpGet ({ url, custHeaders = {} }: GetRequestType): Promise<Object> {
       return data
     })
     .catch((data: Object): Promise<Object> => {
-      logDebug(`Ajax failed: ${JSON.stringify(data)}`)
+      logger.log(`Ajax failed: ${JSON.stringify(data)}`)
       notifyStop(requestId)
       return Promise.reject(data)
     })
@@ -101,7 +101,7 @@ function httpPost ({ url, input, contentType = 'application/json' }: InputReques
       return data
     })
     .catch((data: Object): Promise<Object> => {
-      logDebug(`Ajax failed: ${JSON.stringify(data)}`)
+      logger.log(`Ajax failed: ${JSON.stringify(data)}`)
       notifyStop(requestId)
       return Promise.reject(data)
     })
@@ -125,7 +125,7 @@ function httpPut ({ url, input, contentType = 'application/json' }: InputRequest
       return data
     })
     .catch((data: Object): Promise<Object> => {
-      logDebug(`Ajax failed: ${JSON.stringify(data)}`)
+      logger.log(`Ajax failed: ${JSON.stringify(data)}`)
       notifyStop(requestId)
       return Promise.reject(data)
     })
@@ -137,7 +137,7 @@ function httpDelete ({ url, custHeaders = { 'Accept': 'application/json' } }: De
     'Filter': Selectors.getFilter(),
   }, custHeaders)
   const requestId = notifyStart('DELETE', url)
-  logDebug(`_httpDelete: url="${url}", headers="${JSON.stringify(headers)}"`)
+  logger.log(`_httpDelete: url="${url}", headers="${JSON.stringify(headers)}"`)
 
   return $.ajax(url, {
     type: 'DELETE',
@@ -148,7 +148,7 @@ function httpDelete ({ url, custHeaders = { 'Accept': 'application/json' } }: De
       return data
     })
     .catch((data: Object): Promise<Object> => {
-      logDebug(`Ajax failed: ${JSON.stringify(data)}`)
+      logger.log(`Ajax failed: ${JSON.stringify(data)}`)
       notifyStop(requestId)
       return Promise.reject(data)
     })

--- a/src/reducers/utils.js
+++ b/src/reducers/utils.js
@@ -1,5 +1,5 @@
 import { Map } from 'immutable'
-import { logDebug } from '../helpers'
+import logger from '../logger'
 import { UPDATE_ICONS, REMOVE_ACTIVE_REQUEST, DELAYED_REMOVE_ACTIVE_REQUEST, ADD_ACTIVE_REQUEST } from '../constants'
 
 /**
@@ -45,7 +45,7 @@ export const actionReducer = (initialState, handlers, verbose) => (state = initi
     }
 
     if (![ ADD_ACTIVE_REQUEST, REMOVE_ACTIVE_REQUEST, DELAYED_REMOVE_ACTIVE_REQUEST ].includes(action.type)) {
-      logDebug('Reducing action:', actionJson)
+      logger.log('Reducing action:', actionJson)
     }
   }
 

--- a/src/reducers/vms.js
+++ b/src/reducers/vms.js
@@ -22,7 +22,7 @@ import {
   UPDATE_VMS,
   VM_ACTION_IN_PROGRESS,
 } from '../constants'
-import { logError } from '../helpers'
+import logger from '../logger'
 import { actionReducer, removeMissingItems } from './utils'
 
 const initialState = Immutable.fromJS({
@@ -80,7 +80,7 @@ const vms = actionReducer(initialState, {
     if (state.getIn(['vms', vmId])) {
       return state.setIn(['vms', vmId, 'disks'], Immutable.fromJS(disks)) // deep immutable
     } else { // fail, if VM not found
-      logError(`vms.setVmDisks() reducer: vmId ${vmId} not found`)
+      logger.error(`vms.setVmDisks() reducer: vmId ${vmId} not found`)
     }
     return state
   },
@@ -88,7 +88,7 @@ const vms = actionReducer(initialState, {
     if (state.getIn(['vms', vmId])) {
       return state.setIn(['vms', vmId, 'cdrom'], Immutable.fromJS(cdrom)) // deep immutable
     } else { // fail, if VM not found
-      logError(`vms.setVmCdrom() reducer: vmId ${vmId} not found`)
+      logger.error(`vms.setVmCdrom() reducer: vmId ${vmId} not found`)
     }
     return state
   },
@@ -97,14 +97,14 @@ const vms = actionReducer(initialState, {
       return state.setIn(['vms', vmId, 'snapshots'], Immutable.fromJS(snapshots)) // deep immutable
     }
 
-    logError(`vms.setVmSnapshots() reducer: vmId ${vmId} not found`)
+    logger.error(`vms.setVmSnapshots() reducer: vmId ${vmId} not found`)
     return state
   },
   [SET_VM_NICS] (state, { payload: { vmId, nics } }) {
     if (state.getIn(['vms', vmId])) {
       return state.setIn(['vms', vmId, 'nics'], Immutable.fromJS(nics)) // deep immutable
     } else { // fail, if VM not found
-      logError(`vms.setVmNics() reducer: vmId ${vmId} not found`)
+      logger.error(`vms.setVmNics() reducer: vmId ${vmId} not found`)
     }
     return state
   },
@@ -183,7 +183,7 @@ const vms = actionReducer(initialState, {
       if (state.getIn(['vms', vmId])) {
         return state.setIn(['vms', vmId, 'lastMessage'], shortMessage || message)
       } else {
-        logError(`API reports an error associated to nonexistent VM ${vmId}, error`,
+        logger.error(`API reports an error associated to nonexistent VM ${vmId}, error`,
           { message, shortMessage, type, failedAction })
       }
     }

--- a/src/saga/console/index.js
+++ b/src/saga/console/index.js
@@ -3,7 +3,8 @@ import { put } from 'redux-saga/effects'
 import Api from '../../ovirtapi'
 import Selectors from '../../selectors'
 import OptionsManager from '../../optionsManager'
-import { logDebug, fileDownload } from '../../helpers'
+import logger from '../../logger'
+import { fileDownload } from '../../helpers'
 import {
   downloadConsole,
   getConsoleOptions as getConsoleOptionsAction,
@@ -51,7 +52,7 @@ export function* downloadVmConsole (action) {
     if (data.error === undefined) {
       let options = Selectors.getConsoleOptions({ vmId })
       if (!options) {
-        logDebug('downloadVmConsole() console options not yet present, trying to load from local storage')
+        logger.log('downloadVmConsole() console options not yet present, trying to load from local storage')
         options = yield getConsoleOptions(getConsoleOptionsAction({ vmId }))
       }
 
@@ -90,7 +91,7 @@ export function* getConsoleInUse (action) {
   yield put(setConsoleIsValid({ vmId, isValid: false }))
 
   const sessionsInternal = yield fetchVmSessions({ vmId })
-  logDebug(`vmId: ${vmId}, sessions: ${JSON.stringify(sessionsInternal)}`)
+  logger.log(`vmId: ${vmId}, sessions: ${JSON.stringify(sessionsInternal)}`)
 
   if (sessionsInternal && sessionsInternal.find((x) => x.consoleUser && (!userId || x.user.id === userId)) !== undefined) {
     yield put(setConsoleInUse({ vmId, consoleInUse: true }))

--- a/src/saga/console/vvFileUtils.js
+++ b/src/saga/console/vvFileUtils.js
@@ -1,8 +1,8 @@
-import { logDebug } from '../../helpers'
+import logger from '../../logger'
 
 export function adjustVVFile ({ data, options, usbFilter, isSpice }) {
   // __options__ can either be a plain JS object or ImmutableJS Map
-  logDebug('adjustVVFile options:', options)
+  logger.log('adjustVVFile options:', options)
 
   if (options && ((options.get && options.get('fullscreen')) || options.fullscreen)) {
     data = data.replace(/^fullscreen=0/mg, 'fullscreen=1')
@@ -14,10 +14,10 @@ export function adjustVVFile ({ data, options, usbFilter, isSpice }) {
     text = 'secure-attention=ctrl+alt+end'
   }
   if (data.match(pattern)) {
-    logDebug('secure-attention found, replacing by ', text)
+    logger.log('secure-attention found, replacing by ', text)
     data = data.replace(pattern, text)
   } else {
-    logDebug('secure-attention was not found, inserting ', text)
+    logger.log('secure-attention was not found, inserting ', text)
     data = data.replace(/^\[virt-viewer\]$/mg, `[virt-viewer]\n${text}`) // ending \n is already there
   }
 
@@ -30,6 +30,6 @@ export function adjustVVFile ({ data, options, usbFilter, isSpice }) {
     data = data.replace(/^enable-smartcard=[01]$/mg, `enable-smartcard=${smartcardEnabled ? 1 : 0}`)
   }
 
-  logDebug('adjustVVFile data after adjustment:', data)
+  logger.log('adjustVVFile data after adjustment:', data)
   return data
 }

--- a/src/saga/utils.js
+++ b/src/saga/utils.js
@@ -3,10 +3,8 @@ import {
   put,
 } from 'redux-saga/effects'
 
-import {
-  logDebug,
-  hidePassword,
-} from '../helpers'
+import logger from '../logger'
+import { hidePassword } from '../helpers'
 
 import { msg } from '../intl/index'
 
@@ -19,12 +17,12 @@ export const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms))
 
 export function* callExternalAction (methodName, method, action, canBeMissing = false) {
   try {
-    logDebug(`External action ${methodName}() starts on ${JSON.stringify(hidePassword({ action }))}`)
+    logger.log(`External action ${methodName}() starts on ${JSON.stringify(hidePassword({ action }))}`)
     const result = yield call(method, action.payload)
     return result
   } catch (e) {
     if (!canBeMissing) {
-      logDebug(`External action exception: ${JSON.stringify(e)}`)
+      logger.log(`External action exception: ${JSON.stringify(e)}`)
 
       if (e.status === 401) { // Unauthorized
         yield put(checkTokenExpired())
@@ -59,7 +57,7 @@ export function* waitTillEqual (leftArg, rightArg, limit) {
     yield delay(20) // in ms
     counter--
 
-    logDebug('waitTillEqual() delay ...')
+    logger.log('waitTillEqual() delay ...')
   }
 
   return false

--- a/src/sagas.js
+++ b/src/sagas.js
@@ -18,7 +18,7 @@ import {
   throttle,
 } from 'redux-saga/effects'
 
-import { logDebug } from './helpers'
+import logger from './logger'
 
 import { push } from 'connected-react-router'
 import {
@@ -179,7 +179,7 @@ function* fetchIcon ({ iconId }) {
 }
 
 function* refreshData (action) {
-  logDebug('refreshData(): ', action.payload)
+  logger.log('refreshData(): ', action.payload)
   const shallowFetch = !!action.payload.shallowFetch
 
   // refresh VMs and remove any that haven't been refreshed
@@ -217,7 +217,7 @@ function* refreshData (action) {
 
   // update counts
   yield put(updateVmsPoolsCount())
-  logDebug('refreshData(): finished')
+  logger.log('refreshData(): finished')
 }
 
 function* fetchVmsByPage (action) {
@@ -270,7 +270,7 @@ function* fetchVmsByPageVLower (action) {
       yield fetchVmsSessions({ vms: internalVms })
       yield fetchVmsSnapshots({ vms: internalVms })
     } else {
-      logDebug('getVmsByPage() shallow fetch requested - skipping other resources')
+      logger.log('getVmsByPage() shallow fetch requested - skipping other resources')
     }
   }
 
@@ -328,7 +328,7 @@ function* fetchVmsByCountVLower (action) {
       yield fetchVmsSessions({ vms: internalVms })
       yield fetchVmsSnapshots({ vms: internalVms })
     } else {
-      logDebug('fetchVmsByCountVLower() shallow fetch requested - skipping other resources')
+      logger.log('fetchVmsByCountVLower() shallow fetch requested - skipping other resources')
     }
   }
 
@@ -813,11 +813,11 @@ let _SchedulerCount = 0
 
 function* schedulerWithFixedDelay (delayInSeconds = AppConfiguration.schedulerFixedDelayInSeconds) {
   const myId = _SchedulerCount++
-  logDebug(`⏰ schedulerWithFixedDelay[${myId}] starting fixed delay scheduler`)
+  logger.log(`⏰ schedulerWithFixedDelay[${myId}] starting fixed delay scheduler`)
 
   let enabled = true
   while (enabled) {
-    logDebug(`⏰ schedulerWithFixedDelay[${myId}] stoppable delay for: ${delayInSeconds}`)
+    logger.log(`⏰ schedulerWithFixedDelay[${myId}] stoppable delay for: ${delayInSeconds}`)
     const { stopped } = yield race({
       stopped: take(STOP_SCHEDULER_FIXED_DELAY),
       fixedDelay: call(delay, (delayInSeconds * 1000)),
@@ -825,9 +825,9 @@ function* schedulerWithFixedDelay (delayInSeconds = AppConfiguration.schedulerFi
 
     if (stopped) {
       enabled = false
-      logDebug(`⏰ schedulerWithFixedDelay[${myId}] scheduler has been stopped`)
+      logger.log(`⏰ schedulerWithFixedDelay[${myId}] scheduler has been stopped`)
     } else {
-      logDebug(`⏰ schedulerWithFixedDelay[${myId}] running after delay of: ${delayInSeconds}`)
+      logger.log(`⏰ schedulerWithFixedDelay[${myId}] running after delay of: ${delayInSeconds}`)
 
       const oVirtVersion = Selectors.getOvirtVersion()
       if (oVirtVersion.get('passed')) {
@@ -837,7 +837,7 @@ function* schedulerWithFixedDelay (delayInSeconds = AppConfiguration.schedulerFi
           page: Selectors.getCurrentPage(),
         }))
       } else {
-        logDebug(`⏰ schedulerWithFixedDelay[${myId}] event skipped since oVirt API version does not match`)
+        logger.log(`⏰ schedulerWithFixedDelay[${myId}] event skipped since oVirt API version does not match`)
       }
     }
   }

--- a/src/storage.js
+++ b/src/storage.js
@@ -2,7 +2,7 @@
  Local/Session Storage manipulation
  */
 
-import { logDebug } from './helpers'
+import logger from './logger'
 
 export function saveToLocalStorage (key, value) {
   window.localStorage.setItem(key, value)
@@ -17,12 +17,12 @@ export function removeFromLocalStorage (key) {
 }
 
 export function persistStateToLocalStorage ({ icons }) {
-  logDebug(`persistStateToLocalStorage() called`)
+  logger.log(`persistStateToLocalStorage() called`)
   saveToLocalStorage('icons', JSON.stringify(icons))
 }
 
 export function loadStateFromLocalStorage () {
-  logDebug(`loadStateFromLocalStorage() called`)
+  logger.log(`loadStateFromLocalStorage() called`)
   return {
     icons: JSON.parse(loadFromLocalStorage('icons')),
   }


### PR DESCRIPTION
 - may be used as a module import

 - captures `console.(log|info|warn|error)` and routes it through the same
   logging functions as the module import

 - allows disabling both `logger` and `console` logging via configuration

 - retains proper file and line number reporting

 - adds styles to visually indicate the log level on the browser console

 - retire helpers.js `logDebug` and `logError` in favor of logger.js