### PR TITLE
Fix disk and memory chart units

### DIFF
--- a/src/components/VmDetails/cards/UtilizationCard/DiskCharts.js
+++ b/src/components/VmDetails/cards/UtilizationCard/DiskCharts.js
@@ -13,7 +13,7 @@ import {
   DonutChart,
 } from 'patternfly-react'
 
-import { round, convertValueMap } from '_/utils'
+import { round, floor, convertValueMap } from '_/utils'
 import { donutMemoryTooltipContents } from '_/components/utils'
 import { userFormatOfBytes, isWindows } from '_/helpers'
 
@@ -79,9 +79,13 @@ const DiskCharts = ({ vm, diskStats, isRunning, id, ...props }) => {
     }
   })
 
-  const usedFormated = userFormatOfBytes(actualSize)
-  const availableFormated = userFormatOfBytes(provisionedSize - actualSize)
-  const totalFormated = userFormatOfBytes(provisionedSize)
+  const usedFormated = userFormatOfBytes(actualSize, null, 1)
+  const availableFormated = userFormatOfBytes(provisionedSize - actualSize, null, 1)
+  const totalFormated = userFormatOfBytes(provisionedSize, null, 1)
+
+  const availableMemoryPercision = availableFormated.number >= 10
+    ? availableFormated.number >= 100 ? 0 : 1
+    : 2
 
   const isVmWindows = isWindows(vm.getIn(['os', 'type']))
 
@@ -96,7 +100,7 @@ const DiskCharts = ({ vm, diskStats, isRunning, id, ...props }) => {
           <React.Fragment>
             <UtilizationCardDetails>
               <UtilizationCardDetailsCount id={`${id}-available`}>
-                {round(availableFormated.number, 1)} {availableFormated.suffix !== totalFormated.suffix && availableFormated.suffix}
+                {floor(availableFormated.number, availableMemoryPercision)} {availableFormated.suffix !== totalFormated.suffix && availableFormated.suffix}
               </UtilizationCardDetailsCount>
               <UtilizationCardDetailsDesc>
                 <UtilizationCardDetailsLine1>Unallocated</UtilizationCardDetailsLine1>

--- a/src/components/VmDetails/cards/UtilizationCard/MemoryCharts.js
+++ b/src/components/VmDetails/cards/UtilizationCard/MemoryCharts.js
@@ -13,7 +13,7 @@ import {
   SparklineChart,
 } from 'patternfly-react'
 
-import { round } from '_/utils'
+import { round, floor } from '_/utils'
 import { donutMemoryTooltipContents } from '_/components/utils'
 import { userFormatOfBytes } from '_/helpers'
 
@@ -35,12 +35,16 @@ const MemoryCharts = ({ memoryStats, isRunning, id }) => {
   const available = isRunning ? memoryStats.free.datum : memoryStats.installed.datum
   const used = !isRunning ? 0 : memoryStats.installed.datum - memoryStats.free.datum
 
-  const usedFormated = userFormatOfBytes(used)
-  const availableFormated = userFormatOfBytes(available)
-  const totalFormated = userFormatOfBytes(memoryStats.installed.datum)
+  const usedFormated = userFormatOfBytes(used, null, 1)
+  const availableFormated = userFormatOfBytes(available, null, 1)
+  const totalFormated = userFormatOfBytes(memoryStats.installed.datum, null, 1)
 
   // NOTE: Memory history comes sorted from newest to oldest
   const history = ((memoryStats['usage.history'] && memoryStats['usage.history'].datum) || []).reverse()
+
+  const availableMemoryPercision = availableFormated.number >= 10
+    ? availableFormated.number >= 100 ? 0 : 1
+    : 2
 
   return (
     <UtilizationCard className={style['chart-card']} id={id}>
@@ -51,7 +55,7 @@ const MemoryCharts = ({ memoryStats, isRunning, id }) => {
         <React.Fragment>
           <UtilizationCardDetails>
             <UtilizationCardDetailsCount id={`${id}-available`}>
-              {round(availableFormated.number, 0)}  {availableFormated.suffix !== totalFormated.suffix && availableFormated.suffix}
+              {floor(availableFormated.number, availableMemoryPercision)}  {availableFormated.suffix !== totalFormated.suffix && availableFormated.suffix}
             </UtilizationCardDetailsCount>
             <UtilizationCardDetailsDesc>
               <UtilizationCardDetailsLine1>Available</UtilizationCardDetailsLine1>

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -127,7 +127,7 @@ export function getURLQueryParameterByName (name) {
  * @param suffix optional
  * @returns {*}
  */
-export function userFormatOfBytes (number, suffix) {
+export function userFormatOfBytes (number, suffix, precision = 0) {
   const buildRetVal = (number, suffix) => {
     const rounded = number.toFixed(1)
     return {
@@ -139,7 +139,7 @@ export function userFormatOfBytes (number, suffix) {
   }
   number = number || 0
   const factor = 1024
-  const suffixes = [null, 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB']
+  const suffixes = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB']
 
   if (suffix) {
     const i = suffixes.indexOf(suffix)
@@ -154,9 +154,10 @@ export function userFormatOfBytes (number, suffix) {
   // figure it out
   let divisor = 1
   suffix = ''
+  const minValue = 1 - Math.pow(10, -precision) || 1
   for (let i = 0; i < suffixes.length; i++) {
     const quotient = number / divisor
-    if (quotient < factor) {
+    if ((quotient / factor) < minValue) {
       number = quotient
       suffix = suffixes[i]
       break

--- a/src/utils/round.js
+++ b/src/utils/round.js
@@ -23,3 +23,11 @@ export function round (number, precision = 0) {
 
   return rounded
 }
+
+export function floor (number, precision = 0) {
+  const factor = Math.pow(10, precision)
+  const temp = number * factor
+  let rounded = Math.floor(temp)
+  rounded = rounded / factor
+  return rounded
+}


### PR DESCRIPTION
- Added precision for formating bytes, now if value of Disk or Memory will be closer to next unit more then 10 %, it will calculate next unit.
- And if change round precision according to value, if value less then 10, it give sense to show two digit after point, if less then 100 give sense to show only one digit if greater, then without floating part.

Fixes: https://github.com/oVirt/ovirt-web-ui/issues/889

![image](https://user-images.githubusercontent.com/3332176/50903230-7b7e6980-141d-11e9-92b9-ef18932a3fe1.png)
![image](https://user-images.githubusercontent.com/3332176/50903240-8638fe80-141d-11e9-97b4-2f42148c05aa.png)
