### PR TITLE
Tooltips on the edit button use the same patternfly-react style

### DIFF
--- a/src/components/OverlayTooltip/index.js
+++ b/src/components/OverlayTooltip/index.js
@@ -17,7 +17,7 @@ const OverlayTooltip = ({ id, tooltip, placement = 'left', children }) => {
 OverlayTooltip.propTypes = {
   id: PropTypes.string.isRequired,
   tooltip: PropTypes.string.isRequired,
-  placement: PropTypes.string.isRequired,
+  placement: PropTypes.string,
   children: PropTypes.node.isRequired,
 }
 

--- a/src/components/VmDetails/CardEditButton.js
+++ b/src/components/VmDetails/CardEditButton.js
@@ -7,6 +7,7 @@ import {
 
 import style from './style.css'
 
+import OverlayTooltip from '../OverlayTooltip'
 /**
  * Render the edit icon/button to enable the editing of the content of a card.
  *
@@ -44,9 +45,11 @@ class CardEditButton extends React.Component {
     const myClick = editEnabled ? noop : this.enableEditHandler
 
     return (
-      <a title={tooltip} onClick={(e) => { e.preventDefault(); myClick() }} className={classes} id={id}>
-        <Icon type='pf' name='edit' />
-      </a>
+      <OverlayTooltip id={`${id}-tooltip`} tooltip={tooltip} placement='bottom'>
+        <a id={id} className={classes} onClick={(e) => { e.preventDefault(); myClick() }}>
+          <Icon type='pf' name='edit' />
+        </a>
+      </OverlayTooltip>
     )
   }
 }


### PR DESCRIPTION
Fixes: #1021 

Tooltips on the edit button use the same patternfly-react style - 

![TooltipPush](https://user-images.githubusercontent.com/13103729/62695019-22d87480-b9de-11e9-93c0-f8fae6c83ec4.png)
