### PR TITLE
Fix bug with VM run once.

### DIFF
--- a/src/components/VmDetail/index.js
+++ b/src/components/VmDetail/index.js
@@ -248,7 +248,7 @@ class VmDetail extends Component {
                     <FieldHelp content={msg.bootSequenceTooltip()} text={msg.bootSequence()} />
                   </dt>
                   <dd />
-                  {vm.getIn(['os', 'bootDevices']).map((device, key) =>
+                  {vm.getIn(['os', 'bootDevices']).splice(2).map((device, key) =>
                     <React.Fragment key={key}>
                       <dt className={style['field-shifted']}>
                         <FieldHelp content={msg[`${sequence[key]}DeviceTooltip`]()} text={msg[`${sequence[key]}Device`]()} />


### PR DESCRIPTION
When run VM with `Run Once` and three bootable devices, legacy detail page will fail.

Fixes: https://github.com/oVirt/ovirt-web-ui/issues/788