### PR TITLE
Resolve issues with immediate logout when app starts

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -96,10 +96,10 @@ const App = ({ history, config, appReady }) => {
       <div id='app-container'>
         <VmsPageHeader title={fixedStrings.BRAND_NAME + ' ' + msg.vmPortal()} />
         <OvirtApiCheckFailed />
-        <SessionActivityTracker />
-        { appReady && renderRoutes(getRoutes()) }
         <LoadingData />
         <ToastNotifications />
+        { appReady && <SessionActivityTracker /> }
+        { appReady && renderRoutes(getRoutes()) }
       </div>
     </ConnectedRouter>
   )

--- a/src/components/SessionActivityTracker.js
+++ b/src/components/SessionActivityTracker.js
@@ -18,7 +18,7 @@ class SessionActivityTracker extends React.Component {
       counter: props.config.get('userSessionTimeoutInterval'),
     }
 
-    this.dropCounter = this.dropCounter.bind(this)
+    this.resetTimeoutCounter = this.resetTimeoutCounter.bind(this)
     this.decrementCounter = this.decrementCounter.bind(this)
   }
 
@@ -31,36 +31,37 @@ class SessionActivityTracker extends React.Component {
     return null
   }
 
-  dropCounter () {
+  resetTimeoutCounter () {
     if (!this.state.showTimeoutModal) {
       this.setState({ counter: this.props.config.get('userSessionTimeoutInterval') })
     }
   }
 
   decrementCounter () {
-    this.setState(state => {
-      const { counter } = state
-      if (counter !== null) {
-        return {
-          counter: counter - 1,
-          showTimeoutModal: counter <= TIME_TO_DISPLAY_MODAL,
+    if (this.state.counter === null) { // counter is null if timeout value hasn't been fetched yet
+      return
+    }
+
+    this.setState(
+      state => ({
+        counter: state.counter - 1,
+        showTimeoutModal: state.counter <= TIME_TO_DISPLAY_MODAL,
+      }),
+      () => {
+        if (this.state.counter <= 0) {
+          this.props.onLogout()
         }
       }
-      return null
-    }, () => {
-      if (this.state.counter <= 0) {
-        this.props.onLogout()
-      }
-    })
+    )
   }
 
   componentDidMount () {
-    document.body.addEventListener('mousemove', this.dropCounter)
+    document.body.addEventListener('mousemove', this.resetTimeoutCounter)
     this.timer = setInterval(this.decrementCounter, 1000)
   }
 
   componentWillUnmount () {
-    document.body.removeEventListener('mousemove', this.dropCounter)
+    document.body.removeEventListener('mousemove', this.resetTimeoutCounter)
     if (this.timer) {
       clearInterval(this.timer)
     }


### PR DESCRIPTION
When the app is starting up, the `SessionActivityTracker` would immediately load. If the tracker started before the timeout value is loaded, as part of the login initial data fetch, it was considering a timeout value of `null` as 0 and immediately logging out the user.

This has been fixed in two ways:
  1. The `SessionActivityTracker` isn't loaded on the `App` until the app is ready (i.e. once enough initial data has been fetched)

  2. `SessionActivityTracker` will not tick down its counter when the counter is set to `null` (i.e. the `userSessionTimeoutInterval` hasn't been fetched yet)

Fixes: #1024