### PR TITLE
ux-redesign: VM Details > Nics Card (view only)

### DIFF
--- a/src/components/VmDetails/cards/NicsCard.css
+++ b/src/components/VmDetails/cards/NicsCard.css
@@ -1,0 +1,11 @@
+.nics-container {
+  width: auto;
+  margin-left: -15px; /* max is -20px to edge of the containing card */
+  margin-right: -15px;
+}
+
+.ip4-container,
+.ip6-container {
+  font-size: 0.7em;
+  padding: 0 10px;
+}

--- a/src/components/VmDetails/cards/NicsCard.js
+++ b/src/components/VmDetails/cards/NicsCard.js
@@ -1,13 +1,35 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
 
 import BaseCard from '../BaseCard'
-import style from '../style.css'
+import { Grid, Row, Col } from '../GridComponents'
+
+import style from './NicsCard.css'
 
 /**
  * List of NICs connected to a VM
  */
-const NicsCard = ({ vm, onEditChange }) => {
+const NicsCard = ({ vm, vnicProfiles, onEditChange }) => {
+  const nicList = vm.get('nics')
+    .sort((a, b) => a.get('name').localeCompare(b.get('name')))
+    .map(nic => ({
+      id: nic.get('id'),
+      name: nic.get('name'),
+      plugged: nic.get('plugged'),
+      ipv4: nic.get('ipv4').toJS(),
+      ipv6: nic.get('ipv6').toJS(),
+      vnicProfile: {
+        id: nic.getIn(['vnicProfile', 'id']),
+        name: vnicProfiles.getIn([nic.getIn(['vnicProfile', 'id']), 'name']),
+        network: vnicProfiles.getIn([nic.getIn(['vnicProfile', 'id']), 'network', 'name']),
+      },
+    }))
+    .toJS()
+
+  const ip4Label = 'IPv4'
+  const ip6Label = 'IPv6'
+
   return (
     <BaseCard
       icon={{ type: 'pf', name: 'network' }}
@@ -18,25 +40,49 @@ const NicsCard = ({ vm, onEditChange }) => {
       onCancel={() => { onEditChange(false) }}
       onSave={() => { onEditChange(false) }}
     >
-      {({ isEditing }) => {
-        return (
-          <div>
-            <p className={style['demo-text']}>
-              NICs for {vm.get('name')}
-            </p>
-
-            {isEditing && (
-              <p className={style['demo-text']}>EDITING</p>
-            )}
-          </div>
-        )
-      }}
+      {({ isEditing }) =>
+        <Grid className={style['nics-container']}>
+          {nicList.map(nic =>
+            <Row key={nic.id}>
+              <Col style={{ display: 'block' }}>
+                <div>
+                  <span>{nic.name}</span>
+                  <span>&nbsp;({nic.vnicProfile.name}/{nic.vnicProfile.network})</span>
+                </div>
+                <Grid>
+                  <Row>
+                    <Col cols={6} className={style['ip4-container']}>
+                      { nic.ipv4.length > 0 &&
+                        <div>
+                          {nic.ipv4.map(ip4 => <div key={`${nic.id}-${ip4}`}>{ip4Label}: {ip4}</div>)}
+                        </div>
+                      }
+                    </Col>
+                    <Col cols={6} className={style['ip6-container']}>
+                      { nic.ipv6.length > 0 &&
+                        <div>
+                          {nic.ipv6.map(ip6 => <div key={`${nic.id}-${ip6}`}>{ip6Label}: {ip6}</div>)}
+                        </div>
+                      }
+                    </Col>
+                  </Row>
+                </Grid>
+              </Col>
+            </Row>
+          )}
+        </Grid>
+      }
     </BaseCard>
   )
 }
 NicsCard.propTypes = {
   vm: PropTypes.object.isRequired,
+  vnicProfiles: PropTypes.object.isRequired,
   onEditChange: PropTypes.func.isRequired,
 }
 
-export default NicsCard
+export default connect(
+  (state) => ({
+    vnicProfiles: state.vnicProfiles,
+  })
+)(NicsCard)

--- a/src/components/VmDetails/cards/NicsCard/index.js
+++ b/src/components/VmDetails/cards/NicsCard/index.js
@@ -2,10 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
-import BaseCard from '../BaseCard'
-import { Grid, Row, Col } from '../GridComponents'
+import BaseCard from '../../BaseCard'
+import { Grid, Row, Col } from '../../GridComponents'
 
-import style from './NicsCard.css'
+import style from './style.css'
 
 /**
  * List of NICs connected to a VM
@@ -35,6 +35,7 @@ const NicsCard = ({ vm, vnicProfiles, onEditChange }) => {
       icon={{ type: 'pf', name: 'network' }}
       title='Network Interfaces'
       editTooltip={`Edit NICs for ${vm.get('id')}`}
+      editable={false}
       itemCount={vm.get('nics').size}
       onStartEdit={() => { onEditChange(true) }}
       onCancel={() => { onEditChange(false) }}
@@ -47,7 +48,7 @@ const NicsCard = ({ vm, vnicProfiles, onEditChange }) => {
               <Col style={{ display: 'block' }}>
                 <div>
                   <span>{nic.name}</span>
-                  <span>&nbsp;({nic.vnicProfile.name}/{nic.vnicProfile.network})</span>
+                  <span className={style['vnic-info']}>({nic.vnicProfile.name}/{nic.vnicProfile.network})</span>
                 </div>
                 <Grid>
                   <Row>

--- a/src/components/VmDetails/cards/NicsCard/style.css
+++ b/src/components/VmDetails/cards/NicsCard/style.css
@@ -4,6 +4,10 @@
   margin-right: -15px;
 }
 
+.vnic-info {
+  padding-left: 5px;
+}
+
 .ip4-container,
 .ip6-container {
   font-size: 0.7em;

--- a/src/ovirtapi/index.js
+++ b/src/ovirtapi/index.js
@@ -165,7 +165,7 @@ const OvirtApi = {
     return httpGet({ url })
   },
 
-  addNewVm ({ vm, transformInput = false }: { vm: Object, transformInput?: boolean }): Promise<Object> {
+  addNewVm ({ vm, transformInput = false }: { vm: VmType | Object, transformInput: boolean }): Promise<Object> {
     assertLogin({ methodName: 'addNewVm' })
     const input = JSON.stringify(transformInput ? OvirtApi.internalVmToOvirt({ vm }) : vm)
     logger.log(`OvirtApi.addNewVm(): ${input}`)
@@ -175,7 +175,7 @@ const OvirtApi = {
       input,
     })
   },
-  editVm ({ vm, transformInput = false }: { vm: Object, transformInput?: boolean }): Promise<Object> {
+  editVm ({ vm, transformInput = false }: { vm: VmType | Object, transformInput: boolean }): Promise<Object> {
     assertLogin({ methodName: 'editVm' })
     const input = JSON.stringify(transformInput ? OvirtApi.internalVmToOvirt({ vm }) : vm)
     logger.log(`OvirtApi.editVm(): ${input}`)

--- a/src/ovirtapi/index.js
+++ b/src/ovirtapi/index.js
@@ -2,6 +2,8 @@
 import type {
   CdRomType, ApiCdRomType,
   SnapshotType, ApiSnapshotType,
+  NicType,
+  VmType, ApiVmType,
 } from './types'
 
 import logger from '../logger'
@@ -21,7 +23,6 @@ import * as Transforms from './transform'
 
 type VmIdType = { vmId: string }
 type PoolIdType = { poolId: string }
-type VmType = { vm: Object, transformInput?: boolean }
 
 const zeroUUID: string = '00000000-0000-0000-0000-000000000000'
 
@@ -33,7 +34,7 @@ const OvirtApi = {
   // ---- Data transform functions (API -> internal, internal -> API)
   //
   //
-  vmToInternal ({ vm, getSubResources = false }: { vm: Object, getSubResources: boolean }): Object {
+  vmToInternal ({ vm, getSubResources = false }: { vm: ApiVmType, getSubResources: boolean }): VmType {
     return Transforms.VM.toInternal({ vm, includeSubResources: getSubResources })
   },
 
@@ -164,7 +165,7 @@ const OvirtApi = {
     return httpGet({ url })
   },
 
-  addNewVm ({ vm, transformInput = false }: VmType): Promise<Object> {
+  addNewVm ({ vm, transformInput = false }: { vm: Object, transformInput?: boolean }): Promise<Object> {
     assertLogin({ methodName: 'addNewVm' })
     const input = JSON.stringify(transformInput ? OvirtApi.internalVmToOvirt({ vm }) : vm)
     logger.log(`OvirtApi.addNewVm(): ${input}`)
@@ -174,7 +175,7 @@ const OvirtApi = {
       input,
     })
   },
-  editVm ({ vm, transformInput = false }: VmType): Promise<Object> {
+  editVm ({ vm, transformInput = false }: { vm: Object, transformInput?: boolean }): Promise<Object> {
     assertLogin({ methodName: 'editVm' })
     const input = JSON.stringify(transformInput ? OvirtApi.internalVmToOvirt({ vm }) : vm)
     logger.log(`OvirtApi.editVm(): ${input}`)
@@ -325,7 +326,7 @@ const OvirtApi = {
     })
   },
 
-  addNicToVm ({ nic, vmId }: { nic: Object, vmId: string }): Promise<Object> {
+  addNicToVm ({ nic, vmId }: { nic: NicType, vmId: string }): Promise<Object> {
     assertLogin({ methodName: 'addNicToVm' })
     const input = JSON.stringify(OvirtApi.internalNicToOvirt({ nic }))
     logger.log(`OvirtApi.addNicToVm(): ${input}`)

--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -472,9 +472,21 @@ const Cluster = {
 //
 const Nic = {
   toInternal ({ nic }: { nic: ApiNicType }): NicType {
+    const ips = (
+      nic.reported_devices &&
+      nic.reported_devices.reported_device &&
+      nic.reported_devices.reported_device.map(device => device.ips.ip).reduce((ips, ipArray) => [...ipArray, ...ips], [])
+    ) || []
+
     return {
       id: nic.id,
       name: nic.name,
+      mac: nic.mac.address,
+      plugged: convertBool(nic.plugged),
+      ips,
+      ipv4: ips.filter(ip => ip.version === 'v4').map(rec => rec.address),
+      ipv6: ips.filter(ip => ip.version === 'v6').map(rec => rec.address),
+
       vnicProfile: {
         id: nic.vnic_profile ? nic.vnic_profile.id : null,
       },

--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -472,11 +472,12 @@ const Cluster = {
 //
 const Nic = {
   toInternal ({ nic }: { nic: ApiNicType }): NicType {
-    const ips = (
-      nic.reported_devices &&
-      nic.reported_devices.reported_device &&
-      nic.reported_devices.reported_device.map(device => device.ips.ip).reduce((ips, ipArray) => [...ipArray, ...ips], [])
-    ) || []
+    const ips =
+      nic.reported_devices && nic.reported_devices.reported_device
+        ? nic.reported_devices.reported_device
+          .map(device => device.ips.ip)
+          .reduce((ips, ipArray) => [...ipArray, ...ips], [])
+        : []
 
     return {
       id: nic.id,

--- a/src/ovirtapi/types.js
+++ b/src/ovirtapi/types.js
@@ -89,7 +89,21 @@ export type ApiClusterType = Object
 export type ClusterType = Object
 
 export type ApiNicType = Object
-export type NicType = Object
+export type NicType = {
+  id: string,
+  name: string,
+  mac: string,
+  plugged: boolean,
+  ips: Array<{
+    address: string,
+    version: 'v4' | 'v6'
+  }>,
+  ipv4: Array<string>,
+  ipv6: Array<string>,
+  vnicProfile: {
+    id: string | null
+  }
+}
 
 export type ApiVnicProfileType = Object
 export type VnicProfileType = Object


### PR DESCRIPTION
View only portion of #757

API changes:
  - Add API &rarr; internal transforms to capture more info about NICs
  - Add better api typing, mostly Nic based

Nic Card changes:
  - each Nic is listed on the card
  - the IPv4 and IPv6 addresses are shown below each Nic

Note: There may be a render issue when there are >4 Nics. The nic list may overflow the card. Not quite sure why yet.