### PR TITLE
Make snapshot popover and Disks edit modal more responsive

### DIFF
--- a/src/components/VmDetails/cards/DisksCard/style.css
+++ b/src/components/VmDetails/cards/DisksCard/style.css
@@ -55,3 +55,9 @@
 .editor-field-read-only {
   padding-top: 5px;
 }
+
+@media only screen and (max-width: 600px) {
+  .editor-modal {
+    width: 95%;
+  }
+}

--- a/src/components/VmDetails/cards/SnapshotsCard/style.css
+++ b/src/components/VmDetails/cards/SnapshotsCard/style.css
@@ -35,6 +35,37 @@ div.popover {
   z-index: 20;
 }
 
+@media only screen and (max-width: 600px) {
+  div.popover {
+    width: 90%;
+    margin: 0px 5%;
+  }
+
+  .snapshot-detail-container {
+    display: inline;
+    overflow-wrap: break-word;
+  }
+  
+  .snapshot-detail-container dl {
+    width: 100%;
+    display: flex;
+    flex-flow: row wrap;
+    margin: 0px;
+  }
+
+  .snapshot-detail-container dt {
+    white-space: normal;
+    width: 50%;
+    padding-right: 3px;
+    padding-left: 3px;
+  }
+
+  .snapshot-detail-container dd {
+    width: 50%;
+    float: right;
+  }
+}
+
 .green {
   color: #3B9D2E;
 }


### PR DESCRIPTION
Fixes: suggestions in #946

Make all cards more responsive to different screen sizes. Based on #1028 

### Before:
#### 1. Snapshot detail

![screenshot-localhost-3000-2019 06 05-13-40-50](https://user-images.githubusercontent.com/25762021/58977470-cff0ff80-8797-11e9-8b15-3ae22e8835a8.png)

#### 2. Disk edit

![screenshot-localhost-3000-2019 06 05-11-22-55](https://user-images.githubusercontent.com/25762021/58977502-e1d2a280-8797-11e9-8de7-59eab4146b24.png)

### After:
#### 1. Snapshot detail
![screenshot-localhost-3000-2019 06 05-13-04-41](https://user-images.githubusercontent.com/25762021/58977582-0b8bc980-8798-11e9-8470-8d15c9cec429.png)


#### 2. Disk edit
![screenshot-localhost-3000-2019 06 05-13-05-12](https://user-images.githubusercontent.com/25762021/58977567-04fd5200-8798-11e9-970d-e37c9ee4b3b5.png)
