### PR TITLE
Remove logger.js in favor of straight console logging

### DIFF
--- a/src/components/VmDialog/index.js
+++ b/src/components/VmDialog/index.js
@@ -8,7 +8,6 @@ import { Link } from 'react-router-dom'
 import NavigationPrompt from 'react-router-navigation-prompt'
 import Switch from 'react-bootstrap-switch'
 
-import logger from '_/logger'
 import { generateUnique, templateNameRenderer } from '_/helpers'
 import { isRunning, getVmIconId, isValidOsIcon, isVmNameValid } from '../utils'
 
@@ -193,7 +192,7 @@ class VmDialog extends React.Component {
       'max': this.state.memory * MAX_VM_MEMORY_FACTOR,
       'guaranteed': Math.round(guaranteed),
     }
-    logger.log('getMemoryPolicy() resulting memory_policy: ', memoryPolicy)
+    console.log('getMemoryPolicy() resulting memory_policy: ', memoryPolicy)
 
     return memoryPolicy
   }
@@ -462,13 +461,13 @@ class VmDialog extends React.Component {
       const clustersList = clusters.toList()
       const def = (clustersList.filter(item => item.get('name') === defaultClusterName).first()) || clustersList.first()
       stateChange.clusterId = def ? def.get('id') : undefined
-      logger.log(`VmDialog initDefaults(): Setting initial value for clusterId = ${this.state.clusterId} to ${stateChange.clusterId}`)
+      console.log(`VmDialog initDefaults(): Setting initial value for clusterId = ${this.state.clusterId} to ${stateChange.clusterId}`)
     }
 
     if (!this.getTemplate()) {
       const def = templates.get(zeroUID) || this.props.templates.toList().first()
       stateChange.templateId = def ? def.get('id') : undefined
-      logger.log(`VmDialog initDefaults(): Setting initial value for templateId = ${this.state.templateId} to ${stateChange.templateId}`)
+      console.log(`VmDialog initDefaults(): Setting initial value for templateId = ${this.state.templateId} to ${stateChange.templateId}`)
     }
 
     if (!this.getOS()) {
@@ -480,7 +479,7 @@ class VmDialog extends React.Component {
           id: os.getIn(['icons', 'large', 'id']),
         }
       }
-      logger.log(`VmDialog initDefaults(): Setting initial value for osId = ${this.state.osId} to ${stateChange.osId}`)
+      console.log(`VmDialog initDefaults(): Setting initial value for osId = ${this.state.osId} to ${stateChange.osId}`)
     }
 
     this.setState(stateChange)

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
 import { IntlProvider } from 'react-intl'
 
-import logger from '_/logger'
+import '_/logger' // initialize our console logging overlay
 
 import 'patternfly/dist/css/patternfly.css'
 import 'patternfly/dist/css/patternfly-additions.css'
@@ -69,7 +69,7 @@ function renderApp (store: Object, errorBridge: Object) {
  */
 function fetchToken (): { token: string, username: string, domain: string, userId: string } {
   const userInfo = window.userInfo
-  logger.log(`SSO userInfo: ${JSON.stringify(userInfo)}`)
+  console.log(`SSO userInfo: ${JSON.stringify(userInfo)}`)
 
   if (userInfo) {
     return {
@@ -93,7 +93,7 @@ function loadPersistedState (store: Object) {
 
   if (icons) {
     const iconsArray = valuesOfObject(icons)
-    logger.log(`loadPersistedState: ${iconsArray.length} icons loaded`)
+    console.log(`loadPersistedState: ${iconsArray.length} icons loaded`)
     store.dispatch(updateIcons({ icons: iconsArray }))
   }
 }
@@ -137,7 +137,7 @@ function SagaErrorBridge () {
 }
 
 function onResourcesLoaded () {
-  logger.log(`Current configuration: ${JSON.stringify(AppConfiguration)}`)
+  console.log(`Current configuration: ${JSON.stringify(AppConfiguration)}`)
 
   addBrandedResources()
 
@@ -156,7 +156,7 @@ function onResourcesLoaded () {
   if (token) {
     store.dispatch(login({ username, token, userId, domain }))
   } else {
-    logger.error('Missing SSO Token!')
+    console.error('Missing SSO Token!')
   }
 }
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,5 +1,8 @@
 let isDebugEnabled = true
 
+/**
+ * Control output of console logging.
+ */
 export function setLogDebug (enabled) {
   isDebugEnabled = enabled
 }
@@ -49,6 +52,8 @@ function attachLoggers (object) {
   })
 }
 
+/**
+ * Enhance the standard browser console logging functions.  Output will be colored
+ * and will log based on the `setLogDebug` value.
+ */
 attachLoggers(window.console)
-
-export default attachLoggers({})

--- a/src/optionsManager.js
+++ b/src/optionsManager.js
@@ -1,5 +1,4 @@
 import { saveToLocalStorage, loadFromLocalStorage, removeFromLocalStorage } from './storage'
-import logger from './logger'
 
 export default {
   loadConsoleOptions ({ vmId }) {
@@ -10,7 +9,7 @@ export default {
     try {
       options = (optionsJson && JSON.parse(optionsJson)) || {}
     } catch (e) {
-      logger.log('Unable to parse consoleOptions from local storage: ', optionsJson)
+      console.log('Unable to parse consoleOptions from local storage: ', optionsJson)
       options = {}
     }
 

--- a/src/ovirtapi/index.js
+++ b/src/ovirtapi/index.js
@@ -7,7 +7,6 @@ import type {
   VmType, ApiVmType,
 } from './types'
 
-import logger from '../logger'
 import Selectors from '../selectors'
 import AppConfiguration from '../config'
 
@@ -209,7 +208,7 @@ const OvirtApi = {
   addNewVm ({ vm, transformInput = true, clone = false }: { vm: VmType | Object, transformInput: boolean, clone: boolean }): Promise<Object> {
     assertLogin({ methodName: 'addNewVm' })
     const input = JSON.stringify(transformInput ? OvirtApi.internalVmToOvirt({ vm }) : vm)
-    logger.log(`OvirtApi.addNewVm(): ${input}`)
+    console.log(`OvirtApi.addNewVm(): ${input}`)
 
     return httpPost({
       url: `${AppConfiguration.applicationContext}/api/vms?clone=${clone ? 'true' : 'false'}`,
@@ -219,7 +218,7 @@ const OvirtApi = {
   editVm ({ vm, nextRun = false, transformInput = true }: { vm: VmType | Object, nextRun: boolean, transformInput: boolean}): Promise<Object> {
     assertLogin({ methodName: 'editVm' })
     const input = JSON.stringify(transformInput ? OvirtApi.internalVmToOvirt({ vm }) : vm)
-    logger.log(`OvirtApi.editVm(): ${input}`, 'nextRun?', nextRun)
+    console.log(`OvirtApi.editVm(): ${input}`, 'nextRun?', nextRun)
 
     const suffix = nextRun ? '?next_run=true' : ''
 
@@ -260,7 +259,7 @@ const OvirtApi = {
   addNewSnapshot ({ vmId, snapshot }: { vmId: string, snapshot: SnapshotType }): Promise<Object> {
     assertLogin({ methodName: 'addNewSnapshot' })
     const input = JSON.stringify(OvirtApi.internalSnapshotToOvirt({ snapshot }))
-    logger.log(`OvirtApi.addNewSnapshot(): ${input}`)
+    console.log(`OvirtApi.addNewSnapshot(): ${input}`)
     return httpPost({
       url: `${AppConfiguration.applicationContext}/api/vms/${vmId}/snapshots`,
       input,
@@ -409,7 +408,7 @@ const OvirtApi = {
   changeCdRom ({ cdrom, vmId, current = true }: { cdrom: CdRomType, vmId: string, current?: boolean }): Promise<Object> {
     assertLogin({ methodName: 'changeCdRom' })
     const input = JSON.stringify(OvirtApi.internalCdRomToOvirt({ cdrom }))
-    logger.log(`OvirtApi.changeCdRom(): ${input}`)
+    console.log(`OvirtApi.changeCdRom(): ${input}`)
     return httpPut({
       url: `${AppConfiguration.applicationContext}/api/vms/${vmId}/cdroms/${zeroUUID}?current=${current ? 'true' : 'false'}`,
       input,
@@ -562,18 +561,18 @@ function getOptionWithoutDefault (optionName: string, version: string): Promise<
           .map(valueAndVersion => valueAndVersion.value)[0]
       } catch (error) {
         if (error instanceof TypeError) {
-          logger.log(`Response to getting option '${optionName}' has unexpected format:`, response)
+          console.log(`Response to getting option '${optionName}' has unexpected format:`, response)
         }
         throw error
       }
       if (result === undefined) {
-        logger.log(`Config option '${optionName}' was not found for version '${version}'.`)
+        console.log(`Config option '${optionName}' was not found for version '${version}'.`)
         return null
       }
       return result
     }, error => {
       if (error.status === 404) {
-        logger.log(`Config option '${optionName}' doesn't exist in any version.`)
+        console.log(`Config option '${optionName}' doesn't exist in any version.`)
         return null
       }
       throw error

--- a/src/ovirtapi/transport.js
+++ b/src/ovirtapi/transport.js
@@ -3,7 +3,6 @@
 import $ from 'jquery'
 import AppConfiguration from '../config'
 import { Exception } from '../exceptions'
-import logger from '../logger'
 import Selectors from '../selectors'
 
 //
@@ -71,18 +70,18 @@ function httpGet ({ url, custHeaders = {} }: GetRequestType): Promise<Object> {
     ...custHeaders,
   }
 
-  logger.log(`http GET[${myCounter}] -> url: "${url}", headers: ${logHeaders(headers)}`)
+  console.log(`http GET[${myCounter}] -> url: "${url}", headers: ${logHeaders(headers)}`)
   return $.ajax(url, {
     type: 'GET',
     headers,
   })
     .then((data: Object): Object => {
       notifyStop(requestId)
-      logger.log(`http GET[${myCounter}] <- data:`, data)
+      console.log(`http GET[${myCounter}] <- data:`, data)
       return data
     })
     .catch((data: Object): Promise<Object> => {
-      logger.log(`Ajax GET failed: ${JSON.stringify(data)}`)
+      console.log(`Ajax GET failed: ${JSON.stringify(data)}`)
       notifyStop(requestId)
       return Promise.reject(data)
     })
@@ -106,7 +105,7 @@ function httpPost ({ url, input, contentType = 'application/json' }: InputReques
       return data
     })
     .catch((data: Object): Promise<Object> => {
-      logger.log(`Ajax POST failed: ${JSON.stringify(data)}`)
+      console.log(`Ajax POST failed: ${JSON.stringify(data)}`)
       notifyStop(requestId)
       return Promise.reject(data)
     })
@@ -130,7 +129,7 @@ function httpPut ({ url, input, contentType = 'application/json' }: InputRequest
       return data
     })
     .catch((data: Object): Promise<Object> => {
-      logger.log(`Ajax PUT failed: ${JSON.stringify(data)}`)
+      console.log(`Ajax PUT failed: ${JSON.stringify(data)}`)
       notifyStop(requestId)
       return Promise.reject(data)
     })
@@ -151,7 +150,7 @@ function httpDelete ({ url, custHeaders = { 'Accept': 'application/json' } }: De
       return data
     })
     .catch((data: Object): Promise<Object> => {
-      logger.log(`Ajax DELETE failed: ${JSON.stringify(data)}`)
+      console.log(`Ajax DELETE failed: ${JSON.stringify(data)}`)
       notifyStop(requestId)
       return Promise.reject(data)
     })

--- a/src/reducers/utils.js
+++ b/src/reducers/utils.js
@@ -1,5 +1,4 @@
 import { Map } from 'immutable'
-import logger from '../logger'
 import { UPDATE_ICONS, REMOVE_ACTIVE_REQUEST, DELAYED_REMOVE_ACTIVE_REQUEST, ADD_ACTIVE_REQUEST } from '_/constants'
 
 /**
@@ -45,7 +44,7 @@ export const actionReducer = (initialState, handlers, verbose) => (state = initi
     }
 
     if (![ ADD_ACTIVE_REQUEST, REMOVE_ACTIVE_REQUEST, DELAYED_REMOVE_ACTIVE_REQUEST ].includes(action.type)) {
-      logger.log('Reducing action:', actionJson)
+      console.log('Reducing action:', actionJson)
     }
   }
 

--- a/src/reducers/vms.js
+++ b/src/reducers/vms.js
@@ -24,7 +24,6 @@ import {
   UPDATE_VMS,
   VM_ACTION_IN_PROGRESS,
 } from '_/constants'
-import logger from '../logger'
 import { actionReducer, removeMissingItems } from './utils'
 
 const initialState = Immutable.fromJS({
@@ -87,7 +86,7 @@ const vms = actionReducer(initialState, {
     if (state.getIn(['vms', vmId])) {
       return state.setIn(['vms', vmId, 'disks'], Immutable.fromJS(disks)) // deep immutable
     } else { // fail, if VM not found
-      logger.error(`vms.setVmDisks() reducer: vmId ${vmId} not found`)
+      console.error(`vms.setVmDisks() reducer: vmId ${vmId} not found`)
     }
     return state
   },
@@ -105,7 +104,7 @@ const vms = actionReducer(initialState, {
     if (state.getIn(['vms', vmId])) {
       return state.setIn(['vms', vmId, 'cdrom'], Immutable.fromJS(cdrom)) // deep immutable
     } else { // fail, if VM not found
-      logger.error(`vms[${SET_VM_CDROM}] reducer: vmId ${vmId} not found`)
+      console.error(`vms[${SET_VM_CDROM}] reducer: vmId ${vmId} not found`)
     }
     return state
   },
@@ -114,7 +113,7 @@ const vms = actionReducer(initialState, {
       return state.setIn(['vms', vmId, 'snapshots'], Immutable.fromJS(snapshots)) // deep immutable
     }
 
-    logger.error(`vms.setVmSnapshots() reducer: vmId ${vmId} not found`)
+    console.error(`vms.setVmSnapshots() reducer: vmId ${vmId} not found`)
     return state
   },
   [UPDATE_VM_SNAPSHOT] (state, { payload: { vmId, snapshot } }) {
@@ -130,14 +129,14 @@ const vms = actionReducer(initialState, {
       return state
     }
 
-    logger.error(`vms.setVmSnapshots() reducer: vmId ${vmId} not found`)
+    console.error(`vms.setVmSnapshots() reducer: vmId ${vmId} not found`)
     return state
   },
   [SET_VM_NICS] (state, { payload: { vmId, nics } }) {
     if (state.getIn(['vms', vmId])) {
       return state.setIn(['vms', vmId, 'nics'], Immutable.fromJS(nics)) // deep immutable
     } else { // fail, if VM not found
-      logger.error(`vms.setVmNics() reducer: vmId ${vmId} not found`)
+      console.error(`vms.setVmNics() reducer: vmId ${vmId} not found`)
     }
     return state
   },
@@ -216,7 +215,7 @@ const vms = actionReducer(initialState, {
       if (state.getIn(['vms', vmId])) {
         return state.setIn(['vms', vmId, 'lastMessage'], shortMessage || message)
       } else {
-        logger.error(`API reports an error associated to nonexistent VM ${vmId}, error`,
+        console.error(`API reports an error associated to nonexistent VM ${vmId}, error`,
           { message, shortMessage, type, failedAction })
       }
     }

--- a/src/sagas/console/index.js
+++ b/src/sagas/console/index.js
@@ -3,7 +3,6 @@ import { put } from 'redux-saga/effects'
 import Api from '_/ovirtapi'
 import Selectors from '_/selectors'
 import OptionsManager from '_/optionsManager'
-import logger from '_/logger'
 import { fileDownload } from '_/helpers'
 import { doesVmSessionExistForUserId } from '_/utils'
 import {
@@ -56,7 +55,7 @@ export function* downloadVmConsole (action) {
     if (data.indexOf('type=spice') > -1 || !isNoVNC) {
       let options = Selectors.getConsoleOptions({ vmId })
       if (!options) {
-        logger.log('downloadVmConsole() console options not yet present, trying to load from local storage')
+        console.log('downloadVmConsole() console options not yet present, trying to load from local storage')
         options = yield getConsoleOptions(getConsoleOptionsAction({ vmId }))
       }
 

--- a/src/sagas/console/vvFileUtils.js
+++ b/src/sagas/console/vvFileUtils.js
@@ -1,8 +1,7 @@
-import logger from '../../logger'
 
 export function adjustVVFile ({ data, options, usbFilter, isSpice }) {
   // __options__ can either be a plain JS object or ImmutableJS Map
-  logger.log('adjustVVFile options:', options)
+  console.log('adjustVVFile options:', options)
 
   if (options && ((options.get && options.get('fullscreen')) || options.fullscreen)) {
     data = data.replace(/^fullscreen=0/mg, 'fullscreen=1')
@@ -14,10 +13,10 @@ export function adjustVVFile ({ data, options, usbFilter, isSpice }) {
     text = 'secure-attention=ctrl+alt+end'
   }
   if (data.match(pattern)) {
-    logger.log('secure-attention found, replacing by ', text)
+    console.log('secure-attention found, replacing by ', text)
     data = data.replace(pattern, text)
   } else {
-    logger.log('secure-attention was not found, inserting ', text)
+    console.log('secure-attention was not found, inserting ', text)
     data = data.replace(/^\[virt-viewer\]$/mg, `[virt-viewer]\n${text}`) // ending \n is already there
   }
 
@@ -30,6 +29,6 @@ export function adjustVVFile ({ data, options, usbFilter, isSpice }) {
     data = data.replace(/^enable-smartcard=[01]$/mg, `enable-smartcard=${smartcardEnabled ? 1 : 0}`)
   }
 
-  logger.log('adjustVVFile data after adjustment:', data)
+  console.log('adjustVVFile data after adjustment:', data)
   return data
 }

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -20,8 +20,6 @@ import {
   throttle,
 } from 'redux-saga/effects'
 
-import logger from '_/logger'
-
 import { push } from 'connected-react-router'
 import {
   setChanged,
@@ -368,7 +366,7 @@ function* fetchVmsByPageVLower (action) {
       yield fetchVmsSnapshots({ vms: internalVms })
       // TODO: Support <4.2 for statistics?
     } else {
-      logger.log('getVmsByPage() shallow fetch requested - skipping other resources')
+      console.log('getVmsByPage() shallow fetch requested - skipping other resources')
     }
   }
 
@@ -430,7 +428,7 @@ function* fetchVmsByCountVLower (action) {
       yield fetchVmsSnapshots({ vms: internalVms })
       // TODO: Support <4.2 for statistics?
     } else {
-      logger.log('fetchVmsByCountVLower() shallow fetch requested - skipping other resources')
+      console.log('fetchVmsByCountVLower() shallow fetch requested - skipping other resources')
     }
   }
 
@@ -1005,11 +1003,11 @@ let _SchedulerCount = 0
 
 function* schedulerWithFixedDelay (delayInSeconds = AppConfiguration.schedulerFixedDelayInSeconds) {
   const myId = _SchedulerCount++
-  logger.log(`⏰ schedulerWithFixedDelay[${myId}] starting fixed delay scheduler`)
+  console.log(`⏰ schedulerWithFixedDelay[${myId}] starting fixed delay scheduler`)
 
   let enabled = true
   while (enabled) {
-    logger.log(`⏰ schedulerWithFixedDelay[${myId}] stoppable delay for: ${delayInSeconds}`)
+    console.log(`⏰ schedulerWithFixedDelay[${myId}] stoppable delay for: ${delayInSeconds}`)
     const { stopped } = yield race({
       stopped: take(STOP_SCHEDULER_FIXED_DELAY),
       fixedDelay: call(delay, (delayInSeconds * 1000)),
@@ -1017,9 +1015,9 @@ function* schedulerWithFixedDelay (delayInSeconds = AppConfiguration.schedulerFi
 
     if (stopped) {
       enabled = false
-      logger.log(`⏰ schedulerWithFixedDelay[${myId}] scheduler has been stopped`)
+      console.log(`⏰ schedulerWithFixedDelay[${myId}] scheduler has been stopped`)
     } else {
-      logger.log(`⏰ schedulerWithFixedDelay[${myId}] running after delay of: ${delayInSeconds}`)
+      console.log(`⏰ schedulerWithFixedDelay[${myId}] running after delay of: ${delayInSeconds}`)
 
       const oVirtVersion = Selectors.getOvirtVersion()
       if (oVirtVersion.get('passed')) {
@@ -1029,7 +1027,7 @@ function* schedulerWithFixedDelay (delayInSeconds = AppConfiguration.schedulerFi
           page: Selectors.getCurrentFetchPage(),
         }))
       } else {
-        logger.log(`⏰ schedulerWithFixedDelay[${myId}] event skipped since oVirt API version does not match`)
+        console.log(`⏰ schedulerWithFixedDelay[${myId}] event skipped since oVirt API version does not match`)
       }
     }
   }

--- a/src/sagas/login.js
+++ b/src/sagas/login.js
@@ -5,7 +5,6 @@ import Product from '_/version'
 import Api from '_/ovirtapi'
 import AppConfiguration from '_/config'
 import OptionsManager from '_/optionsManager'
-import logger from '_/logger'
 
 import {
   loginSuccessful,
@@ -76,7 +75,7 @@ function* login (action) {
   const oVirtMeta = yield callExternalAction('getOvirtApiMeta', Api.getOvirtApiMeta, action)
   const versionOk = yield checkOvirtApiVersion(oVirtMeta)
   if (!versionOk) {
-    logger.error('oVirt API version check failed')
+    console.error('oVirt API version check failed')
     yield put(failedExternalAction({
       message: composeIncompatibleOVirtApiVersionMessage(oVirtMeta),
       shortMessage: 'oVirt API version check failed', // TODO: Localize
@@ -125,7 +124,7 @@ function* checkOvirtApiVersion (oVirtMeta) {
         oVirtMeta['product_info']['version'] &&
         oVirtMeta['product_info']['version']['major'] &&
         oVirtMeta['product_info']['version']['minor'])) {
-    logger.error('Incompatible oVirt API version: ', oVirtMeta)
+    console.error('Incompatible oVirt API version: ', oVirtMeta)
     yield put(setOvirtApiVersion({ passed: false, ...oVirtMeta }))
     return false
   }

--- a/src/sagas/utils.js
+++ b/src/sagas/utils.js
@@ -6,7 +6,6 @@ import {
 import AppConfiguration from '_/config'
 import { hidePassword } from '_/helpers'
 import { msg } from '_/intl'
-import logger from '_/logger'
 import Api from '_/ovirtapi'
 import { getUserPermits } from '_/utils'
 
@@ -28,7 +27,7 @@ export const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms))
  * Backward compatibility of the API is assumed.
  */
 export function compareVersion (actual, required) {
-  logger.log(`compareVersion(), actual=${JSON.stringify(actual)}, required=${JSON.stringify(required)}`)
+  console.log(`compareVersion(), actual=${JSON.stringify(actual)}, required=${JSON.stringify(required)}`)
 
   if (actual.major >= required.major) {
     if (actual.major === required.major) {
@@ -43,12 +42,12 @@ export function compareVersion (actual, required) {
 
 export function* callExternalAction (methodName, method, action, canBeMissing = false) {
   try {
-    logger.log(`External action: ${JSON.stringify(hidePassword({ action }))}, API method: ${methodName}()`)
+    console.log(`External action: ${JSON.stringify(hidePassword({ action }))}, API method: ${methodName}()`)
     const result = yield call(method, action.payload)
     return result
   } catch (e) {
     if (!canBeMissing) {
-      logger.log(`External action exception: ${JSON.stringify(e)}`)
+      console.log(`External action exception: ${JSON.stringify(e)}`)
 
       if (e.status === 401) { // Unauthorized
         yield put(checkTokenExpired())
@@ -72,22 +71,22 @@ export function* callExternalAction (methodName, method, action, canBeMissing = 
 export function* doCheckTokenExpired (action) {
   try {
     yield call(Api.getOvirtApiMeta, action.payload)
-    logger.info('doCheckTokenExpired(): token is still valid') // info level: to pair former HTTP 401 error message with updated information
+    console.info('doCheckTokenExpired(): token is still valid') // info level: to pair former HTTP 401 error message with updated information
     return
   } catch (error) {
     if (error.status === 401) {
-      logger.info('Token expired, going to reload the page')
+      console.info('Token expired, going to reload the page')
       yield put(showTokenExpiredMessage())
 
       // Reload the page after a delay
       // No matter saga is canceled for whatever reason, the reload must happen, so here comes the ugly setTimeout()
       setTimeout(() => {
-        logger.info('======= doCheckTokenExpired() issuing page reload')
+        console.info('======= doCheckTokenExpired() issuing page reload')
         window.location.href = AppConfiguration.applicationURL
       }, 5 * 1000)
       return
     }
-    logger.error('doCheckTokenExpired(): unexpected oVirt API error: ', error)
+    console.error('doCheckTokenExpired(): unexpected oVirt API error: ', error)
   }
 }
 
@@ -105,7 +104,7 @@ export function* waitTillEqual (leftArg, rightArg, limit) {
     yield delay(20) // in ms
     counter--
 
-    logger.log('waitTillEqual() delay ...')
+    console.log('waitTillEqual() delay ...')
   }
 
   return false

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,8 +1,6 @@
-/**
+/*
  Local/Session Storage manipulation
  */
-
-import logger from './logger'
 
 export function saveToLocalStorage (key, value) {
   window.localStorage.setItem(key, value)
@@ -17,12 +15,12 @@ export function removeFromLocalStorage (key) {
 }
 
 export function persistStateToLocalStorage ({ icons }) {
-  logger.log(`persistStateToLocalStorage() called`)
+  console.log(`persistStateToLocalStorage() called`)
   saveToLocalStorage('icons', JSON.stringify(icons))
 }
 
 export function loadStateFromLocalStorage () {
-  logger.log(`loadStateFromLocalStorage() called`)
+  console.log(`loadStateFromLocalStorage() called`)
   return {
     icons: JSON.parse(loadFromLocalStorage('icons')),
   }


### PR DESCRIPTION
`logger.js` is structured in such a way that standard console logging
is enhanced and is identical in functionality to using the exported
logger.  To maintain consistency across the code base for logging,
the exported version of logger has been removed and its previous usage
has been replaced by traditional console logging.