### PR TITLE
Move the core error messages above PageRouter

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,10 +50,10 @@ const App = ({ history, config, appReady }) => {
     <ConnectedRouter history={history}>
       <div id='app-container'>
         <VmsPageHeader title={fixedStrings.BRAND_NAME + ' ' + msg.vmPortal()} />
-        { appReady && renderRoutes(getRoutes()) }
-        <LoadingData />
         <OvirtApiCheckFailed />
         <TokenExpired />
+        { appReady && renderRoutes(getRoutes()) }
+        <LoadingData />
         <ToastNotifications />
       </div>
     </ConnectedRouter>


### PR DESCRIPTION
After the redesign layout upgrade, the error message (oVirt version
check and SSO token expiry) alerts were on the bottom of the page
and not always visible.  Moved the alerts above the page render so
they are always visible.

Fixes #513