### PR TITLE
Add kebob actions menu and changed Shutdown button type to default in Dashboard

### DIFF
--- a/src/components/VmActions/Action.js
+++ b/src/components/VmActions/Action.js
@@ -88,16 +88,16 @@ Button.propTypes = {
   id: PropTypes.string.isRequired,
 }
 
-const MenuItemAction = ({ id, confirmation, shortTitle, icon, onClick }) => {
+const MenuItemAction = ({ confirmation, shortTitle, icon, onClick, ...rest }) => {
   return <Action confirmation={confirmation}>
     <MenuItem
-      id={id}
       onClick={() => {
         onClick && onClick()
         document.dispatchEvent(new MouseEvent('click'))
       }}
+      {...rest}
     >
-      <span>{shortTitle}</span> { icon }
+      <span>{shortTitle}</span> {icon}
     </MenuItem>
   </Action>
 }
@@ -108,6 +108,8 @@ MenuItemAction.propTypes = {
   shortTitle: PropTypes.string.isRequired,
   icon: PropTypes.node,
   onClick: PropTypes.func,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
 }
 
 const ActionButtonWraper = (props) => {
@@ -133,4 +135,46 @@ ActionButtonWraper.propTypes = {
   ...Button.propTypes,
 }
 
-export { ActionButtonWraper, MenuItemAction }
+const ActionMenuItemWrapper = (props) => {
+  const { items, actionDisabled, confirmation, shortTitle } = props
+
+  const dangerText = (!actionDisabled && props.className === 'btn btn-danger') ? style['menu-item-danger'] : ''
+
+  // For console button
+  if (items && items.filter(i => i !== null).length > 0) {
+    if (actionDisabled) {
+      return <MenuItemAction
+        shortTitle={shortTitle}
+        id='console-selector'
+        disabled={actionDisabled}
+      />
+    } else {
+      return (<React.Fragment>
+        <MenuItem divider />
+        {items.filter(i => i !== null && !i.actionDisabled).map(item => {
+          return <MenuItemAction key={item.id} {...item} />
+        })
+        }
+        <MenuItem divider />
+      </React.Fragment>)
+    }
+  }
+
+  return (
+    <MenuItemAction
+      id={shortTitle}
+      key={shortTitle}
+      confirmation={!actionDisabled && confirmation}
+      disabled={actionDisabled}
+      className={dangerText}
+      shortTitle={shortTitle}
+    />)
+}
+
+ActionMenuItemWrapper.propTypes = {
+  confirmation: PropTypes.node,
+  items: PropTypes.array,
+  ...Button.propTypes,
+}
+
+export { ActionButtonWraper, MenuItemAction, ActionMenuItemWrapper }

--- a/src/components/VmActions/Action.js
+++ b/src/components/VmActions/Action.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { excludeKeys, DropdownButton, MenuItem } from 'patternfly-react'
+import { excludeKeys, DropdownButton, MenuItem, noop } from 'patternfly-react'
 
 import { hrefWithoutHistory } from '_/helpers'
 
@@ -26,12 +26,15 @@ class Action extends React.Component {
 
   render () {
     const { children, confirmation } = this.props
-    let trigger = children
-    let confirmationDialog = confirmation || null
-    if (confirmation) {
-      trigger = React.cloneElement(trigger, { onClick: this.handleOpen })
-      confirmationDialog = React.cloneElement(confirmationDialog, { show: this.state.showModal, onClose: this.handleClose })
-    }
+
+    const trigger = confirmation
+      ? React.cloneElement(children, { onClick: this.handleOpen })
+      : children
+
+    const confirmationDialog = confirmation
+      ? React.cloneElement(confirmation, { show: this.state.showModal, onClose: this.handleClose })
+      : null
+
     return <React.Fragment>
       {trigger}
       {confirmationDialog}
@@ -43,41 +46,35 @@ Action.propTypes = {
   confirmation: PropTypes.node,
 }
 
-export default Action
+const Button = ({
+  className,
+  tooltip = '',
+  shortTitle,
+  onClick = noop,
+  actionDisabled = false,
+  id,
+}) => {
+  const handleClick = hrefWithoutHistory(onClick)
 
-class Button extends React.Component {
-  render () {
-    let {
-      className,
-      tooltip = '',
-      actionDisabled = false,
-      onClick,
-      shortTitle,
-      id,
-    } = this.props
-
-    let handleClick = hrefWithoutHistory(onClick)
-
-    if (actionDisabled) {
-      return (
-        <button className={`${className} ${style['disabled-button']}`} disabled='disabled' id={id}>
-          <span data-toggle='tooltip' data-placement='left' title={tooltip}>
-            {shortTitle}
-          </span>
-        </button>
-      )
-    }
-
+  if (actionDisabled) {
     return (
-      <span className={style['full-button']}>
-        <a href='#' onClick={handleClick} className={`${className} ${style['link']}`} id={id}>
-          <span data-toggle='tooltip' data-placement='left' title={tooltip} id={`${id}-title`}>
-            {shortTitle}
-          </span>
-        </a>
-      </span>
+      <button className={`${className} ${style['disabled-button']}`} disabled='disabled' id={id}>
+        <span data-toggle='tooltip' data-placement='left' title={tooltip}>
+          {shortTitle}
+        </span>
+      </button>
     )
   }
+
+  return (
+    <span className={style['full-button']}>
+      <a href='#' onClick={handleClick} className={`${className} ${style['link']}`} id={id}>
+        <span data-toggle='tooltip' data-placement='left' title={tooltip} id={`${id}-title`}>
+          {shortTitle}
+        </span>
+      </a>
+    </span>
+  )
 }
 Button.propTypes = {
   className: PropTypes.string.isRequired,
@@ -88,7 +85,7 @@ Button.propTypes = {
   id: PropTypes.string.isRequired,
 }
 
-const MenuItemAction = ({ confirmation, shortTitle, icon, onClick, ...rest }) => {
+const MenuItemAction = ({ confirmation, onClick, shortTitle, icon, ...rest }) => {
   return <Action confirmation={confirmation}>
     <MenuItem
       onClick={() => {
@@ -101,20 +98,20 @@ const MenuItemAction = ({ confirmation, shortTitle, icon, onClick, ...rest }) =>
     </MenuItem>
   </Action>
 }
-
 MenuItemAction.propTypes = {
   id: PropTypes.string.isRequired,
   confirmation: PropTypes.node,
+  onClick: PropTypes.func,
   shortTitle: PropTypes.string.isRequired,
   icon: PropTypes.node,
-  onClick: PropTypes.func,
   className: PropTypes.string,
   disabled: PropTypes.bool,
 }
 
 const ActionButtonWraper = (props) => {
-  const btnProps = excludeKeys(props, [ 'confirmation', 'items' ])
   const { items, actionDisabled, confirmation, shortTitle } = props
+  const btnProps = excludeKeys(props, [ 'confirmation', 'items' ])
+
   if (items && items.filter(i => i !== null).length > 0) {
     return <DropdownButton
       title={shortTitle}
@@ -122,12 +119,17 @@ const ActionButtonWraper = (props) => {
       id='console-selector'
       disabled={actionDisabled}
     >
-      { items.filter(i => i !== null && !i.actionDisabled).map(item => {
-        return <MenuItemAction key={item.id} {...item} />
-      }) }
+      {
+        items.filter(i => i !== null && !i.actionDisabled).map(
+          item => <MenuItemAction key={item.id} {...item} />
+        )
+      }
     </DropdownButton>
   }
-  return <Action confirmation={confirmation} key={shortTitle}><Button {...btnProps} /></Action>
+
+  return <Action confirmation={confirmation} key={shortTitle}>
+    <Button {...btnProps} />
+  </Action>
 }
 ActionButtonWraper.propTypes = {
   confirmation: PropTypes.node,
@@ -136,9 +138,7 @@ ActionButtonWraper.propTypes = {
 }
 
 const ActionMenuItemWrapper = (props) => {
-  const { items, actionDisabled, confirmation, shortTitle } = props
-
-  const dangerText = (!actionDisabled && props.className === 'btn btn-danger') ? style['menu-item-danger'] : ''
+  const { items, actionDisabled, shortTitle } = props
 
   // For console button
   if (items && items.filter(i => i !== null).length > 0) {
@@ -146,35 +146,46 @@ const ActionMenuItemWrapper = (props) => {
       return <MenuItemAction
         shortTitle={shortTitle}
         id='console-selector'
-        disabled={actionDisabled}
+        disabled
       />
     } else {
-      return (<React.Fragment>
+      return <React.Fragment>
         <MenuItem divider />
-        {items.filter(i => i !== null && !i.actionDisabled).map(item => {
-          return <MenuItemAction key={item.id} {...item} />
-        })
+        {
+          items.filter(i => i !== null && !i.actionDisabled).map(
+            item => <MenuItemAction key={item.id} {...item} />
+          )
         }
         <MenuItem divider />
-      </React.Fragment>)
+      </React.Fragment>
     }
   }
 
+  const menuProps = excludeKeys(props, [ 'confirmation', 'items' ])
+  const menuClassName = (!actionDisabled && /btn-danger/.test(props.className)) ? style['menu-item-danger'] : ''
   return (
     <MenuItemAction
-      id={shortTitle}
-      key={shortTitle}
-      confirmation={!actionDisabled && confirmation}
+      {...menuProps}
+      id={`${props.id}-kebab`}
+      key={props.id}
+      confirmation={!actionDisabled && props.confirmation}
       disabled={actionDisabled}
-      className={dangerText}
-      shortTitle={shortTitle}
-    />)
+      className={menuClassName}
+    />
+  )
 }
-
 ActionMenuItemWrapper.propTypes = {
-  confirmation: PropTypes.node,
   items: PropTypes.array,
-  ...Button.propTypes,
+  confirmation: PropTypes.node,
+  actionDisabled: PropTypes.bool,
+
+  // modified from MenuItemAction.propTypes
+  id: PropTypes.string.isRequired,
+  onClick: PropTypes.func,
+  shortTitle: PropTypes.string.isRequired,
+  icon: PropTypes.node,
+  className: PropTypes.string,
 }
 
+export default Action
 export { ActionButtonWraper, MenuItemAction, ActionMenuItemWrapper }

--- a/src/components/VmActions/index.js
+++ b/src/components/VmActions/index.js
@@ -29,10 +29,10 @@ import {
 
 import { isWindows } from '_/helpers'
 
-import { SplitButton, Icon, Checkbox } from 'patternfly-react'
+import { SplitButton, Icon, Checkbox, DropdownKebab } from 'patternfly-react'
 import ConfirmationModal from './ConfirmationModal'
 import ConsoleConfirmationModal from './ConsoleConfirmationModal'
-import Action, { ActionButtonWraper, MenuItemAction } from './Action'
+import Action, { ActionButtonWraper, MenuItemAction, ActionMenuItemWrapper } from './Action'
 
 const EmptyAction = ({ state, isOnCard }) => {
   if (!canConsole(state) && !canShutdown(state) && !canRestart(state) && !canStart(state)) {
@@ -201,7 +201,7 @@ class VmActions extends React.Component {
         actionDisabled: isPool || !canShutdown(status) || vm.getIn(['actionInProgress', 'shutdown']),
         shortTitle: msg.shutdown(),
         tooltip: msg.shutdownVm(),
-        className: 'btn btn-danger',
+        className: 'btn btn-default',
         id: `${idPrefix}-button-shutdown`,
         confirmation: shutdownConfirmation,
       },
@@ -279,8 +279,18 @@ class VmActions extends React.Component {
         confirm={{ title: msg.remove(), type: 'danger', onClick: () => onRemove({ preserveDisks: this.state.removePreserveDisks }) }}
       />)
 
-    return (
-      <div className={`actions-line ${style['actions-toolbar']}`} id={idPrefix}>
+    return (<React.Fragment>
+      <DropdownKebab id='kebab' pullRight className='visible-xs'>
+        { actions.map(action => <ActionMenuItemWrapper key={action.id} {...action} />) }
+        <ActionMenuItemWrapper
+          confirmation={removeConfirmation}
+          actionDisabled={isPool || !canRemove(status) || vm.getIn(['actionInProgress', 'remove'])}
+          shortTitle={msg.remove()}
+          className='btn btn-danger'
+          id={`${idPrefix}-button-remove`}
+        />
+      </DropdownKebab>
+      <div className={`actions-line ${style['actions-toolbar']} hidden-xs`} id={idPrefix}>
         <EmptyAction state={status} isOnCard={isOnCard} />
 
         {actions.map(action => <ActionButtonWraper key={action.id} {...action} />)}
@@ -294,9 +304,11 @@ class VmActions extends React.Component {
           id={`${idPrefix}-button-remove`}
         />
       </div>
+    </React.Fragment>
     )
   }
 }
+
 VmActions.propTypes = {
   vm: PropTypes.object.isRequired,
   pool: PropTypes.object,

--- a/src/components/VmActions/index.js
+++ b/src/components/VmActions/index.js
@@ -280,16 +280,19 @@ class VmActions extends React.Component {
       />)
 
     return (<React.Fragment>
-      <DropdownKebab id='kebab' pullRight className='visible-xs'>
-        { actions.map(action => <ActionMenuItemWrapper key={action.id} {...action} />) }
-        <ActionMenuItemWrapper
-          confirmation={removeConfirmation}
-          actionDisabled={isPool || !canRemove(status) || vm.getIn(['actionInProgress', 'remove'])}
-          shortTitle={msg.remove()}
-          className='btn btn-danger'
-          id={`${idPrefix}-button-remove`}
-        />
-      </DropdownKebab>
+      <div className={`actions-line ${style['actions-toolbar']} visible-xs`} id={`${idPrefix}Kebab`}>
+        <DropdownKebab id={`${idPrefix}Kebab-kebab`} pullRight>
+          { actions.map(action => <ActionMenuItemWrapper key={action.id} {...action} />) }
+          <ActionMenuItemWrapper
+            confirmation={removeConfirmation}
+            actionDisabled={isPool || !canRemove(status) || vm.getIn(['actionInProgress', 'remove'])}
+            shortTitle={msg.remove()}
+            className='btn btn-danger'
+            id={`${idPrefix}Kebab-button-remove`}
+          />
+        </DropdownKebab>
+      </div>
+
       <div className={`actions-line ${style['actions-toolbar']} hidden-xs`} id={idPrefix}>
         <EmptyAction state={status} isOnCard={isOnCard} />
 

--- a/src/components/VmActions/style.css
+++ b/src/components/VmActions/style.css
@@ -62,3 +62,10 @@
     height: 27px;
 }
 
+:global(.dropdown-menu) > .menu-item-danger > a {
+    color: #cc0000;
+}
+
+:global(a#console-selector)  {
+    box-shadow: none;
+}

--- a/src/index-nomodules.css
+++ b/src/index-nomodules.css
@@ -86,6 +86,12 @@ body {
   height: 28px;
 }
 
+@media (max-width: 768px) {
+  .toolbar-pf-action-right {
+    float: right;
+  }
+}
+
 .card-pf .card-pf-footer {
   background-color: inherit;
   padding-top: 10px;


### PR DESCRIPTION
Fixes: suggestions in #946 and #1069 
Prerequisite: #1030 

Enhancements: For narrow mobile screens (<= 600px), automatically retract the Action menu to a kebob menu
Before: 
![screenshot-localhost_3000-2019 07 23-15_32_43](https://user-images.githubusercontent.com/25762021/61743313-05ab7100-ad63-11e9-9162-0725ab0d965e.png)

After: 
![screenshot-localhost_3000-2019 07 25-12_54_33](https://user-images.githubusercontent.com/25762021/61893172-6c539a80-aedb-11e9-80c6-7e3ee0174ce6.png)
![screenshot-localhost_3000-2019 07 25-12_54_46](https://user-images.githubusercontent.com/25762021/61893179-6eb5f480-aedb-11e9-83ed-9bbfb0ec6a75.png)


