### PR TITLE
allow VM list card popover content to overflow the card container

### DIFF
--- a/src/components/ScrollPositionHistory.js
+++ b/src/components/ScrollPositionHistory.js
@@ -3,32 +3,37 @@ import PropTypes from 'prop-types'
 
 import { loadFromSessionStorage, saveToSessionStorage } from '../storage'
 
+/*
+ * NOTE: On a page reload, if the scroll position was quite high (the user scrolled
+ *       down quite far), that scroll position will not be available until multiple
+ *       pages of VMs are loaded.  So instead the user will be scrolled to the place
+ *       where the last current loaded VM is rendered.
+ */
 class ScrollPositionHistory extends React.Component {
   componentDidMount () {
-    const { uniquePrefix } = this.props
+    const { uniquePrefix, scrollContainerSelector } = this.props
 
     const scrollTop = loadFromSessionStorage(`${uniquePrefix}-scroll-top`) || 0
-
-    // So far, main browser's window is used for scrolling
-    window.document.querySelector('#page-router-render-component').scrollTop = scrollTop
+    window.document.querySelector(scrollContainerSelector).scrollTop = scrollTop
   }
 
   componentWillUnmount () {
-    const { uniquePrefix } = this.props
+    const { uniquePrefix, scrollContainerSelector } = this.props
 
-    const scrollTop = window.document.querySelector('#page-router-render-component').scrollTop
+    const scrollTop = window.document.querySelector(scrollContainerSelector).scrollTop
     saveToSessionStorage(`${uniquePrefix}-scroll-top`, '' + scrollTop)
   }
 
   render () {
     return (
-      <div>
+      <React.Fragment>
         {this.props.children}
-      </div>
+      </React.Fragment>
     )
   }
 }
 ScrollPositionHistory.propTypes = {
+  scrollContainerSelector: PropTypes.string.isRequired,
   uniquePrefix: PropTypes.string.isRequired,
   children: PropTypes.any,
 }

--- a/src/components/VmsList/Vms.js
+++ b/src/components/VmsList/Vms.js
@@ -51,7 +51,7 @@ class Vms extends React.Component {
         useWindow={false}
       >
         <ScrollPositionHistory uniquePrefix='vms-list' scrollContainerSelector='#page-router-render-component'>
-          <div className={`container-fluid container-cards-pf ${style['vm-card-list-container']}`}>
+          <div className={`container-fluid container-cards-pf`}>
             <div className={style['scrollingWrapper']}>
               <div className='row row-cards-pf'>
                 {sortedVms.map(vm => <Vm vm={vm} key={vm.get('id')} />)}

--- a/src/components/VmsList/Vms.js
+++ b/src/components/VmsList/Vms.js
@@ -50,19 +50,17 @@ class Vms extends React.Component {
         loader={<div key='infinite-scroll-loader' className={style['loaderBox']}><div className={style['loader']} /></div>}
         useWindow={false}
       >
-        <div>
-          <ScrollPositionHistory uniquePrefix='vms-list'>
-            <div className={`container-fluid container-cards-pf ${style['movable-left']} ${style['full-window']}`}>
-              <div className={style['scrollingWrapper']}>
-                <div className='row row-cards-pf'>
-                  {sortedVms.map(vm => <Vm vm={vm} key={vm.get('id')} />)}
-                  {sortedPools.map(pool => <Pool pool={pool} key={pool.get('id')} />)}
-                </div>
-                <div className={style['overlay']} />
+        <ScrollPositionHistory uniquePrefix='vms-list' scrollContainerSelector='#page-router-render-component'>
+          <div className={`container-fluid container-cards-pf ${style['vm-card-list-container']}`}>
+            <div className={style['scrollingWrapper']}>
+              <div className='row row-cards-pf'>
+                {sortedVms.map(vm => <Vm vm={vm} key={vm.get('id')} />)}
+                {sortedPools.map(pool => <Pool pool={pool} key={pool.get('id')} />)}
               </div>
+              <div className={style['overlay']} />
             </div>
-          </ScrollPositionHistory>
-        </div>
+          </div>
+        </ScrollPositionHistory>
       </InfiniteScroll>
     )
   }

--- a/src/components/VmsList/style.css
+++ b/src/components/VmsList/style.css
@@ -1,15 +1,7 @@
-.movable-left { /* general transition properties */
+.vm-card-list-container { /* general transition properties */
     transition: all 0.6s;
     transform-origin: 0 50%;
     transition-timing-function: ease-out;
-
-    overflow: auto;
-/*    height: calc(100vh - 49px);*/
-}
-
-.moved-left { /* altered state */
-    transform: perspective(1000px) rotateY(50deg);
-    overflow: hidden; /* scrolling disabled */
 }
 
 .card-pf-icon {
@@ -40,11 +32,6 @@
     opacity: 0;
     background-color: lightgrey;
     display: none;
-}
-
-.moved-left .overlay {
-    display: block;
-    opacity: 0.4;
 }
 
 .vm-name {

--- a/src/components/VmsList/style.css
+++ b/src/components/VmsList/style.css
@@ -1,9 +1,3 @@
-.vm-card-list-container { /* general transition properties */
-    transition: all 0.6s;
-    transform-origin: 0 50%;
-    transition-timing-function: ease-out;
-}
-
 .card-pf-icon {
     overflow: hidden;
     display: block;


### PR DESCRIPTION
 - fixes #721 by making sure the `div` wrapping the card list grid is the direct child of `#page-router-render-component` therefore picking up the CSS rule `#page-router-render-component > *:last-child` and expanding its height

 - reduced unnecessary `div` wrappers, using `Fragment` as necessary

 - pushed `scrollContainer` config up from `ScrollPositionHistory` to `Vms`

 - removed old CSS classes from **VmsList** that have no current effect

----
![screenshot-localhost-3000-2018 09 13-12-37-28](https://user-images.githubusercontent.com/3985964/45502378-d5ae3d00-b751-11e8-8b14-ef0c8f944336.png)
