### PR TITLE
refine BaseCard event handlers and children render

### DIFF
--- a/src/components/VmDetails/GridComponents.js
+++ b/src/components/VmDetails/GridComponents.js
@@ -9,7 +9,7 @@ import styles from './style.css'
  */
 const Grid = ({ className = '', children, ...props }) => {
   const cn = `${styles['grid-container']} ${className}`
-  return <div className={cn} {...props}>{children}</div>
+  return <div className={cn}>{children}</div>
 }
 Grid.propTypes = {
   children: PropTypes.node.isRequired,
@@ -18,7 +18,7 @@ Grid.propTypes = {
 
 const Row = ({ className = '', children, ...props }) => {
   const cn = `${styles['grid-row']} ${className}`
-  return <div className={cn} {...props}>{children}</div>
+  return <div className={cn}>{children}</div>
 }
 Row.propTypes = {
   children: PropTypes.node.isRequired,
@@ -37,7 +37,6 @@ const Col = ({ className = '', cols = -1, style, children, content = 'expand', .
       column-content={content}
       className={cn}
       style={{ ...col, ...style }}
-      {...props}
     >
       {children}
     </div>


### PR DESCRIPTION
Based on work in #691 and #700, refine the `BaseCard`:

  - better description of the component in the class comment

  - event handlers are defined functions bound to `this` in the
    constructor, matching the style in the rest of the app

  - children are rendered as a function, element or any other
    node type via `renderChildren`

  - update components in **GridComponent.js** so they don't blindly pass props to a `div` tag and cause React errors