### PR TITLE
VM Details card - Add ellipse/tooltip for IP Addresses

### DIFF
--- a/src/components/VmDetails/cards/DetailsCard/index.js
+++ b/src/components/VmDetails/cards/DetailsCard/index.js
@@ -676,10 +676,12 @@ class DetailsCard extends React.Component {
                           <NotAvailable tooltip={msg.notAvailableUntilRunningAndGuestAgent()} id={`${idPrefix}-ip-not-available`} />
                         }
                         { ip4Addresses.length > 0 &&
-                          ip4Addresses.map((ip4, index) => <div key={`ip4-${index}`} id={`${idPrefix}-ip-ipv4-${index}`}>{ip4}</div>)
+                          ip4Addresses.map((ip4, index) => <FieldValue tooltip={ip4} key={`ip4-${index}`} id={`${idPrefix}-ip-ipv4-${index}`}>
+                            {ip4}</FieldValue>)
                         }
                         { ip6Addresses.length > 0 &&
-                          ip6Addresses.map((ip4, index) => <div key={`ip4-${index}`} id={`${idPrefix}-ip-ipv6-${index}`}>{ip4}</div>)
+                          ip6Addresses.map((ip4, index) => <FieldValue tooltip={ip4} key={`ip4-${index}`} id={`${idPrefix}-ip-ipv6-${index}`}>
+                            {ip4}</FieldValue>)
                         }
                       </React.Fragment>
                     </FieldRow>

--- a/src/components/VmDetails/cards/DetailsCard/index.js
+++ b/src/components/VmDetails/cards/DetailsCard/index.js
@@ -676,12 +676,18 @@ class DetailsCard extends React.Component {
                           <NotAvailable tooltip={msg.notAvailableUntilRunningAndGuestAgent()} id={`${idPrefix}-ip-not-available`} />
                         }
                         { ip4Addresses.length > 0 &&
-                          ip4Addresses.map((ip4, index) => <FieldValue tooltip={ip4} key={`ip4-${index}`} id={`${idPrefix}-ip-ipv4-${index}`}>
-                            {ip4}</FieldValue>)
+                          ip4Addresses.map((ip4, index) =>
+                            <EllipsisValue tooltip={ip4} key={`ip4-${index}`} id={`${idPrefix}-ip-ipv4-${index}`}>
+                              {ip4}
+                            </EllipsisValue>
+                          )
                         }
                         { ip6Addresses.length > 0 &&
-                          ip6Addresses.map((ip4, index) => <FieldValue tooltip={ip4} key={`ip4-${index}`} id={`${idPrefix}-ip-ipv6-${index}`}>
-                            {ip4}</FieldValue>)
+                          ip6Addresses.map((ip4, index) =>
+                            <EllipsisValue tooltip={ip4} key={`ip4-${index}`} id={`${idPrefix}-ip-ipv6-${index}`}>
+                              {ip4}
+                            </EllipsisValue>
+                          )
                         }
                       </React.Fragment>
                     </FieldRow>

--- a/src/components/VmDetails/cards/DetailsCard/style.css
+++ b/src/components/VmDetails/cards/DetailsCard/style.css
@@ -9,6 +9,10 @@
   min-width: 250px;
 }
 
+.field-row {
+  max-width: 100%;
+}
+
 .field-row + .field-row {
   margin-top: 5px;
 }


### PR DESCRIPTION
Fixes: suggestions in #946

In narrow screen resolution (for example: 2:3 ratio), entries from IP address field could overflow onto the next card, causing a clustered and disordered appearance. 
![screenshot-localhost-3000-2019 06 05-11-06-44](https://user-images.githubusercontent.com/25762021/58975548-3d4e6180-8793-11e9-9bb1-018c31404e4c.png)


![screenshot-localhost-3000-2019 06 05-11-08-18](https://user-images.githubusercontent.com/25762021/58975542-39224400-8793-11e9-806b-cddae43609a9.png)
