### PR TITLE
automation: use PR's last commit's hash for filename

### DIFF
--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -18,7 +18,7 @@ rm -f ./*tar.gz
 version_release="$(grep -m1 VERSION_RELEASE configure.ac | cut -d ' ' -f2 | sed 's/[][)]//g')"
 if [[ "${version_release}" == "0" ]]; then
     date="$(date --utc +%Y%m%d)"
-    commit="$(git log -1 --pretty=format:%h)"
+    commit="$(git log --no-merges -1 --pretty=format:%h)"
     version_release="0.${date}git${commit}"
     # update configure.ac with this
     sed -i -r "s/define\(\[VERSION_RELEASE\], \[0\]\)/define([VERSION_RELEASE], [${version_release}])/" configure.ac


### PR DESCRIPTION
Snapshot rpms have a release of '0.${date}git${commit-hash}'
Previously, the commit hash was HEAD, but that was a merge commit hash.
Changed to use the actual last commit from the PR.