### PR TITLE
OverviewCard: update to use DetailsCard change/onSave handling

### DIFF
--- a/src/components/VmDetails/cards/OverviewCard/index.js
+++ b/src/components/VmDetails/cards/OverviewCard/index.js
@@ -142,7 +142,6 @@ class OverviewCard extends React.Component {
     //     saveChanges will add the result of the operation to the vm under the given
     //     correlationId. So, when the vm prop changes, it can be checked and the edit
     //     mode controlled based on the result of the dispatch/saga/api call.
-    console.info('saving changes to VM', vmUpdates.id, ', updates:', vmUpdates)
     this.setState({ correlationId })
     this.props.saveChanges(vmUpdates, correlationId)
 
@@ -167,7 +166,9 @@ class OverviewCard extends React.Component {
         {({ isEditing }) => {
           return (
             <div>
-              <div className={`${sharedStyle['operating-system-label']} ${style['operating-system-label']}`}>{getOsHumanName(vm.getIn(['os', 'type']))}</div>
+              <div className={`${sharedStyle['operating-system-label']} ${style['operating-system-label']}`}>
+                {getOsHumanName(vm.getIn(['os', 'type']))}
+              </div>
 
               <Media>
                 <Media.Left>
@@ -208,7 +209,9 @@ class OverviewCard extends React.Component {
 
               { correlatedMessages && correlatedMessages.size > 0 &&
                 correlatedMessages.map((message, key) =>
-                  <Alert key={`user-message-${key}`} type='error' style={{ margin: '5px 0 0 0' }}>{message.get('message')}</Alert>
+                  <Alert key={`user-message-${key}`} type='error' style={{ margin: '5px 0 0 0' }}>
+                    {message.get('message')}
+                  </Alert>
                 )
               }
             </div>


### PR DESCRIPTION
After OverviewCard was developed and merged, some better techniques for managing VM edits were used in the DetailsCard #701.  This PR adopts the change handling and form style of the Details card to the OverviewCard.

There are no functional or visual changes to the card.