### PR TITLE
import patternfly-react CSS for runtime use

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,9 +12,9 @@ import { IntlProvider } from 'react-intl'
 
 import logger from '_/logger'
 
-// TODO: Look at this WRT patternfly-react CSS!!!!!!!
 import 'patternfly/dist/css/patternfly.css'
 import 'patternfly/dist/css/patternfly-additions.css'
+import 'patternfly-react/dist/css/patternfly-react.css'
 import './index-nomodules.css'
 import * as branding from '_/branding'
 


### PR DESCRIPTION
This change ensures that all of the necessary `patternfly` and `patternfly-react` CSS files are imported at the base level for the entire app.

Pre-work for PR #987, Issue #923