### PR TITLE
Fix rpm build after updates to automake configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,14 @@ missing
 ovirt-web-ui.spec
 tmp.repos/
 /ovirt-web-ui-*.tar.gz
+
 # intl related
 /extra
 /.zanata-cache/
 
-
+# mock_runner
+.bash_history
+.node-gyp/
+exported-artifacts/
+rpmbuild/
+mocker-*.cfg

--- a/Makefile.am
+++ b/Makefile.am
@@ -95,7 +95,7 @@ install-data-local:
 	cp -rpv build/ovirt-web-ui.war $(DESTDIR)$(USER_PORTAL_DIR)
 	cp -rpvT build/branding $(DESTDIR)$(USER_PORTAL_DIR)/branding/ovirt
 	cp -rpv build/etc/* $(DESTDIR)$(sysconfdir)
-	ln -sf $(DESTDIR)$(USER_PORTAL_DIR)/ovirt-web-ui.war $(DESTDIR)$(OVIRT_ENGINE_DIR)/ovirt-web-ui.war
+	ln -sfr $(DESTDIR)$(USER_PORTAL_DIR)/ovirt-web-ui.war $(DESTDIR)$(OVIRT_ENGINE_DIR)/ovirt-web-ui.war
 	ln -sfr $(DESTDIR)$(USER_PORTAL_DIR)/branding/ovirt $(DESTDIR)$(sysconfdir)/ovirt-web-ui/branding/00-ovirt.brand
 
 check-local:

--- a/Makefile.am
+++ b/Makefile.am
@@ -32,9 +32,7 @@ EXTRA_DIST = \
 	scripts \
 	packaging \
 	package.json \
-	index.html \
-  index.jsp \
-	index.jsp.template \
+	static \
 	yarn.lock \
 	.flowconfig
 

--- a/ovirt-web-ui.spec.in
+++ b/ovirt-web-ui.spec.in
@@ -57,7 +57,7 @@ make install DESTDIR=%{buildroot}
 %{_sysconfdir}/ovirt-web-ui/branding/00-ovirt.brand
 
 %changelog
-* Wed Sep 4 2018 Greg Sheremeta <gshereme@redhat.com> - 1.4.3-1
+* Tue Sep 4 2018 Greg Sheremeta <gshereme@redhat.com> - 1.4.3-1
   Fixed issues:
 - ux-redesign: make old Normal View the default when clicking a VM [#751](https://github.com/oVirt/ovirt-web-ui/issues/751)
 

--- a/ovirt-web-ui.spec.in
+++ b/ovirt-web-ui.spec.in
@@ -1,7 +1,4 @@
 # Used for rpm-packaging of pre-bundled application with already resolved JS dependencies
-%global _ovirtwebuidir %{_datarootdir}/ovirt-web-ui
-%global _ovirt_engine_conf %{_datarootdir}/ovirt-engine/services/ovirt-engine/ovirt-engine.conf
-%global _ovirt_engine_ear_application_xml %{_datarootdir}/ovirt-engine/engine.ear/META-INF/application.xml
 %global product oVirt
 
 %global use_rhev %( test -z @RHEV@ && echo 1 || echo 0)
@@ -23,10 +20,10 @@ BuildArch: noarch
 BuildRequires: ovirt-engine-nodejs = 8.11.4
 BuildRequires: ovirt-engine-yarn = 1.7.0
 
-BuildRequires: ovirt-engine-nodejs-modules >= 1.7.3
+BuildRequires: ovirt-engine-nodejs-modules >= 1.8.2
 
 %description
-This package provides new VM Portal for %{product}, so far as technical preview.
+This package provides the VM Portal for %{product}.
 
 %prep
 # Use the ovirt-engine nodejs installation
@@ -51,7 +48,7 @@ make install DESTDIR=%{buildroot}
 %files
 %doc README.md
 %license LICENSE
-%{_ovirtwebuidir}
+%{_datarootdir}/ovirt-web-ui
 %{_datarootdir}/ovirt-engine/ovirt-web-ui.war
 %{_sysconfdir}/ovirt-engine/engine.conf.d/50-ovirt-web-ui.conf
 %{_sysconfdir}/ovirt-web-ui/branding/00-ovirt.brand


### PR DESCRIPTION
Changes in #885 caused the rpm build to fail.  This was for 2 reasons.  First, the nodejs-modules project needed to be updated to accommodate a new project dependency.  Second, the automake configs needed further updates for the rpm build to function properly.