### PR TITLE
Allow starting dev server without opening browser

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -58,6 +58,15 @@ to accomplish this. To start the server:
 When asked, provide a valid user name (in the form of `user@domain`) and password so
 the application can start in the context of a logged in user.
 
+When the dev server is started, it will attempt to open a new browser window/tab on
+your system default browser to the app's running URL.  This behavior can be modified
+by specifying the `BROWSER` environment variable.  Possible values are:
+    BROWSER=none               # disable the feature
+    BROWSER=google-chrome      # open a new tab in chrome on Linux
+    BROWSER='google chrome'    # open a new tab in chrome on MacOS
+    BROWSER=chrome             # open a new tab in chrome on Windows
+    BROWSER=firefox            # open a new tab in firefox on Linux
+
 
 ### Build
 You can build the static assets from source by:

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -134,9 +134,11 @@ function openBrowser(port, protocol) {
   if (process.env.BROWSER) {
     options.app = process.env.BROWSER
   }
-  opn(protocol + '://localhost:' + port + '/', options).catch(err => {
-    // ignore errors - can happen when starting the server in docker container
-  })
+  if (options.app !== 'none') {
+    opn(protocol + '://localhost:' + port + '/', options).catch(err => {
+      // ignore errors - can happen when starting the server in docker container
+    })
+  }
 }
 
 // We need to provide a custom onError function for httpProxyMiddleware.


### PR DESCRIPTION
Simple change to the `start.js` such that if the BROWSER env var is set to "none", the script will not attempt to open a browser window/tab to the newly started server.  This is useful when running the server on a remote box that has a GUI so random tabs aren't open every time the server is restarted (and freaking out whoever is sitting at the remote box).