### PR TITLE
Refactor GlobalErrorBoundary console logging

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -12,4 +12,5 @@ module.exports = Object
     return env
   }, {
     'process.env.NODE_ENV': NODE_ENV,
+    'window.DEVELOPMENT': JSON.stringify(process.env.NODE_ENV === 'development')
   })

--- a/src/GlobalErrorBoundary.js
+++ b/src/GlobalErrorBoundary.js
@@ -17,8 +17,10 @@ class GlobalErrorBoundary extends React.Component {
 
   componentDidCatch (error, info) {
     this.setState({ hasError: true })
-    console.error(error)
-    console.error(info.componentStack)
+    if (!window.DEVELOPMENT) {
+      console.error(error)
+      console.error(info.componentStack)
+    }
   }
 
   render () {


### PR DESCRIPTION
When running the app via the dev server (i.e. `yarn start`), the
`GlobalErrorBoundary` component would log to console errors that
have already been logged by react dev mode code.

This change utilizes "webpack.DefinePlugin" to push the
`window.DEVELOPMENT` flag to the code (via text replace).  The flag
is checked in `GlobalErrorBoundary` and won't log the error again
in DEV mode.