### PR TITLE
backport bump Dockerfile nodejs version to 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6
+FROM node:8
 
 RUN apt-get update -qq && apt-get install -qy libelf1
 


### PR DESCRIPTION
bump Dockerfile nodejs version to 8 for patternfly yarn
build warning workaround (needs node > 8.9), and to align with
the node version used locally.
