### PR TITLE
Refactor App init code (redux store create and config) and OS icon caching

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -8,7 +8,6 @@ import {
   GET_USB_FILTER,
   GET_USER_GROUPS,
   GET_VM,
-  PERSIST_STATE,
   SET_ADMINISTRATOR,
   SET_CPU_TOPOLOGY_OPTIONS,
   SET_CURRENT_PAGE,
@@ -53,10 +52,6 @@ export function startSchedulerFixedDelay (delayInSeconds = AppConfiguration.sche
 
 export function stopSchedulerFixedDelay () {
   return { type: STOP_SCHEDULER_FIXED_DELAY }
-}
-
-export function persistState () {
-  return { type: PERSIST_STATE }
 }
 
 /**

--- a/src/components/VmsList/BaseCard.js
+++ b/src/components/VmsList/BaseCard.js
@@ -34,20 +34,21 @@ BaseCardHeader.propTypes = {
   ]).isRequired,
 }
 
-const BaseCardIcon = ({ url, icon }) => (
-  url
-    ? <Link to={url}>
-      <VmIcon icon={icon} className={style['card-pf-icon']}
-        missingIconClassName='fa fa-birthday-cake card-pf-icon-circle' />
-    </Link>
-    : <VmIcon icon={icon} className={style['card-pf-icon']}
-      missingIconClassName='fa fa-birthday-cake card-pf-icon-circle' />
-)
+const BaseCardIcon = ({ url, icon }) => {
+  const i =
+    <VmIcon
+      icon={icon}
+      className={style['card-pf-icon']}
+      missingIconClassName='fa fa-birthday-cake card-pf-icon-circle'
+    />
+
+  return (url ? <Link to={url}>{i}</Link> : i)
+}
 
 BaseCardIcon.displayName = ICON_NAME
 
 BaseCardIcon.propTypes = {
-  icon: PropTypes.object.isRequired,
+  icon: PropTypes.object,
   url: PropTypes.string,
 }
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -51,7 +51,6 @@ export const LOGIN_SUCCESSFUL = 'LOGIN_SUCCESSFUL'
 export const LOGOUT = 'LOGOUT'
 export const MAX_VM_MEMORY_FACTOR = 4 // see Edit VM flow; magic constant to stay aligned with Web Admin
 export const OPEN_CONSOLE_VM = 'OPEN_CONSOLE_VM'
-export const PERSIST_STATE = 'PERSIST_STATE'
 export const POOL_ACTION_IN_PROGRESS = 'POOL_ACTION_IN_PROGRESS'
 export const REDIRECT = 'REDIRECT'
 export const REFRESH_DATA = 'REFRESH_DATA'

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -67,10 +67,6 @@ export function fileDownload ({ data, fileName = 'myFile.dat', mimeType = 'appli
   }
 }
 
-export function valuesOfObject (obj) {
-  return Object.keys(obj).map(key => obj[key])
-}
-
 export function generateUnique (prefix) {
   prefix = prefix || ''
   return prefix + 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {

--- a/src/index.js
+++ b/src/index.js
@@ -22,12 +22,9 @@ import { getSelectedMessages, locale } from '_/intl'
 import configureStore from '_/store'
 import Selectors from '_/selectors'
 import AppConfiguration, { readConfiguration } from '_/config'
-import { loadStateFromLocalStorage } from '_/storage'
-import { valuesOfObject } from '_/helpers'
 import { rootSaga } from '_/sagas'
 import {
   login,
-  updateIcons,
   addActiveRequest,
   delayedRemoveActiveRequest,
 } from '_/actions'
@@ -87,17 +84,6 @@ function fetchToken (): { token: string, username: string, domain: string, userI
   }
 }
 
-function loadPersistedState (store: Object) {
-  // load persisted icons, etc ...
-  const { icons } = loadStateFromLocalStorage()
-
-  if (icons) {
-    const iconsArray = valuesOfObject(icons)
-    console.log(`loadPersistedState: ${iconsArray.length} icons loaded`)
-    store.dispatch(updateIcons({ icons: iconsArray }))
-  }
-}
-
 function addBrandedResources () {
   addLinkElement('shortcut icon', branding.resourcesUrls.favicon)
   addLinkElement('stylesheet', branding.resourcesUrls.brandStylesheet)
@@ -147,11 +133,11 @@ function onResourcesLoaded () {
   rootTask.done.catch(err => sagaErrorBridge.throw(err))
   Selectors.init({ store })
   initializeApiListener(store)
-  loadPersistedState(store)
 
   // do initial render
   renderApp(store, sagaErrorBridge)
 
+  // and start the login/init-data-load action
   const { token, username, domain, userId }: { token: string, username: string, domain: string, userId: string } = fetchToken()
   if (token) {
     store.dispatch(login({ username, token, userId, domain }))

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
 import { IntlProvider } from 'react-intl'
+import { type Task } from 'redux-saga'
 
 import '_/logger' // initialize our console logging overlay
 
@@ -22,13 +23,7 @@ import { getSelectedMessages, locale } from '_/intl'
 import configureStore from '_/store'
 import Selectors from '_/selectors'
 import AppConfiguration, { readConfiguration } from '_/config'
-import { rootSaga } from '_/sagas'
-import {
-  login,
-  addActiveRequest,
-  delayedRemoveActiveRequest,
-} from '_/actions'
-import OvirtApi from '_/ovirtapi'
+import { login } from '_/actions'
 
 import App from './App'
 import GlobalErrorBoundary from './GlobalErrorBoundary'
@@ -97,20 +92,9 @@ function addLinkElement (rel: string, href: string) {
   window.document.head.appendChild(linkElement)
 }
 
-function initializeApiListener (store: Object) {
-  OvirtApi.addHttpListener((requestId, eventType) => {
-    if (eventType === 'START') {
-      store.dispatch(addActiveRequest(requestId))
-      return
-    }
-    if (eventType === 'STOP') {
-      store.dispatch(delayedRemoveActiveRequest(requestId))
-    }
-  })
-}
-
-function SagaErrorBridge () {
+function SagaErrorBridge (storeRootTask: Task) {
   let handler = null
+
   this.setErrorHandler = (errorHandler) => {
     handler = errorHandler
   }
@@ -120,6 +104,8 @@ function SagaErrorBridge () {
       handler(err)
     }
   }
+
+  storeRootTask.done.catch(err => this.throw(err))
 }
 
 function onResourcesLoaded () {
@@ -128,14 +114,10 @@ function onResourcesLoaded () {
   addBrandedResources()
 
   const store = configureStore()
-  const rootTask = store.runSaga(rootSaga)
-  const sagaErrorBridge = new SagaErrorBridge()
-  rootTask.done.catch(err => sagaErrorBridge.throw(err))
   Selectors.init({ store })
-  initializeApiListener(store)
 
   // do initial render
-  renderApp(store, sagaErrorBridge)
+  renderApp(store, new SagaErrorBridge(store.rootTask))
 
   // and start the login/init-data-load action
   const { token, username, domain, userId }: { token: string, username: string, domain: string, userId: string } = fetchToken()

--- a/src/sagas/login.js
+++ b/src/sagas/login.js
@@ -54,6 +54,7 @@ import {
 import { downloadVmConsole } from './console'
 import { fetchServerConfiguredValues } from './server-configs'
 import { fetchDataCentersAndStorageDomains, fetchIsoFiles } from './storageDomains'
+import { loadIconsFromLocalStorage } from './osIcons'
 
 import { loadFromLocalStorage } from '_/storage'
 
@@ -187,6 +188,7 @@ function* loadFilters () {
 function* initialLoad () {
   // no data prerequisites
   yield all([
+    call(loadIconsFromLocalStorage),
     call(fetchUserGroups, getUserGroups()),
     call(fetchAllOS, getAllOperatingSystems()),
     call(fetchAllHosts, getAllHosts()),

--- a/src/sagas/osIcons.js
+++ b/src/sagas/osIcons.js
@@ -1,0 +1,54 @@
+import { all, call, put, select } from 'redux-saga/effects'
+import { loadFromLocalStorage, saveToLocalStorage } from '_/storage'
+import { updateIcons } from '_/actions'
+import Api from '_/ovirtapi'
+
+import { callExternalAction } from './utils'
+
+export function* loadIconsFromLocalStorage () {
+  const iconMapString = loadFromLocalStorage('icons')
+  try {
+    const iconMap = iconMapString && JSON.parse(iconMapString)
+    if (iconMap) {
+      const iconArray = Object.values(iconMap)
+      console.log(`Loaded ${iconArray.length} cached icons from localStorage`)
+      yield put(updateIcons({ icons: iconArray }))
+    }
+  } catch (e) {
+    console.error('Unexpected value of `icons` in localStorage', e)
+  }
+}
+
+function* pushIconsToLocalStorage () {
+  const iconMap = yield select(state => state.icons) // ImmutableJS Map
+  const iconsString = JSON.stringify(iconMap)
+  saveToLocalStorage('icons', iconsString)
+}
+
+export function* fetchUnknownIcons ({ vms = [], os = [] }) {
+  // unique iconIds from all VMs or OS
+  const iconsIds = new Set()
+  vms.forEach(vm => iconsIds.add(vm.icons.large.id))
+  os.forEach(os => iconsIds.add(os.icons.large.id))
+
+  // reduce to just unknown
+  const allKnownIcons = yield select(state => state.icons)
+  const notLoadedIconIds = [...iconsIds].filter(id => id && !allKnownIcons.has(id))
+
+  if (notLoadedIconIds.length > 0) {
+    console.log(`Fetching ${notLoadedIconIds.length} OS icons:`, notLoadedIconIds)
+    yield all(notLoadedIconIds.map(iconId => call(fetchIcon, { iconId })))
+    yield pushIconsToLocalStorage()
+  }
+}
+
+function* fetchIcon ({ iconId }) {
+  if (!iconId) {
+    return
+  }
+
+  const icon = yield callExternalAction('icon', Api.icon, { payload: { id: iconId } })
+  if (icon['media_type'] && icon['data']) {
+    yield put(updateIcons({ icons: [Api.iconToInternal({ icon })] }))
+  }
+}

--- a/src/storage.js
+++ b/src/storage.js
@@ -14,18 +14,6 @@ export function removeFromLocalStorage (key) {
   return window.localStorage.removeItem(key)
 }
 
-export function persistStateToLocalStorage ({ icons }) {
-  console.log(`persistStateToLocalStorage() called`)
-  saveToLocalStorage('icons', JSON.stringify(icons))
-}
-
-export function loadStateFromLocalStorage () {
-  console.log(`loadStateFromLocalStorage() called`)
-  return {
-    icons: JSON.parse(loadFromLocalStorage('icons')),
-  }
-}
-
 // --------------------
 export function saveToSessionStorage (key, value) {
   window.sessionStorage.setItem(key, value)


### PR DESCRIPTION
Redux store refactoring:
 - All of the redux store creation and configuration, including saga middleware and ovirt API activity listening, is now done only in **store.js**.

Made the OS icon handling more consistent with the other entities:
 - Moved the code that loads cached OS icons (from browser local storage) to the login saga.
 - Refactored the OS icon handling to **src/saga/osIcon.js**.