### PR TITLE
Utilization card > Disk chart to show no data if no Disks are attached

### DIFF
--- a/src/components/VmDetails/cards/UtilizationCard/DiskCharts.js
+++ b/src/components/VmDetails/cards/UtilizationCard/DiskCharts.js
@@ -18,6 +18,8 @@ import { round } from '../../../../utils/round'
 
 import style from './style.css'
 
+import NoLiveData from './NoLiveData'
+
 /*
  * Disks, but intended to be in terms of guest agent reported data (file system viewpoint),
  * not in terms of storage allocation (infrastructure viewpoint - like dashboard/webadmin).
@@ -26,6 +28,8 @@ import style from './style.css'
  *       via REST. Storage allocation is being used instead.
  */
 const DiskCharts = ({ vm, isRunning, ...props }) => {
+  const hasDisks = vm.get('disks').size > 0
+
   let actualSize = 0
   let provisionedSize = 0
 
@@ -43,34 +47,41 @@ const DiskCharts = ({ vm, isRunning, ...props }) => {
     <UtilizationCard className={style['chart-card']}>
       <CardTitle>Disk <span style={{ fontSize: '55%', verticalAlign: 'super' }}>(storage allocations)</span></CardTitle>
       <CardBody>
-        <UtilizationCardDetails>
-          <UtilizationCardDetailsCount>{available}</UtilizationCardDetailsCount>
-          <UtilizationCardDetailsDesc>
-            <UtilizationCardDetailsLine1>Available</UtilizationCardDetailsLine1>
-            <UtilizationCardDetailsLine2>of {total} {unit} Provisioned</UtilizationCardDetailsLine2>
-          </UtilizationCardDetailsDesc>
-        </UtilizationCardDetails>
+        { !hasDisks &&
+          <NoLiveData message='This VM has no attached disks.' />
+        }
+        { hasDisks &&
+        <React.Fragment>
+          <UtilizationCardDetails>
+            <UtilizationCardDetailsCount>{available}</UtilizationCardDetailsCount>
+            <UtilizationCardDetailsDesc>
+              <UtilizationCardDetailsLine1>Available</UtilizationCardDetailsLine1>
+              <UtilizationCardDetailsLine2>of {total} {unit} Provisioned</UtilizationCardDetailsLine2>
+            </UtilizationCardDetailsDesc>
+          </UtilizationCardDetails>
 
-        <DonutChart
-          id='donut-chart-disk'
-          data={{
-            columns: [
-              [`${unit} allocated`, used],
-              [`${unit} unallocated`, available],
-            ],
-            order: null,
-          }}
-          title={{
-            primary: `${used}`,
-            secondary: `${unit} Allocated`,
-          }}
-          tooltip={{
-            show: true,
-            contents: patternfly.pfDonutTooltipContents,
-          }}
-        />
+          <DonutChart
+            id='donut-chart-disk'
+            data={{
+              columns: [
+                [`${unit} allocated`, used],
+                [`${unit} unallocated`, available],
+              ],
+              order: null,
+            }}
+            title={{
+              primary: `${used}`,
+              secondary: `${unit} Allocated`,
+            }}
+            tooltip={{
+              show: true,
+              contents: patternfly.pfDonutTooltipContents,
+            }}
+          />
 
-        {/* Disks don't have historic data */}
+          {/* Disks don't have historic data */}
+        </React.Fragment>
+        }
       </CardBody>
     </UtilizationCard>
   )


### PR DESCRIPTION
Fixes #773

If a VM has no attached disks, the Disk chart on the utilization card still displays.

This change will display an "No Data Available" place holder instead:
![screenshot-localhost-3000-2018 09 13-12-15-53](https://user-images.githubusercontent.com/3985964/45501588-9f6fbe00-b74f-11e8-8346-7549dce96c0a.png)
