### PR TITLE
Fix a broken constants.js import

### DIFF
--- a/src/components/NewDiskDialog/actions.js
+++ b/src/components/NewDiskDialog/actions.js
@@ -6,7 +6,7 @@ import {
   SET_NEW_DISK_DIALOG_PROGRESS_INDICATOR,
   SET_NEW_DISK_DIALOG_ERROR_TEXT,
   SET_NEW_DISK_DIALOG_DONE,
-} from '_/constants'
+} from './constants'
 
 export function cleanNewDiskDialogSubtree () {
   return {


### PR DESCRIPTION
The import of `constants` in NewDiskDialog/actions.js was changed
to use the App level constants in error. The disk create option still
works but redux reports an error on the browser console. Fixed the
import, fixed the error.