### PR TITLE
Fix use of VmNics in VmDetail such that Nic operations work again

### DIFF
--- a/src/components/VmDetail/index.js
+++ b/src/components/VmDetail/index.js
@@ -239,7 +239,9 @@ class VmDetail extends Component {
                   </dt>
                   {noDisks}
                   {disksElement}
-                  <VmNics nics={nics} vmId={vm.get('id')} enableSettings={notPoolOrPoolVm} />
+
+                  <VmNics nics={nics} vm={vm} enableSettings={notPoolOrPoolVm} />
+
                   <dt>
                     <FieldHelp content={msg.bootMenuTooltip()} text={msg.bootMenu()} />
                   </dt>


### PR DESCRIPTION
  PR #573 introduced a change to pass the VM id instead of the VM
  object itself.  `VmNics` is setup to use VM objects and the
  change broke the add and delete actions.  The minimum change
  to get things working was done.

Fixes [BZ1631149](https://bugzilla.redhat.com/show_bug.cgi?id=1631149)