### PR TITLE
Overview card - move uptime in the block with status

### DIFF
--- a/src/components/VmDetails/cards/OverviewCard/index.js
+++ b/src/components/VmDetails/cards/OverviewCard/index.js
@@ -197,10 +197,11 @@ class OverviewCard extends React.Component {
                   <div className={style['vm-status']} id={`${idPrefix}-status`}>
                     <VmStatusIcon className={style['vm-status-icon']} state={vm.get('status')} />
                     <span className={style['vm-status-text']} id={`${idPrefix}-status-value`}>{enumMsg('VmStatus', vm.get('status'))}</span>
+
+                    { uptime &&
+                      <div className={style['vm-uptime']} id={`${idPrefix}-uptime`}>(up {uptime})</div>
+                    }
                   </div>
-                  { uptime &&
-                    <div className={style['vm-uptime']} id={`${idPrefix}-uptime`}>(up {uptime})</div>
-                  }
 
                   <div>
                     { !isEditing &&


### PR DESCRIPTION
The uptime was rendered below the spacing between the status
and description fields.  This caused the uptime to look odd
being closer to the VM description rather then the status.  Moving
the uptime into the same render div as the status looks better.

Fixes: #898

Before:
![screenshot-localhost-3000-2019 01 08-13-15-25](https://user-images.githubusercontent.com/3985964/50850661-80bdb480-1348-11e9-8501-43e6459125b6.png)

After:
![screenshot-localhost-3000-2019 01 08-13-14-39](https://user-images.githubusercontent.com/3985964/50850675-8915ef80-1348-11e9-99a8-12db6537640f.png)

