### PR TITLE
update TravisCI to run yarn in node 8 (drop node 6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
-script: npm run build
+script: yarn run build
 node_js:
- - "6"
  - "8"


### PR DESCRIPTION
Current version of patternfly don't like node6, and since ovirt builds with node8, it doesn't make sense to retain node6 CI builds in travis any longer.

Also swapped from npm to yarn for the build to match what we're doing locally and in packaging.