### PR TITLE
Fix an eslint error for string quote use

### DIFF
--- a/src/propTypeExtras.test.js
+++ b/src/propTypeExtras.test.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import { xor } from '_/propTypeExtras'
 
 describe('xor PropType cross property validation', () => {
-  const propTypesRest = [ 'prop', null, "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED" ]
+  const propTypesRest = [ 'prop', null, 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED' ]
 
   it('both exist, and self-verify', () => {
     const p1 = xor(PropTypes.string, 'p2')


### PR DESCRIPTION
Fixed a lint error that comes up with `yarn eslint` but doesn't come up in `yarn build`.

Will need to look into the configurations further to see why the lint error doesn't come up with the standard build (may be due to a test file vs a normal file).