### PR TITLE
ovirtapi: fixed typo with getAllClusters follow url param

### DIFF
--- a/src/ovirtapi/index.js
+++ b/src/ovirtapi/index.js
@@ -154,7 +154,7 @@ const OvirtApi = {
   getAllClusters ({ additional }: { additional: Array<string> }): Promise<Object> {
     assertLogin({ methodName: 'getAllClusters' })
 
-    let follow = 'network'
+    let follow = 'networks'
     if (additional && additional.length > 0) {
       if (!additional.includes('networks')) {
         additional.push('networks')


### PR DESCRIPTION
Fix of a latent bug for when `ovirtapi.getAllClusters()` is called without `additional` params and the call is made with `follow=network` instead of `follow=networks`.

Most likely the cause of #851 when #813 is applied.

Fixes #851.