### PR TITLE
Refactor `FieldValue` to be more generic as `EllipsisValue` with better type handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,12 +68,13 @@
     "whatwg-fetch": "1.0.0"
   },
   "dependencies": {
-    "babel-polyfill": "6.26.0",
     "@patternfly/react-console": "1.10.22",
+    "babel-polyfill": "6.26.0",
     "blob-util": "1.2.1",
     "bootstrap": "3.4.1",
     "bootstrap-select": "1.13.1",
     "bootstrap-switch": "3.3.4",
+    "classnames": "2.2.6",
     "connected-react-router": "4.3.0",
     "history": "4.7.2",
     "immutable": "3.8.2",

--- a/src/components/EllipsisValue/index.js
+++ b/src/components/EllipsisValue/index.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { xor } from '_/propTypeExtras'
 import style from './style.css'
 import classnames from 'classnames'
 
-class FieldValue extends React.Component {
+class EllipsisValue extends React.Component {
   constructor (props) {
     super(props)
     this.ref = React.createRef()
@@ -53,27 +54,16 @@ class FieldValue extends React.Component {
       >
         {children}
       </span>
-    } else {
-      return null
     }
+    return null
   }
 }
 
-FieldValue.propTypes = {
+EllipsisValue.propTypes = {
   className: PropTypes.string,
   id: PropTypes.string,
-  children: function (props, propName, componentName, ...rest) {
-    if ((props.children && !props.tooltip) || (!props.children && props.tooltip)) {
-      return new Error(`Props 'children' and 'tooltip' are both required for component ${componentName}`)
-    }
-    return PropTypes.oneOfType([ PropTypes.string, PropTypes.node ])(props, propName, componentName, ...rest)
-  },
-  tooltip: function (props, propName, componentName, ...rest) {
-    if ((props.children && !props.tooltip) || (!props.children && props.tooltip)) {
-      return new Error(`Props 'children' and 'tooltip' are both required for component ${componentName}`)
-    }
-    return PropTypes.string(props, propName, componentName, ...rest)
-  },
+  children: xor(PropTypes.oneOfType([ PropTypes.string, PropTypes.node ]), 'tooltip'),
+  tooltip: xor(PropTypes.string, 'children'),
 }
 
-export default FieldValue
+export default EllipsisValue

--- a/src/components/EllipsisValue/index.js
+++ b/src/components/EllipsisValue/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import style from './style.css'
+import classnames from 'classnames'
 
 class FieldValue extends React.Component {
   constructor (props) {
@@ -41,11 +42,12 @@ class FieldValue extends React.Component {
   }
 
   render () {
-    const { children, tooltip } = this.props
+    const { className, id, children, tooltip } = this.props
 
     if (children) {
       return <span
-        className={style['field-value']}
+        className={classnames(style['field-value'], className)}
+        id={id}
         title={this.state.isOverflow ? tooltip : ''}
         ref={this.ref}
       >
@@ -58,6 +60,8 @@ class FieldValue extends React.Component {
 }
 
 FieldValue.propTypes = {
+  className: PropTypes.string,
+  id: PropTypes.string,
   children: function (props, propName, componentName, ...rest) {
     if ((props.children && !props.tooltip) || (!props.children && props.tooltip)) {
       return new Error(`Props 'children' and 'tooltip' are both required for component ${componentName}`)

--- a/src/components/EllipsisValue/style.css
+++ b/src/components/EllipsisValue/style.css
@@ -1,0 +1,5 @@
+.field-value {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/src/components/VmDetails/cards/DetailsCard/FieldValue.js
+++ b/src/components/VmDetails/cards/DetailsCard/FieldValue.js
@@ -12,18 +12,9 @@ class FieldValue extends React.Component {
 
     this.updateOverflow = this.updateOverflow.bind(this)
   }
+
   componentDidUpdate () {
     this.updateOverflow()
-  }
-
-  updateOverflow () {
-    const state = { isOverflow: false }
-    if (this.ref.current.offsetWidth < this.ref.current.scrollWidth) {
-      state.isOverflow = true
-    }
-    if (this.state.isOverflow !== state.isOverflow) {
-      this.setState(state)
-    }
   }
 
   componentDidMount () {
@@ -34,17 +25,51 @@ class FieldValue extends React.Component {
   componentWillUnmount () {
     window.removeEventListener('resize', this.updateOverflow)
   }
+
+  updateOverflow () {
+    if (!this.props.children) {
+      return
+    }
+
+    const state = { isOverflow: false }
+    if (this.ref.current.offsetWidth < this.ref.current.scrollWidth) {
+      state.isOverflow = true
+    }
+    if (this.state.isOverflow !== state.isOverflow) {
+      this.setState(state)
+    }
+  }
+
   render () {
     const { children, tooltip } = this.props
-    return <span className={style['field-value']} title={this.state.isOverflow ? tooltip : ''} ref={this.ref}>
-      {children}
-    </span>
+
+    if (children) {
+      return <span
+        className={style['field-value']}
+        title={this.state.isOverflow ? tooltip : ''}
+        ref={this.ref}
+      >
+        {children}
+      </span>
+    } else {
+      return null
+    }
   }
 }
 
 FieldValue.propTypes = {
-  children: PropTypes.oneOfType([ PropTypes.string, PropTypes.node ]).isRequired,
-  tooltip: PropTypes.string.isRequired,
+  children: function (props, propName, componentName, ...rest) {
+    if ((props.children && !props.tooltip) || (!props.children && props.tooltip)) {
+      return new Error(`Props 'children' and 'tooltip' are both required for component ${componentName}`)
+    }
+    return PropTypes.oneOfType([ PropTypes.string, PropTypes.node ])(props, propName, componentName, ...rest)
+  },
+  tooltip: function (props, propName, componentName, ...rest) {
+    if ((props.children && !props.tooltip) || (!props.children && props.tooltip)) {
+      return new Error(`Props 'children' and 'tooltip' are both required for component ${componentName}`)
+    }
+    return PropTypes.string(props, propName, componentName, ...rest)
+  },
 }
 
 export default FieldValue

--- a/src/components/VmDetails/cards/DetailsCard/index.js
+++ b/src/components/VmDetails/cards/DetailsCard/index.js
@@ -31,15 +31,14 @@ import SelectBox from '../../../SelectBox'
 import BaseCard from '../../BaseCard'
 
 import { Grid, Row, Col } from '_/components/Grid'
-import CloudInit from './CloudInit'
+import EllipsisValue from '_/components/EllipsisValue'
+import ExpandCollapseSection from '_/components/ExpandCollapseSection'
 
 import style from './style.css'
 
+import CloudInit from './CloudInit'
 import HotPlugChangeConfirmationModal from './HotPlugConfirmationModal'
 import NextRunChangeConfirmationModal from './NextRunChangeConfirmationModal'
-
-import ExpandCollapseSection from '../../../ExpandCollapseSection'
-import FieldValue from './FieldValue'
 import FieldRow from './FieldRow'
 
 /*
@@ -723,7 +722,7 @@ class DetailsCard extends React.Component {
                 <Col className={style['fields-column']}>
                   <Grid>
                     <FieldRow label={msg.host()} id={`${idPrefix}-host`}>
-                      { <FieldValue tooltip={hostName}>{hostName}</FieldValue> || <NotAvailable tooltip={msg.notAvailableUntilRunning()} id={`${idPrefix}-host-not-available`} /> }
+                      { <EllipsisValue tooltip={hostName}>{hostName}</EllipsisValue> || <NotAvailable tooltip={msg.notAvailableUntilRunning()} id={`${idPrefix}-host-not-available`} /> }
                     </FieldRow>
                     <FieldRow label={msg.ipAddress()} id={`${idPrefix}-ip`}>
                       <React.Fragment>
@@ -739,7 +738,7 @@ class DetailsCard extends React.Component {
                       </React.Fragment>
                     </FieldRow>
                     <FieldRow label={msg.fqdn()} id={`${idPrefix}-fqdn`}>
-                      { <FieldValue tooltip={fqdn}>{fqdn}</FieldValue> || <NotAvailable tooltip={msg.notAvailableUntilRunningAndGuestAgent()} id={`${idPrefix}-fqdn-not-available`} /> }
+                      { <EllipsisValue tooltip={fqdn}>{fqdn}</EllipsisValue> || <NotAvailable tooltip={msg.notAvailableUntilRunningAndGuestAgent()} id={`${idPrefix}-fqdn-not-available`} /> }
                     </FieldRow>
                     <FieldRow label={msg.cluster()} id={`${idPrefix}-cluster`}>
                       { !isFullEdit && clusterName }
@@ -775,10 +774,10 @@ class DetailsCard extends React.Component {
                       { templateName }
                     </FieldRow>
                     <FieldRow label={isEditing ? msg.changeCd() : msg.cd()} id={`${idPrefix}-cdrom`}>
-                      { !isEditing && <FieldValue tooltip={cdImageName}>{cdImageName}</FieldValue> }
+                      { !isEditing && <EllipsisValue tooltip={cdImageName}>{cdImageName}</EllipsisValue> }
                       { isEditing && !canChangeCd &&
                         <div>
-                          <FieldValue tooltip={cdImageName}>{cdImageName}</FieldValue>
+                          <EllipsisValue tooltip={cdImageName}>{cdImageName}</EllipsisValue>
                           <FieldLevelHelp disabled={false} content={msg.cdCanOnlyChangeWhenVmRunning()} inline />
                         </div>
                       }

--- a/src/components/VmDetails/cards/DetailsCard/style.css
+++ b/src/components/VmDetails/cards/DetailsCard/style.css
@@ -53,12 +53,6 @@
   display: inline-block;
 }
 
-.field-value {
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
 button.field-level-help:global(.popover-pf-info) {
   flex-grow: 0;
 }

--- a/src/propTypeExtras.js
+++ b/src/propTypeExtras.js
@@ -1,0 +1,23 @@
+// @flow
+
+import PropTypes from 'prop-types'
+
+/**
+ * Validate the property by verifying the _xorPropName_ existence matches this prop's
+ * existence and then that the prop meets the _baseValidator_'s tests.
+ *
+ * Use this to ensure that both properties must be present or missing.
+ */
+const xor =
+  (baseValidator: PropTypes.Validator, xorPropName: string) =>
+    (props: Object, propName: string, componentName: string, ...rest: Array<any>): Error | null => {
+      if ((props[propName] && !props[xorPropName]) || (!props[propName] && props[xorPropName])) {
+        return new Error(`Props '${propName}' and '${xorPropName}' are both required for component '${componentName}'`)
+      }
+
+      return baseValidator(props, propName, componentName, ...rest)
+    }
+
+export {
+  xor,
+}

--- a/src/propTypeExtras.test.js
+++ b/src/propTypeExtras.test.js
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+
+import PropTypes from 'prop-types'
+import { xor } from '_/propTypeExtras'
+
+describe('xor PropType cross property validation', () => {
+  const propTypesRest = [ 'prop', null, "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED" ]
+
+  it('both exist, and self-verify', () => {
+    const p1 = xor(PropTypes.string, 'p2')
+    const p2 = xor(PropTypes.number, 'p1')
+
+    const r1 = p1({ p1: 'foo', p2: 42 }, 'p1', 'Test', ...propTypesRest)
+    const r2 = p2({ p1: 'foo', p2: 42 }, 'p2', 'Test', ...propTypesRest)
+
+    expect(r1).toBeNull()
+    expect(r2).toBeNull()
+  })
+
+  it('both exist, but one or the other does not self verify', () => {
+    const p1 = xor(PropTypes.string, 'p2')
+    const p2 = xor(PropTypes.number, 'p1')
+
+    const r1 = p1({ p1: 42, p2: 'foo' }, 'p1', 'Test', ...propTypesRest)
+    const r2 = p2({ p1: 42, p2: 'foo' }, 'p2', 'Test', ...propTypesRest)
+
+    expect(r1).toEqual(new Error('Invalid prop `p1` of type `number` supplied to `Test`, expected `string`.'))
+    expect(r2).toEqual(new Error('Invalid prop `p2` of type `string` supplied to `Test`, expected `number`.'))
+  })
+
+  it('one or the other exits, throw error', () => {
+    const p1 = xor(PropTypes.string, 'p2')
+    const p2 = xor(PropTypes.number, 'p1')
+
+    const r1 = p1({ p1: 'foo' }, 'p1', 'Test', ...propTypesRest)
+    const r2 = p2({ p2: 42 }, 'p2', 'Test', ...propTypesRest)
+
+    expect(r1).toEqual(new Error(`Props 'p1' and 'p2' are both required for component 'Test'`))
+    expect(r2).toEqual(new Error(`Props 'p2' and 'p1' are both required for component 'Test'`))
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1879,7 +1879,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.0, classnames@^2.2.5:
+classnames@2.2.6, classnames@^2.2.0, classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
 


### PR DESCRIPTION
When rendering a VM that is not running, the VM's __host__ is undefined.  This causes the `FieldValue` proptype checker to throw an error on the browser console.  The child value is in the JSX code, but the value is `undefined`.

Updated the component's prop type such that `children` and `tooltips` must both be defined or must both be undefined.  If they are not defined, don't bother rendering anything.