### PR TITLE
Text wrapping in Utilization card

### DIFF
--- a/src/components/VmDetails/cards/UtilizationCard/style.css
+++ b/src/components/VmDetails/cards/UtilizationCard/style.css
@@ -36,6 +36,7 @@
 }
 
 .no-data-card-body .no-data-title {
+  text-align: center;
   font-size: 150%;
   color: rgba(0, 0, 0, 0.65);
 }


### PR DESCRIPTION
Fixes: suggestions in #946

Problem: The text within Utilization card goes from center aligned to left aligned once the screen reaches a certain resolution.

![screenshot-localhost-3000-2019 06 05-11-12-35](https://user-images.githubusercontent.com/25762021/58975715-a6ce7000-8793-11e9-85a3-c0e89f354742.png)

After:
![screenshot-localhost-3000-2019 06 05-11-29-21](https://user-images.githubusercontent.com/25762021/58975754-b948a980-8793-11e9-9a2e-094a1dd34963.png)
