### PR TITLE
Nics Card > detect if no nics are attached and show 'no nics' message

### DIFF
--- a/src/components/VmDetails/cards/NicsCard/index.js
+++ b/src/components/VmDetails/cards/NicsCard/index.js
@@ -2,6 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
+import { msg } from '../../../../intl'
+
 import BaseCard from '../../BaseCard'
 import { Grid, Row, Col } from '../../GridComponents'
 
@@ -41,7 +43,11 @@ const NicsCard = ({ vm, vnicProfiles, onEditChange }) => {
       onCancel={() => { onEditChange(false) }}
       onSave={() => { onEditChange(false) }}
     >
-      {({ isEditing }) =>
+      {({ isEditing }) => <React.Fragment>
+        { nicList.length === 0 &&
+          <div className={style['no-nics']}>{msg.noNics()}</div>
+        }
+        { nicList.length > 0 &&
         <Grid className={style['nics-container']}>
           {nicList.map(nic =>
             <Row key={nic.id}>
@@ -72,7 +78,8 @@ const NicsCard = ({ vm, vnicProfiles, onEditChange }) => {
             </Row>
           )}
         </Grid>
-      }
+        }
+      </React.Fragment>}
     </BaseCard>
   )
 }

--- a/src/components/VmDetails/cards/NicsCard/style.css
+++ b/src/components/VmDetails/cards/NicsCard/style.css
@@ -4,6 +4,12 @@
   margin-right: -15px;
 }
 
+.no-nics {
+  font-style: italic;
+  text-align: center;
+  color: rgba(0, 0, 0, 0.65);
+}
+
 .vnic-info {
   padding-left: 5px;
 }


### PR DESCRIPTION
Detect if no NICs are attached to a VM.  If none are attached, display a message (the same message as used on the legacy details page)

![screenshot-localhost-3000-2018 09 21-02-49-04](https://user-images.githubusercontent.com/3985964/45864718-ec9ff100-bd48-11e8-9c8f-04d7084e023c.png)
