### PR TITLE
zanata: bump master to reference zanata version "1.5"

### DIFF
--- a/zanata.xml
+++ b/zanata.xml
@@ -2,7 +2,7 @@
 <config xmlns="http://zanata.org/namespace/config/">
     <url>https://translate.zanata.org/</url>
     <project>ovirt-web-ui</project>
-    <project-version>1.4.0</project-version>
+    <project-version>1.5</project-version>
     <project-type>gettext</project-type>
 
     <src-dir>extra/to-zanata</src-dir>


### PR DESCRIPTION
In preparation for the oVirt 4.3 translation cycle, bumped the zanata version to match the new version created in web-ui's Zanata project.

 - Zanata project: https://translate.zanata.org/project/view/ovirt-web-ui
 - new version: https://translate.zanata.org/iteration/view/ovirt-web-ui/1.5
