### PR TITLE
adjust imports after src/utils.js moved to src/utils/index.js

### DIFF
--- a/src/components/VmDetails/cards/UtilizationCard/DiskCharts.js
+++ b/src/components/VmDetails/cards/UtilizationCard/DiskCharts.js
@@ -13,8 +13,7 @@ import {
   DonutChart,
 } from 'patternfly-react'
 
-import { convertValueMap } from '../../../../utils/storage-conversion'
-import { round } from '../../../../utils/round'
+import { convertValueMap, round } from '../../../../utils'
 
 import style from './style.css'
 

--- a/src/components/VmDetails/cards/UtilizationCard/MemoryCharts.js
+++ b/src/components/VmDetails/cards/UtilizationCard/MemoryCharts.js
@@ -14,8 +14,7 @@ import {
   SparklineChart,
 } from 'patternfly-react'
 
-import { convertValueMap } from '../../../../utils/storage-conversion'
-import { round } from '../../../../utils/round'
+import { convertValueMap, round } from '../../../../utils'
 
 import style from './style.css'
 


### PR DESCRIPTION
Note: Pulled this change out of #701 since it applied to Utilization card chart components.