### PR TITLE
Add form onSubmit handler to NicEditor, DiskImageEditor

### DIFF
--- a/src/components/VmDetails/cards/DisksCard/DiskImageEditor.js
+++ b/src/components/VmDetails/cards/DisksCard/DiskImageEditor.js
@@ -236,7 +236,11 @@ class DiskImageEditor extends Component {
         </Modal.Header>
         <Modal.Body>
 
-          <Form horizontal>
+          <Form
+            horizontal
+            onSubmit={e => { e.preventDefault() }}
+            id={`${idPrefix}-modal-form`}
+          >
             {/* Alias */}
             <FormGroup controlId={`${idPrefix}-alias`} className={createMode && 'required'}>
               <LabelCol sm={3}>

--- a/src/components/VmDetails/cards/NicsCard/NicEditor.js
+++ b/src/components/VmDetails/cards/NicsCard/NicEditor.js
@@ -127,8 +127,8 @@ class NicEditor extends Component {
     return nic
   }
 
-  changeName (event) {
-    this.setState({ name: event.target.value })
+  changeName ({ target: { value } }) {
+    this.setState({ name: value })
   }
 
   changeVnicProfile (value) {
@@ -190,7 +190,11 @@ class NicEditor extends Component {
         </Modal.Header>
         <Modal.Body>
 
-          <Form horizontal>
+          <Form
+            horizontal
+            onSubmit={e => { e.preventDefault() }}
+            id={`${modalId}-form`}
+          >
             <FormGroup controlId={`${modalId}-name`} className='required'>
               <LabelCol sm={3}>
                 { msg.nicEditorNameLabel() }
@@ -246,7 +250,6 @@ class NicEditor extends Component {
                   }
                 </Col>
               </FormGroup>
-
               <FormGroup controlId='nic-link-state-group'>
                 <LabelCol sm={3}>
                   { msg.nicEditorLinkStateLabel() }

--- a/src/components/VmDetails/cards/NicsCard/index.js
+++ b/src/components/VmDetails/cards/NicsCard/index.js
@@ -161,7 +161,6 @@ class NicsCard extends React.Component {
                           <span className={itemStyle['create-text']} >{msg.nicActionCreateNew()}</span>
                         </a>
                       </div>
-
                     }
                   />
                 </Col>


### PR DESCRIPTION
There was behavior on the `NicEditor` form would submit when 'Enter'
was presses when the name field had focus.  This caused the page to
completely reload.  The form's new `onSubmit` handler cancels the
default behavior and prevents the page reload.

Fixes: #981