### PR TITLE
Only show file system chart when there is >0 file systems

### DIFF
--- a/src/components/VmDetails/cards/UtilizationCard/DiskCharts.js
+++ b/src/components/VmDetails/cards/UtilizationCard/DiskCharts.js
@@ -74,7 +74,8 @@ DiskBar.propTypes = {
  *       via REST. Storage allocation is being used instead.
  */
 const DiskCharts = ({ vm, diskStats, isRunning, id, ...props }) => {
-  const diskDetails = diskStats && diskStats['usage'] && diskStats['usage'].datum
+  const diskDetails = diskStats && diskStats.usage && diskStats.usage.datum
+  const hasDiskDetails = diskDetails && diskDetails.length > 0
 
   let actualSize = 0
   let provisionedSize = 0
@@ -125,7 +126,7 @@ const DiskCharts = ({ vm, diskStats, isRunning, id, ...props }) => {
                 </UtilizationCardDetailsLine2>
               </UtilizationCardDetailsDesc>
             </UtilizationCardDetails>
-            { !diskDetails &&
+            { !hasDiskDetails &&
               <DonutChart
                 id={`${id}-donut-chart`}
                 data={{
@@ -145,7 +146,7 @@ const DiskCharts = ({ vm, diskStats, isRunning, id, ...props }) => {
                 }}
               />
             }
-            { isRunning && diskDetails &&
+            { isRunning && hasDiskDetails &&
               <div className={style['disk-fs-list']}>
                 {
                   diskDetails.map((disk) =>
@@ -154,14 +155,14 @@ const DiskCharts = ({ vm, diskStats, isRunning, id, ...props }) => {
                 }
               </div>
             }
-            { isRunning && !diskDetails &&
+            { isRunning && !hasDiskDetails &&
               <NoHistoricData message={msg.utilizationCardNoGuestAgent()} />
             }
             {/*
               Disks don't have historic data but stub the space so the card stretches like the others,
               thus if message above doesn't show, need to insert EmptyBlock
             */}
-            { !(isRunning && !diskDetails) &&
+            { !(isRunning && !hasDiskDetails) &&
               <EmptyBlock />
             }
           </React.Fragment>


### PR DESCRIPTION
Fixes: #1055

There is a permutation where the standard QEMU guest agent
will not report actual per file system data.  In this case, the
VM's `disks.usage` statistic is an empty array.  This case is
now tested, and if the usage array is empty, the unallocated vs
provisioned donut chart is displayed (as if the guest agent is
not installed).

Showing the same VM used to report #1055:
![screenshot-localhost-3000-2019 07 03-15-16-49](https://user-images.githubusercontent.com/3985964/60619003-a5e62980-9da5-11e9-86a4-8c5b211d8992.png)
