### PR TITLE
responsive - VM Details, set minimum card widths

### DIFF
--- a/src/components/VmDetails/index.js
+++ b/src/components/VmDetails/index.js
@@ -71,13 +71,13 @@ class VmDetailsContainer extends React.Component {
         }
 
         <Row>
-          <Col cols={4}><OverviewCard vm={vm} onEditChange={(isEdit, isDirty) => this.handleEditChange('over', isEdit, isDirty)} /></Col>
-          <Col cols={5}><DetailsCard vm={vm} onEditChange={(isEdit, isDirty) => this.handleEditChange('detail', isEdit, isDirty)} /></Col>
-          <Col cols={3}><SnapshotsCard vm={vm} onEditChange={(isEdit, isDirty) => this.handleEditChange('snap', isEdit, isDirty)} /></Col>
+          <Col cols={4} className={styles['col-overview']}><OverviewCard vm={vm} onEditChange={(isEdit, isDirty) => this.handleEditChange('over', isEdit, isDirty)} /></Col>
+          <Col cols={5} className={styles['col-details']}><DetailsCard vm={vm} onEditChange={(isEdit, isDirty) => this.handleEditChange('detail', isEdit, isDirty)} /></Col>
+          <Col cols={3} className={styles['col-snapshots']}><SnapshotsCard vm={vm} onEditChange={(isEdit, isDirty) => this.handleEditChange('snap', isEdit, isDirty)} /></Col>
         </Row>
         <Row>
-          <Col cols={9}><UtilizationCard vm={vm} /></Col>
-          <Col cols={3}>
+          <Col cols={9} className={styles['col-utilization']}><UtilizationCard vm={vm} /></Col>
+          <Col cols={3} className={styles['col-nics-disks']}>
             <NicsCard vm={vm} onEditChange={(isEdit, isDirty) => this.handleEditChange('nic', isEdit, isDirty)} />
             <DisksCard vm={vm} onEditChange={(isEdit, isDirty) => this.handleEditChange('disk', isEdit, isDirty)} />
           </Col>

--- a/src/components/VmDetails/style.css
+++ b/src/components/VmDetails/style.css
@@ -63,3 +63,11 @@
 div.base-card.cell-card {
   flex-basis: auto;
 }
+
+@media only screen and (max-width: 600px) {
+  .col-overview, .col-details, .col-snapshots, 
+  .col-utilization, .col-nics-disks
+  {
+    min-width: 100%;
+  }
+}


### PR DESCRIPTION
Fixes: suggestions in #946

Problem: Once the card reaches a certain narrow width, the cards become very clustered; contents became jammed and hard to understand

![screenshot-localhost-3000-2019 06 05-11-14-20](https://user-images.githubusercontent.com/25762021/58975809-dc735900-8793-11e9-9ffe-507a968cf332.png)

This PR addresses responsive screen displays on mobile phones: 

![screenshot-localhost-3000-2019 06 05-11-34-33](https://user-images.githubusercontent.com/25762021/58975988-60c5dc00-8794-11e9-8e36-75cf1788f5d0.png)
