### PR TITLE
fix webpack prod config for 'ovirtapi' alias, adjust imports

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -69,7 +69,7 @@ module.exports = {
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
-      'ovirtapi': './ovirtapi'
+      'ovirtapi': `${paths.appSrc}/ovirtapi/index.js`
     },
   },
   // Resolve loaders (webpack plugins for CSS, images, transpilation) from the

--- a/src/components/NewDiskDialog/sagas.js
+++ b/src/components/NewDiskDialog/sagas.js
@@ -1,7 +1,7 @@
 import { takeEvery, put } from 'redux-saga/effects'
 
 import { CREATE_DISK_FOR_VM } from './constants'
-import Api from '../../ovirtapi'
+import Api from 'ovirtapi'
 import { callExternalAction } from '../../saga/utils'
 import { fetchDisks } from '../../sagas'
 import {

--- a/src/components/OptionsDialog/sagas.js
+++ b/src/components/OptionsDialog/sagas.js
@@ -1,7 +1,7 @@
 import { put, takeEvery } from 'redux-saga/effects'
 import { SAVE_SSH_KEY, GET_SSH_KEY } from './constants'
 import { setSSHKey, setUnloaded } from './actions'
-import Api from '../../ovirtapi'
+import Api from 'ovirtapi'
 
 function* saveSSHKey (sagas, action) {
   yield sagas.callExternalAction('saveSSHKey', Api.saveSSHKey, action)

--- a/src/components/VmDisks/sagas.js
+++ b/src/components/VmDisks/sagas.js
@@ -1,7 +1,7 @@
 import { takeEvery, put } from 'redux-saga/effects'
 
 import { REMOVE_DISK } from './constants'
-import Api from '../../ovirtapi'
+import Api from 'ovirtapi'
 import { callExternalAction, delay } from '../../saga/utils'
 import { fetchDisks } from '../../sagas'
 import { addDiskRemovalPendingTask, removeDiskRemovalPendingTask } from '../../actions'

--- a/src/components/VmSnapshots/sagas.js
+++ b/src/components/VmSnapshots/sagas.js
@@ -1,7 +1,7 @@
 import { takeEvery, put } from 'redux-saga/effects'
 
 import { ADD_VM_SNAPSHOT, DELETE_VM_SNAPSHOT, RESTORE_VM_SNAPSHOT } from './constants'
-import Api from '../../ovirtapi'
+import Api from 'ovirtapi'
 import { callExternalAction, delay } from '../../saga/utils'
 import { fetchVmSnapshots, startProgress, stopProgress } from '../../sagas'
 import { addSnapshotRemovalPendingTask, removeSnapshotRemovalPendingTask } from '../../actions'

--- a/src/saga/console/index.js
+++ b/src/saga/console/index.js
@@ -1,6 +1,6 @@
 import { put } from 'redux-saga/effects'
 
-import Api from '../../ovirtapi'
+import Api from 'ovirtapi'
 import Selectors from '../../selectors'
 import OptionsManager from '../../optionsManager'
 import logger from '../../logger'

--- a/src/saga/login.js
+++ b/src/saga/login.js
@@ -1,5 +1,5 @@
 import Product from '../version'
-import Api from '../ovirtapi'
+import Api from 'ovirtapi'
 import AppConfiguration from '../config'
 import OptionsManager from '../optionsManager'
 import Selectors from '../selectors'


### PR DESCRIPTION
In #679, the path for the `import Api from 'ovirtapi'` webpack alias changed.  In #691, a saga was changed to use the `ovirtapi` alias instead of the direct path to the file.  These two occurrences together will cause production builds to fail when a non root js imports `ovirtapi` via the alias .

  - updated the webpack prod config to use the same alias path as in the dev config

  - updated all imports of `ovirtapi` to use the alias