### PR TITLE
Update branding.js fetch() to include browser credentials

### DIFF
--- a/src/branding.js
+++ b/src/branding.js
@@ -22,7 +22,7 @@ export const resourcesUrls = {
 
 export function loadOnce (): Promise<void> {
   if (!loaded) {
-    loaded = fetch(resourcesUrls.fixedStrings)
+    loaded = fetch(resourcesUrls.fixedStrings, { credentials: 'include' })
       .then(body => body.json())
       .then(json => {
         fixedStrings = Object.freeze(json)


### PR DESCRIPTION
As per the Fetch API, credentials will not be sent by default with
the request [1].  By setting the _credentials_ flag to `include`
instead of the default `omit`, SSL client certificate authentication
will work [2].

[1] = https://fetch.spec.whatwg.org/#concept-request-credentials-mode
[2] = https://stackoverflow.com/questions/39417232/fetch-fails-in-firefox-with-ssl-client-authentication

Addresses [BZ1640048](https://bugzilla.redhat.com/show_bug.cgi?id=1640048)