### PR TITLE
About Dialog - Report issues URL added to branding

### DIFF
--- a/branding/fixed-strings.json
+++ b/branding/fixed-strings.json
@@ -3,5 +3,7 @@
   "LEGAL_INFO": "Released under",
   "LEGAL_INFO_LINK_TEXT": "Apache License 2.0",
   "LEGAL_INFO_LINK_URL": "https://github.com/oVirt/ovirt-web-ui/blob/master/LICENSE",
-  "DOCUMENTATION_LINK": "https://ovirt.org/documentation"
+  "DOCUMENTATION_LINK": "https://ovirt.org/documentation",
+  "ISSUES_TRACKER_URL": "https://github.com/oVirt/ovirt-web-ui/issues",
+  "ISSUES_TRACKER_TEXT": "Github Issue Tracker"
 }

--- a/src/GlobalErrorBoundary.js
+++ b/src/GlobalErrorBoundary.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { msg } from '_/intl'
 import AppConfiguration from './config'
 import ErrorContent from '_/components/ErrorContent'
-import { resourcesUrls } from '_/branding'
+import * as branding from '_/branding'
 
 class GlobalErrorBoundary extends React.Component {
   constructor (props) {
@@ -24,28 +24,36 @@ class GlobalErrorBoundary extends React.Component {
   }
 
   render () {
+    const trackText = branding.fixedStrings.ISSUES_TRACKER_TEXT || 'Github Issue Tracker'
+    const trackUrl = branding.fixedStrings.ISSUES_TRACKER_URL || 'https://github.com/oVirt/ovirt-web-ui/issues'
+    // const title = msg.globalErrorBoundaryTitle()
+    const descr = msg.globalErrorBoundaryDescription({
+      bugUrl: `<a href='${trackUrl}'>${trackText}</a>`,
+    })
+    const logOut = msg.logOut()
+    const refresh = msg.refresh()
+    const refreshUrl = AppConfiguration.applicationURL
+    const logoutUrl = AppConfiguration.applicationURL + '/sso/logout'
     if (this.state.hasError) {
       return (
         <div>
           <nav className='navbar obrand_mastheadBackground obrand_topBorder navbar-pf-vertical'>
             <div className='navbar-header'>
               <a href='/' className='navbar-brand obrand_headerLogoLink' id='pageheader-logo'>
-                <img className='obrand_mastheadLogo' src={resourcesUrls.clearGif} />
+                <img className='obrand_mastheadLogo' src={branding.resourcesUrls.clearGif} />
               </a>
             </div>
           </nav>
           <ErrorContent
             title={msg.globalErrorBoundaryTitle()}
-            description={msg.globalErrorBoundaryDescription({
-              bugUrl: `<a href='https://github.com/oVirt/ovirt-web-ui/issues'>${msg.gitHub()}</a>`,
-            })}
+            description={msg.globalErrorBoundaryDescription(descr)}
             leftButton={{
-              href: AppConfiguration.applicationURL,
-              title: msg.refresh(),
+              href: logoutUrl,
+              title: logOut,
             }}
             rightButton={{
-              href: AppConfiguration.applicationURL + '/sso/logout',
-              title: msg.logOut(),
+              href: refreshUrl + '/sso/logout',
+              title: refresh,
             }}
           />
         </div>

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -37,6 +37,11 @@ class AboutDialog extends React.Component {
 
     const { oVirtApiVersion } = this.props
     const idPrefix = `about`
+    const trackText = fixedStrings.ISSUES_TRACKER_TEXT || 'Github Issue Tracker'
+    const trackUrl = fixedStrings.ISSUES_TRACKER_URL || 'https://github.com/oVirt/ovirt-web-ui/issues'
+    const reportLink = msg.aboutDialogReportIssuesLink({
+      link: `<strong><a href='${trackUrl}' target='_blank' id='${idPrefix}-issues-link'>${trackText}</a></strong>`,
+    })
 
     let apiVersion = 'unknown'
     if (oVirtApiVersion && oVirtApiVersion.get('major')) {
@@ -67,6 +72,9 @@ class AboutDialog extends React.Component {
                       <span dangerouslySetInnerHTML={{ __html: docLink }} />
                     </li>
                   }
+                  <li id={`${idPrefix}-issues`}>
+                    <div dangerouslySetInnerHTML={{ __html: reportLink }} />
+                  </li>
                 </ul>
               </div>
 

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -43,6 +43,7 @@ export const messages: { [messageId: string]: MessageType } = {
   authorizationExpired: 'Authorization expired. The page is going to be reloaded to re-login.',
   automaticPoolsNotEditable: 'The pool type of {poolName} is automatic so the details of this virtual machine are not editable.',
   availableVmsFromPool: 'Available VMs from this Pool',
+  aboutDialogReportIssuesLink: 'Please report issues on {link}',
   bootMenu: 'Boot Menu',
   bootMenuTooltip: 'Boot menu allows to select bootable device. It is accessible from a console.',
   bootMenuWarning: 'All changes will take effect after reboot only.',


### PR DESCRIPTION
So far, both in RHV and oVirt, the -"About" window dialog included a reference to github to report issues. However In RHV the customers supposed to report to access.redhat.com in case of a problem.
Now the report reference depends on what brand do you use.

![Reports1](https://user-images.githubusercontent.com/13103729/62700676-2de5d180-b9eb-11e9-835c-e906d1c3210a.png)

Fixed  https://bugzilla.redhat.com/show_bug.cgi?id=1724959 