### PR TITLE
Added permissions to disk card

### DIFF
--- a/src/components/VmDetails/cards/DisksCard/DiskImageEditor.js
+++ b/src/components/VmDetails/cards/DisksCard/DiskImageEditor.js
@@ -35,6 +35,7 @@ const DISK_DEFAULTS = {
 
 function storageDomainsToSelectList (storageDomainList) {
   return storageDomainList
+    .filter(storageDomain => storageDomain.get('canUserUseDomain'))
     .map(
       item => ({
         id: item.get('id'),

--- a/src/components/VmDetails/cards/DisksCard/DiskListItem.js
+++ b/src/components/VmDetails/cards/DisksCard/DiskListItem.js
@@ -30,7 +30,7 @@ function isDiskBeingDeleted (diskId, pendingTasks) {
  */
 const DiskListItem = ({
   idPrefix, vm, disk, storageDomainList,
-  isEditing, isDiskBeingDeleted, canDeleteDisks, canEditDisks,
+  isEditing, isDiskBeingDeleted, canDeleteDisks,
   onEdit, onDelete,
 }) => {
   const size = disk.get('type') === 'lun' ? disk.get('lunSize') : disk.get('provisionedSize')
@@ -49,7 +49,7 @@ const DiskListItem = ({
   }
 
   const canDelete = canDeleteDisks && !isDiskBeingDeleted && !isLocked
-  const canEdit = canEditDisks && !isDiskBeingDeleted && !isLocked
+  const canEdit = !isDiskBeingDeleted && !isLocked && disk.get('canUserEditDisk')
 
   return <div className={itemStyle['item-row']}>
     {/* No Disk Status Column (could be the disk's active/inactive status) */}
@@ -172,7 +172,6 @@ DiskListItem.propTypes = {
   isEditing: PropTypes.bool.isRequired,
   isDiskBeingDeleted: PropTypes.bool.isRequired,
   canDeleteDisks: PropTypes.bool.isRequired,
-  canEditDisks: PropTypes.bool.isRequired,
 
   onEdit: PropTypes.func,
   onDelete: PropTypes.func,

--- a/src/components/VmDetails/cards/DisksCard/index.js
+++ b/src/components/VmDetails/cards/DisksCard/index.js
@@ -26,10 +26,9 @@ function filterStorageDomains (vm, clusters, storageDomains) {
   return storageDomains
     .filter(sd =>
       sd.get('type') === 'data' &&
-      sd.getIn(['statusPerDataCenter', dataCenterId]) === 'active'
-    )
-    // TODO: Add storage domain permission/permit checking and filtering as necessary.
-    .toList()
+      sd.getIn(['statusPerDataCenter', dataCenterId]) === 'active' &&
+      sd.get('canUserUseDomain')
+    ).toList()
 }
 
 function suggestDiskName (vm) {
@@ -127,12 +126,11 @@ class DisksCard extends React.Component {
 
     const idPrefix = 'vmdetail-disks'
     const canEditTheCard =
-      vm.get('canUserEditVm') &&
+      vm.get('canUserEditVmStorage') &&
       vm.getIn(['pool', 'id']) === undefined
 
-    const canCreateDisks = true // TODO: Better creation condition / Permission check?
-    const canDeleteDisks = vm.get('status') === 'down' // TODO: Permission check?
-    const canEditDisks = true // TODO: Better edit conditions / Permission check?
+    const canCreateDisks = filteredStorageDomainList.size > 0
+    const canDeleteDisks = vm.get('status') === 'down'
 
     const diskList = sortDisksForDisplay(vm.get('disks')) // ImmutableJS List()
 
@@ -142,9 +140,9 @@ class DisksCard extends React.Component {
         icon={{ type: 'pf', name: 'storage-domain' }}
         title={msg.disks()}
         editTooltip={msg.disksCardEditTooltip({ vmName: vm.get('name') })}
-        editable={canEditTheCard}
         itemCount={diskList.size}
         className={baseStyle['cell-card']}
+        editable={canEditTheCard}
         onStartEdit={() => { onEditChange(true) }}
         onCancel={() => { onEditChange(false) }}
         onSave={() => { onEditChange(false) }}
@@ -192,7 +190,6 @@ class DisksCard extends React.Component {
                     storageDomainList={filteredStorageDomainList}
                     isEditing={isEditing}
                     canDeleteDisks={canDeleteDisks}
-                    canEditDisks={canEditDisks}
                     onEdit={this.onEditConfirm}
                     onDelete={this.onDeleteConfirm}
                   />

--- a/src/ovirtapi/index.js
+++ b/src/ovirtapi/index.js
@@ -175,6 +175,16 @@ const OvirtApi = {
     const url = `${AppConfiguration.applicationContext}/api/vnicprofiles/${id}/permissions?follow=role.permits`
     return httpGet({ url, custHeaders: { Filter: true } })
   },
+  getStorageDomainPermissions ({ id }: { id: string }): Promise<Object> {
+    assertLogin({ methodName: 'getStorageDomainPermissions' })
+    const url = `${AppConfiguration.applicationContext}/api/storagedomains/${id}/permissions?follow=role.permits`
+    return httpGet({ url, custHeaders: { Filter: true } })
+  },
+  getDiskPermissions ({ id }: { id: string }): Promise<Object> {
+    assertLogin({ methodName: 'getDiskPermissions' })
+    const url = `${AppConfiguration.applicationContext}/api/disks/${id}/permissions?follow=role.permits`
+    return httpGet({ url, custHeaders: { Filter: true } })
+  },
   getVmPermissions ({ vmId }: VmIdType): Promise<Object> {
     assertLogin({ methodName: 'getClusterPermissions' })
     const url = `${AppConfiguration.applicationContext}/api/vms/${vmId}/permissions?follow=role`

--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -28,6 +28,7 @@ import type {
 import {
   canUserUseCluster,
   canUserEditVm,
+  canUserEditVmStorage,
   getUserPermits,
   canUserUseVnicProfile,
   canUserManipulateSnapshots,
@@ -187,6 +188,7 @@ const VM = {
         }))
         parsedVm.canUserEditVm = canUserEditVm(parsedVm.permits)
         parsedVm.canUserManipulateSnapshots = canUserManipulateSnapshots(parsedVm.permits)
+        parsedVm.canUserEditVmStorage = canUserEditVmStorage(parsedVm.permits)
       }
     }
 
@@ -412,6 +414,7 @@ const Snapshot = {
 // VM -> DiskAttachments.DiskAttachment[] -> Disk
 const DiskAttachment = {
   toInternal ({ attachment, disk }: { attachment?: ApiDiskAttachmentType, disk: ApiDiskType }): DiskType {
+    // TODO Add nested permissions support when BZ 1639784 will be done
     return cleanUndefined({
       attachmentId: attachment && attachment['id'],
       active: attachment && convertBool(attachment['active']),
@@ -480,6 +483,7 @@ const DiskAttachment = {
 //
 const DataCenter = {
   toInternal ({ dataCenter }: { dataCenter: ApiDataCenterType }): DataCenterType {
+    // TODO Add nested permissions support when BZ 1639784 will be done
     return {
       id: dataCenter.id,
       name: dataCenter.name,

--- a/src/saga/utils.js
+++ b/src/saga/utils.js
@@ -13,6 +13,10 @@ import {
   checkTokenExpired,
 } from '_/actions'
 
+import Api from '_/ovirtapi'
+
+import { getUserPermits } from '_/utils'
+
 export const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms))
 
 export function* callExternalAction (methodName, method, action, canBeMissing = false) {
@@ -109,4 +113,16 @@ export function* delayInMsSteps (count = 20, msMultiplier = 2000) {
   for (let i = 2; i < (count + 2); i++) {
     yield Math.round(Math.log2(i) * msMultiplier)
   }
+}
+
+export function* fetchPermits ({ entityType, id }) {
+  const permissions = yield callExternalAction(`get${entityType}Permissions`, Api[`get${entityType}Permissions`], { payload: { id } })
+  return getUserPermits(Api.permissionsToInternal({ permissions: permissions.permission }))
+}
+
+export const PermissionsType = {
+  STORAGE_DOMAIN_TYPE: 'StorageDomain',
+  CLUSTER_TYPE: 'Cluster',
+  VNIC_PROFILE_TYPE: 'VnicProfile',
+  DISK_TYPE: 'Disk',
 }

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -22,6 +22,18 @@ export function canUserManipulateSnapshots (permits: Set<string>): boolean {
   return checkUserPermit('manipulate_vm_snapshots', permits)
 }
 
+export function canUserUseStorageDomain (permits: Set<string>): boolean {
+  return checkUserPermit('create_disk', permits)
+}
+
+export function canUserEditVmStorage (permits: Set<string>): boolean {
+  return checkUserPermit('configure_vm_storage', permits)
+}
+
+export function canUserEditDisk (permits: Set<string>): boolean {
+  return checkUserPermit('edit_disk_properties', permits)
+}
+
 /*
  * Return if any of the given clusters are available for use by the user (as defined
  * by `canUserUseCluster` above)


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/507

If user has no permissions to edit VM storage, then pencil is missed:
![image](https://user-images.githubusercontent.com/3332176/51045144-2f6d2980-15c3-11e9-9efe-640d922ad3b9.png)

If user has no permissions to add disk to any of domain storages, then button `create` is missed:
![image](https://user-images.githubusercontent.com/3332176/51045260-778c4c00-15c3-11e9-886c-6266a9fc0a70.png)

User can use only those Storage Domains that has permissions for:
![image](https://user-images.githubusercontent.com/3332176/51045454-eb2e5900-15c3-11e9-9b42-cb872a4c4561.png)

User can edit disks for which has permissions:
![image](https://user-images.githubusercontent.com/3332176/51045414-cc2fc700-15c3-11e9-9c1f-f98b30e5dccd.png)

Because of this bug is still present https://bugzilla.redhat.com/show_bug.cgi?id=1639784 , number of request grew.