### PR TITLE
Setup /pool/123 to use the LegacyVmDetails page

### DIFF
--- a/src/components/Pages/index.js
+++ b/src/components/Pages/index.js
@@ -156,7 +156,7 @@ class PoolDetailsPage extends React.Component {
 
     if (poolId && vms.getIn(['pools', poolId, 'vm'])) {
       // TODO: ux-redesign VmDetails will need to also handle viewing a Pool / Pool (template)? VM
-      return (<VmDetails vm={vms.getIn(['pools', poolId, 'vm'])} pool={vms.getIn(['pools', poolId])} />)
+      return (<LegacyVmDetails vm={vms.getIn(['pools', poolId, 'vm'])} pool={vms.getIn(['pools', poolId])} />)
     }
 
     // TODO: Add handling for if the fetch runs but fails (FETCH-FAIL), see issue #631


### PR DESCRIPTION
When adding back the legacy view/edit pages for VMs, we overlooked
the pool view page.  It was attempting to use the new VM Details
dashboard page and failing.  This change sets up /pool to use its
original page component.

Fixes #781 