### PR TITLE
Fixed textarea resize bug

### DIFF
--- a/src/index-nomodules.css
+++ b/src/index-nomodules.css
@@ -222,3 +222,7 @@ a.disabled {
 .vnc-console > div {
   height: calc(100vh - 150px);
 }
+
+textarea {
+  resize: vertical;
+}


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/970

In Firefox and Chrome everything works fine, it resize only in vertical
![image](https://user-images.githubusercontent.com/3332176/56807716-e8ccd380-682f-11e9-8a6d-57fe13bebad1.png)

Edge doesn't have support of CSS property `resize`, so it doesn't have any resize permissions 
![image](https://user-images.githubusercontent.com/3332176/56807615-a86d5580-682f-11e9-812f-3e94128cccb5.png)

Property support: https://caniuse.com/#feat=css-resize
