### PR TITLE
Asleep Changed to Suspended

### DIFF
--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -221,7 +221,7 @@ export const messages: { [messageId: string]: MessageType } = {
     description: 'Being hibernated. One of states of a virtual machine. Other are e.g. Up, Down, Powering-Up',
   },
   enum_VmStatus_suspended: {
-    message: 'Asleep',
+    message: 'Suspended',
     description: 'Hibernated. One of states of a virtual machine. Other are e.g. Up, Down, Powering-Up',
   },
   enum_VmStatus_unassigned: {


### PR DESCRIPTION
Fixes: #1078 
Asleep changed to Suspended in filter and in grid layout.
![suspended1](https://user-images.githubusercontent.com/13103729/62546520-4b406180-b86c-11e9-8fef-9949a1006727.png)
![suspended2](https://user-images.githubusercontent.com/13103729/62546525-4da2bb80-b86c-11e9-8ade-1085a1849cc3.png)
