### PR TITLE
update Dockerfile to use new index.hbs instead of index.html (ovirt-web-ui-1.4 backport)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM node:8
 
 RUN apt-get update -qq && apt-get install -qy libelf1
 
-RUN mkdir -p /web-ui
-COPY index.html package.json LICENSE yarn.lock .flowconfig /web-ui/
+RUN mkdir -p /web-ui/static
+COPY package.json LICENSE yarn.lock .flowconfig /web-ui/
+COPY static/index.hbs /web-ui/static/
 COPY scripts /web-ui/scripts
 COPY config /web-ui/config
 COPY src /web-ui/src
@@ -13,4 +14,3 @@ WORKDIR /web-ui
 RUN yarn install
 
 ENTRYPOINT ["yarn", "start"]
-


### PR DESCRIPTION
update Dockerfile to use new index.hbs instead of index.html