### PR TITLE
bump ovirt-web-ui-1.4 branch version to 1.4.6-snapshot

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,9 +18,9 @@ AC_PREREQ(2.60)
 
 define([VERSION_MAJOR], [1])
 define([VERSION_MINOR], [4])
-define([VERSION_FIX], [5])
+define([VERSION_FIX], [6])
 define([VERSION_NUMBER], VERSION_MAJOR[.]VERSION_MINOR[.]VERSION_FIX)
-define([VERSION_RELEASE], [1])
+define([VERSION_RELEASE], [0])
 
 AC_INIT([ovirt-web-ui], VERSION_NUMBER, [gshereme@redhat.com])
 PACKAGE_RPM_VERSION="VERSION_NUMBER"

--- a/src/version.js
+++ b/src/version.js
@@ -1,7 +1,7 @@
 const Product = {
   name: 'oVirt Basic Portal',
-  version: '1.4.5',
-  release: '1',
+  version: '1.4.6',
+  release: '0',
 
   ovirtApiVersionRequired: {
     major: 4,


### PR DESCRIPTION
bump ovirt-web-ui-1.4 branch version to 1.4.6-snapshot