### PR TITLE
Allow users without edit VM permissions to change a running VM's CD

### DIFF
--- a/src/actions/vm.js
+++ b/src/actions/vm.js
@@ -150,7 +150,7 @@ export function createVm ({ vm, transformInput = true, pushToDetailsOnSuccess = 
 }
 
 export function editVm (
-  { vm, transformInput = true, restartAfterEdit = false, nextRun = false },
+  { vm, transformInput = true, restartAfterEdit = false, nextRun = false, changeCurrentCd = true },
   { correlationId, ...additionalMeta }
 ) {
   return {
@@ -160,6 +160,7 @@ export function editVm (
       transformInput,
       restartAfterEdit,
       nextRun,
+      changeCurrentCd,
     },
     meta: {
       correlationId,

--- a/src/components/VmDetails/cards/DetailsCard/index.js
+++ b/src/components/VmDetails/cards/DetailsCard/index.js
@@ -600,11 +600,9 @@ class DetailsCard extends React.Component {
     const { vm, isEditing, correlatedMessages, clusterList, isoList, templateList } = this.state
 
     const idPrefix = 'vmdetail-details'
+
     const isPoolVm = vm.getIn(['pool', 'id']) !== undefined
-
-    const canEditDetails = (vm.get('canUserChangeCd') || vm.get('canUserEditVm')) && !isPoolVm
-    const canOnlyChangeCD = (vm.get('canUserChangeCd') && !vm.get('canUserEditVm')) && !isPoolVm
-
+    const canEditDetails = vm.get('canUserEditVm') && !isPoolVm
     const status = vm.get('status')
 
     // Host Name
@@ -682,7 +680,7 @@ class DetailsCard extends React.Component {
       />
       <BaseCard
         title={msg.cardTitleDetails()}
-        editable={canEditDetails}
+        editable={canEditDetails || canChangeCd}
         editMode={isEditing}
         idPrefix={idPrefix}
         editTooltip={msg.cardTooltipEditDetails({ vmName: vm.get('name') })}
@@ -691,7 +689,7 @@ class DetailsCard extends React.Component {
         onSave={this.handleCardOnSave}
       >
         {({ isEditing }) => {
-          const isFullEdit = isEditing && !canOnlyChangeCD
+          const isFullEdit = isEditing && canEditDetails
           return <React.Fragment>
             {/* Regular options */}
             <Grid className={style['details-container']}>

--- a/src/components/VmDetails/cards/DetailsCard/index.js
+++ b/src/components/VmDetails/cards/DetailsCard/index.js
@@ -596,10 +596,10 @@ class DetailsCard extends React.Component {
     const { vm, isEditing, correlatedMessages, clusterList, isoList, templateList } = this.state
 
     const idPrefix = 'vmdetail-details'
+    const isPoolVm = vm.getIn(['pool', 'id']) !== undefined
 
-    const canEditDetails =
-      vm.get('canUserEditVm') &&
-      vm.getIn(['pool', 'id']) === undefined
+    const canEditDetails = (vm.get('canUserChangeCd') || vm.get('canUserEditVm')) && !isPoolVm
+    const canOnlyChangeCD = (vm.get('canUserChangeCd') && !vm.get('canUserEditVm')) && !isPoolVm
 
     const status = vm.get('status')
 
@@ -629,7 +629,7 @@ class DetailsCard extends React.Component {
     const templateName = (templates && templates.getIn([templateId, 'name'])) || msg.notAvailable()
 
     // CD
-    const canChangeCd = vmCanChangeCd(status)
+    const canChangeCd = vm.get('canUserChangeCd') && vmCanChangeCd(status)
     const cdImageId = vm.getIn(['cdrom', 'fileId'])
     const cdImage = isoList.find(iso => iso.file.id === cdImageId)
     const cdImageName = (cdImage && cdImage.file.name) || `[${msg.empty()}]`
@@ -686,8 +686,9 @@ class DetailsCard extends React.Component {
         onCancel={this.handleCardOnCancel}
         onSave={this.handleCardOnSave}
       >
-        {({ isEditing }) =>
-          <React.Fragment>
+        {({ isEditing }) => {
+          const isFullEdit = isEditing && !canOnlyChangeCD
+          return <React.Fragment>
             {/* Regular options */}
             <Grid className={style['details-container']}>
               <Row>
@@ -713,14 +714,14 @@ class DetailsCard extends React.Component {
                       { fqdn || <NotAvailable tooltip={msg.notAvailableUntilRunningAndGuestAgent()} id={`${idPrefix}-fqdn-not-available`} /> }
                     </FieldRow>
                     <FieldRow label={msg.cluster()} id={`${idPrefix}-cluster`}>
-                      { !isEditing && clusterName }
-                      { isEditing && !canChangeCluster &&
+                      { !isFullEdit && clusterName }
+                      { isFullEdit && !canChangeCluster &&
                         <div>
                           {clusterName}
                           <FieldLevelHelp disabled={false} content={msg.clusterCanOnlyChangeWhenVmStopped()} inline />
                         </div>
                       }
-                      { isEditing && canChangeCluster &&
+                      { isFullEdit && canChangeCluster &&
                         <SelectBox
                           id={`${idPrefix}-cluster-edit`}
                           items={clusterList.filter(cluster => cluster.datacenter === dataCenterId)}
@@ -730,8 +731,8 @@ class DetailsCard extends React.Component {
                       }
                     </FieldRow>
                     <FieldRow label={msg.dataCenter()} id={`${idPrefix}-data-center`}>
-                      { !isEditing && dataCenterName }
-                      { isEditing &&
+                      { !isFullEdit && dataCenterName }
+                      { isFullEdit &&
                         <div>
                           {dataCenterName}
                           <FieldLevelHelp disabled={false} content={msg.dataCenterChangesWithCluster()} inline />
@@ -743,8 +744,8 @@ class DetailsCard extends React.Component {
                 <Col className={style['fields-column']}>
                   <Grid>
                     <FieldRow label={msg.template()} id={`${idPrefix}-template`}>
-                      { !isEditing && templateName }
-                      { isEditing &&
+                      { !isFullEdit && templateName }
+                      { isFullEdit &&
                         <SelectBox
                           id={`${idPrefix}-template-edit`}
                           items={templateList}
@@ -795,8 +796,8 @@ class DetailsCard extends React.Component {
                     </FieldRow>
 
                     <FieldRow label={msg.cpus()} id={`${idPrefix}-cpus`}>
-                      { !isEditing && vCpuCount }
-                      { isEditing &&
+                      { !isFullEdit && vCpuCount }
+                      { isFullEdit &&
                         <div>
                           <FormControl
                             id={`${idPrefix}-cpus-edit`}
@@ -809,8 +810,8 @@ class DetailsCard extends React.Component {
                       }
                     </FieldRow>
                     <FieldRow label={msg.memory()} id={`${idPrefix}-memory`}>
-                      { !isEditing && `${round(memorySize)} ${memoryUnit}` }
-                      { isEditing &&
+                      { !isFullEdit && `${round(memorySize)} ${memoryUnit}` }
+                      { isFullEdit &&
                         <div>
                           <FormControl
                             id={`${idPrefix}-memory-edit`}
@@ -828,7 +829,7 @@ class DetailsCard extends React.Component {
               </Row>
             </Grid>
             {/* Advanced options */}
-            { isEditing && <ExpandCollapseSection id={`${idPrefix}-advanced-options`} sectionHeader={msg.advancedOptions()}>
+            { isFullEdit && <ExpandCollapseSection id={`${idPrefix}-advanced-options`} sectionHeader={msg.advancedOptions()}>
               <Grid className={style['details-container']}>
                 <Row>
                   {/* First column */}
@@ -934,7 +935,7 @@ class DetailsCard extends React.Component {
               )
             }
           </React.Fragment>
-        }
+        }}
       </BaseCard>
     </React.Fragment>
   }

--- a/src/components/VmDetails/cards/DetailsCard/index.js
+++ b/src/components/VmDetails/cards/DetailsCard/index.js
@@ -550,7 +550,11 @@ class DetailsCard extends React.Component {
 
     // ---- dispatch the save
     this.setState({ correlationId })
-    this.props.saveChanges(vmUpdates, this.restartAfterSave, !this.hotPlugNow, correlationId)
+    this.props.saveChanges(
+      vmUpdates,
+      this.restartAfterSave,
+      !this.hotPlugNow,
+      correlationId)
 
     return false // control BaseCard's view/edit transition
   }

--- a/src/ovirtapi/index.js
+++ b/src/ovirtapi/index.js
@@ -186,8 +186,8 @@ const OvirtApi = {
     return httpGet({ url, custHeaders: { Filter: true } })
   },
   getVmPermissions ({ vmId }: VmIdType): Promise<Object> {
-    assertLogin({ methodName: 'getClusterPermissions' })
-    const url = `${AppConfiguration.applicationContext}/api/vms/${vmId}/permissions?follow=role`
+    assertLogin({ methodName: 'getVmPermissions' })
+    const url = `${AppConfiguration.applicationContext}/api/vms/${vmId}/permissions?follow=role.permits`
     return httpGet({ url, custHeaders: { Filter: true } })
   },
   getAllHosts (): Promise<Object> {

--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -26,6 +26,7 @@ import type {
 } from './types'
 
 import {
+  canUserChangeCd,
   canUserUseCluster,
   canUserEditVm,
   canUserEditVmStorage,
@@ -136,9 +137,12 @@ const VM = {
       cdrom: {},
       sessions: [],
       nics: [],
+
       permits: new Set(),
+      canUserChangeCd: true,
       canUserEditVm: false,
       canUserManipulateSnapshots: false,
+
       ssoGuestAgent: vm.sso.methods && vm.sso.methods.method && vm.sso.methods.method.length > 0 && vm.sso.methods.method.findIndex(method => method.id === 'guest_agent') > -1,
       display: {
         smartcardEnabled: vm.display && vm.display.smartcard_enabled && convertBool(vm.display.smartcard_enabled),
@@ -186,6 +190,7 @@ const VM = {
         parsedVm.permits = getUserPermits(Permissions.toInternal({
           permissions: vm.permissions.permission,
         }))
+        parsedVm.canUserChangeCd = canUserChangeCd(parsedVm.permits)
         parsedVm.canUserEditVm = canUserEditVm(parsedVm.permits)
         parsedVm.canUserManipulateSnapshots = canUserManipulateSnapshots(parsedVm.permits)
         parsedVm.canUserEditVmStorage = canUserEditVmStorage(parsedVm.permits)

--- a/src/utils/array-utils.js
+++ b/src/utils/array-utils.js
@@ -1,0 +1,16 @@
+
+export function arrayMatch (a1, a2) {
+  if (
+    (!Array.isArray(a1) || !Array.isArray(a2)) ||
+    (a1.length !== a2.length)
+  ) {
+    return false
+  }
+
+  const difference = new Set(a1)
+  for (let member of a2) {
+    difference.delete(member)
+  }
+
+  return difference.size === 0
+}

--- a/src/utils/array-utils.test.js
+++ b/src/utils/array-utils.test.js
@@ -1,0 +1,25 @@
+/* eslint-env jest */
+import { arrayMatch } from './array-utils'
+
+describe('test array utilities', () => {
+  test('arrayMatch, positive matches', () => {
+    expect(arrayMatch([], [])).toBeTruthy()
+    expect(arrayMatch([ 1, 2, 3 ], [ 1, 2, 3 ])).toBeTruthy()
+    expect(arrayMatch([ 'A', 'B', 'C' ], [ 'A', 'B', 'C' ])).toBeTruthy()
+  })
+
+  test('arrayMatch, bad inputs', () => {
+    expect(arrayMatch()).toBeFalsy()
+    expect(arrayMatch([])).toBeFalsy()
+    expect(arrayMatch('A')).toBeFalsy()
+    expect(arrayMatch('A', 'A')).toBeFalsy()
+    expect(arrayMatch(42, 42)).toBeFalsy()
+  })
+
+  test('arrayMatch, negative matches', () => {
+    expect(arrayMatch([ 1, 2, 3 ], [])).toBeFalsy()
+    expect(arrayMatch([], [ 1, 2, 3 ])).toBeFalsy()
+    expect(arrayMatch([ 1, 2 ], [ 1, 2, 3 ])).toBeFalsy()
+    expect(arrayMatch([ 'A', 'B', 'C' ], [ 1, 2, 3 ])).toBeFalsy()
+  })
+})

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -7,6 +7,7 @@ export * from './format'
 export * from './round'
 export * from './storage-conversion'
 export { isNumber } from './unit-conversion'
+export * from './array-utils'
 
 export function flatMap<T, U> (array: Array<T>, mapper: (T) => Array<U>): Array<U> {
   return array.map(mapper)

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -6,6 +6,10 @@ function checkUserPermit (permit: string, permits: Set<string>): boolean {
   return permits.has(permit)
 }
 
+export function canUserChangeCd (permits: Set<string>): boolean {
+  return checkUserPermit('change_vm_cd', permits)
+}
+
 export function canUserUseCluster (permits: Set<string>): boolean {
   return checkUserPermit('create_vm', permits)
 }


### PR DESCRIPTION
  - Add 'canUserChangeCd' permit check to VM transform
    - To support a normal user's ability to change a VM's CD, a field has been added to a VM's transform: `canUserChangeCd`.  This is the basis for DetailsCard permission check to be able to edit
the VM.

  - Update DetailsCard to support 'Edit CD' and 'Full Edit' modes
    - If a user only has enough permissions to be able to change the CD, the card will be editable but, apart from the CD, the individual fields will not be.
    - Only when a user has full VM edit permissions will all of the fields be editable.

  - `editVm` saga to skip VM update if only CD change is needed
    - On the `DetailsCard`, it is quite possible the only change that needs to be committed is to change the CD.  In this case, the VM edit call can be skipped.  Additionally, when the user does not have access to edit the VM, but can change the CD, it is essential to skip the VM update call.
    - The `editVm` saga now looks at the given `vm` object and if only fields required to change the CD are present, the VM update is skipped.  The ability to specify if the change CD should be only temporary on the running VM or an update to the default CD on the VM itself was added.


----
Demo for a "UserRole" user with permissions assigned directly to the VM (shows the edit on an off VM then on an up VM):
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/3985964/52442664-c5786f00-2af1-11e9-800c-b2c5690b9dc4.gif)

Demo for an Admin user:
![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/3985964/52442761-01133900-2af2-11e9-92fb-cba9f5ba8c4b.gif)

Fixes: #954