### PR TITLE
make legacy view the default when clicking a vm

### DIFF
--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -5,16 +5,15 @@ import { connect } from 'react-redux'
 import { RouterPropTypeShapes } from '../../propTypeShapes'
 import VmActions from '../VmActions'
 
-const VmDetailToolbar = ({ match, vms, includeLegacyDetails = false }) => {
+const VmDetailToolbar = ({ match, vms }) => {
   if (vms.getIn(['vms', match.params.id])) {
-    return (<VmActions vm={vms.getIn(['vms', match.params.id])} includeLegacyDetails={includeLegacyDetails} />)
+    return (<VmActions vm={vms.getIn(['vms', match.params.id])} />)
   }
   return null
 }
 
 VmDetailToolbar.propTypes = {
   vms: PropTypes.object.isRequired,
-  includeLegacyDetails: PropTypes.bool,
 
   match: RouterPropTypeShapes.match.isRequired,
 }

--- a/src/components/VmActions/index.js
+++ b/src/components/VmActions/index.js
@@ -196,7 +196,6 @@ class VmActions extends React.Component {
       pool,
       isOnCard = false,
       onRemove,
-      includeLegacyDetails = false,
       location,
     } = this.props
 
@@ -245,24 +244,25 @@ class VmActions extends React.Component {
         {actions.map(action => <ActionButtonWraper key={action.id} {...action} />)}
 
         <span className={style['button-spacer']} />
-        {includeLegacyDetails && (
+
+        {location && /vm-legacy/.test(location.pathname) && (
           <LinkButton
             isOnCard={isOnCard}
-            shortTitle='Legacy View'
-            tooltip='Legacy View'
-            to={`/vm-legacy/${vm.get('id')}`}
+            shortTitle='Dashboard View'
+            tooltip='Dashboard View'
+            to={`/vm/${vm.get('id')}`}
             button='btn btn-default'
             className={`pficon pficon-edit ${style['action-link']}`}
             id={`action-${vm.get('name')}-edit`}
           />
         )}
 
-        {location && /vm-legacy/.test(location.pathname) && (
+        {location && /vm\//.test(location.pathname) && (
           <LinkButton
             isOnCard={isOnCard}
-            shortTitle='View'
-            tooltip='View'
-            to={`/vm/${vm.get('id')}`}
+            shortTitle='Normal View'
+            tooltip='Normal View'
+            to={`/vm-legacy/${vm.get('id')}`}
             button='btn btn-default'
             className={`pficon pficon-edit ${style['action-link']}`}
             id={`action-${vm.get('name')}-edit`}
@@ -296,7 +296,6 @@ VmActions.propTypes = {
   vm: PropTypes.object.isRequired,
   pool: PropTypes.object,
   isOnCard: PropTypes.bool,
-  includeLegacyDetails: PropTypes.bool,
 
   location: RouterPropTypeShapes.location.isRequired,
 

--- a/src/components/VmsList/Vm.js
+++ b/src/components/VmsList/Vm.js
@@ -34,14 +34,14 @@ const Vm = ({ vm, icons, os, onStart }) => {
         </div>
         <div className='card-pf-body'>
           <div className={`card-pf-top-element ${style['card-icon']}`}>
-            <Link to={`/vm/${vm.get('id')}`}>
+            <Link to={`/vm-legacy/${vm.get('id')}`}>
               <VmIcon icon={icon} className={style['card-pf-icon']}
                 missingIconClassName='fa fa-birthday-cake card-pf-icon-circle' />
             </Link>
           </div>
 
           <h2 className={`card-pf-title text-center ${style['status-height']}`}>
-            <Link to={`/vm/${vm.get('id')}`} className={style['vm-detail-link']}>
+            <Link to={`/vm-legacy/${vm.get('id')}`} className={style['vm-detail-link']}>
               <p className={`${style['vm-name']} ${style['crop']}`} title={vm.get('name')} data-toggle='tooltip' id={`${idPrefix}-name`}>
                 {vm.get('name')}
               </p>

--- a/src/routes.js
+++ b/src/routes.js
@@ -43,7 +43,7 @@ export default function getRoutes (vms) {
         path: '/vm/:id',
         title: (match, vms) => vms.getIn(['vms', match.params.id, 'name']) || match.params.id,
         component: VmDetailsPage,
-        toolbars: [(match) => (<VmDetailToolbar match={match} key='vmaction' includeLegacyDetails />)],
+        toolbars: [(match) => (<VmDetailToolbar match={match} key='vmaction' />)],
         routes: [
           {
             path: '/vm/:id/edit',


### PR DESCRIPTION
- Make the legacy view the default view instead of the work-in-progress
  dashboard view when clicking a vm.
- Relabel the buttons to switch back and forth - "Normal view" and
  "Dashboard view"

Fixes #751