### PR TITLE
Fixed text overflow for CD names

### DIFF
--- a/src/components/VmDetails/cards/DetailsCard/index.js
+++ b/src/components/VmDetails/cards/DetailsCard/index.js
@@ -778,10 +778,10 @@ class DetailsCard extends React.Component {
                       { templateName }
                     </FieldRow>
                     <FieldRow label={isEditing ? msg.changeCd() : msg.cd()} id={`${idPrefix}-cdrom`}>
-                      { !isEditing && cdImageName }
+                      { !isEditing && <FieldValue tooltip={cdImageName}>{cdImageName}</FieldValue> }
                       { isEditing && !canChangeCd &&
                         <div>
-                          {cdImageName}
+                          <FieldValue tooltip={cdImageName}>{cdImageName}</FieldValue>
                           <FieldLevelHelp disabled={false} content={msg.cdCanOnlyChangeWhenVmRunning()} inline />
                         </div>
                       }


### PR DESCRIPTION
It works the same as for Host and FQDN fields.

Fixes: https://github.com/oVirt/ovirt-web-ui/issues/916

![some3](https://user-images.githubusercontent.com/3332176/56361826-a6304900-61e8-11e9-92ba-da24999bb21e.jpeg)
