### PR TITLE
ovirtapi: add and edit VM actions/sagas default transformInput true

### DIFF
--- a/src/actions/vm.js
+++ b/src/actions/vm.js
@@ -141,7 +141,7 @@ export function suspendVm ({ vmId }) {
   }
 }
 
-export function createVm ({ vm, transformInput = false, pushToDetailsOnSuccess = false }, { correlationId, ...additionalMeta }) {
+export function createVm ({ vm, transformInput = true, pushToDetailsOnSuccess = false }, { correlationId, ...additionalMeta }) {
   return {
     type: CREATE_VM,
     payload: {
@@ -157,7 +157,7 @@ export function createVm ({ vm, transformInput = false, pushToDetailsOnSuccess =
 }
 
 export function editVm (
-  { vm, transformInput = false, restartAfterEdit = false, nextRun = false },
+  { vm, transformInput = true, restartAfterEdit = false, nextRun = false },
   { correlationId, ...additionalMeta }
 ) {
   return {

--- a/src/components/VmDetails/cards/DetailsCard/index.js
+++ b/src/components/VmDetails/cards/DetailsCard/index.js
@@ -759,7 +759,7 @@ const DetailsCardConnected = connect(
   (dispatch) => ({
     saveChanges: (minimalVmChanges, restartAfterEdit, nextRun, correlationId) =>
       dispatch(Actions.editVm(
-        { vm: minimalVmChanges, transformInput: true, restartAfterEdit, nextRun },
+        { vm: minimalVmChanges, restartAfterEdit, nextRun },
         { correlationId }
       )),
   })

--- a/src/components/VmDialog/index.js
+++ b/src/components/VmDialog/index.js
@@ -801,7 +801,7 @@ export default connect(
     storages: state.storageDomains,
   }),
   (dispatch) => ({
-    addVm: (vm, correlationId) => dispatch(createVm({ vm, transformInput: true, pushToDetailsOnSuccess: true }, { correlationId })),
-    updateVm: (vm, correlationId) => dispatch(editVm({ vm, transformInput: true }, { correlationId })),
+    addVm: (vm, correlationId) => dispatch(createVm({ vm, pushToDetailsOnSuccess: true }, { correlationId })),
+    updateVm: (vm, correlationId) => dispatch(editVm({ vm }, { correlationId })),
   })
 )(VmDialog)

--- a/src/ovirtapi/index.js
+++ b/src/ovirtapi/index.js
@@ -178,7 +178,7 @@ const OvirtApi = {
     return httpGet({ url })
   },
 
-  addNewVm ({ vm, transformInput = false }: { vm: VmType | Object, transformInput: boolean }): Promise<Object> {
+  addNewVm ({ vm, transformInput = true }: { vm: VmType | Object, transformInput: boolean }): Promise<Object> {
     assertLogin({ methodName: 'addNewVm' })
     const input = JSON.stringify(transformInput ? OvirtApi.internalVmToOvirt({ vm }) : vm)
     logger.log(`OvirtApi.addNewVm(): ${input}`)
@@ -188,7 +188,7 @@ const OvirtApi = {
       input,
     })
   },
-  editVm ({ vm, nextRun = false, transformInput = false }: { vm: VmType | Object, nextRun: boolean, transformInput: boolean}): Promise<Object> {
+  editVm ({ vm, nextRun = false, transformInput = true }: { vm: VmType | Object, nextRun: boolean, transformInput: boolean}): Promise<Object> {
     assertLogin({ methodName: 'editVm' })
     const input = JSON.stringify(transformInput ? OvirtApi.internalVmToOvirt({ vm }) : vm)
     logger.log(`OvirtApi.editVm(): ${input}`, 'nextRun?', nextRun)


### PR DESCRIPTION
Since the VM.toApi() transform is now intelligent enough to handle a partial input, we can allow it to transform everything by default.

  - (legacy page) VmDialog dispatches updated to match the new default

  - DetailsCard dispatches updated to match the new default

  - OverviewCard doesn't need to be updated

  - createVm and editVm actions default _transformInput_ to true

  - addNewVm and editVm sagas default _transformInput_ to true