### PR TITLE
Hover texts in masthead fixed and changed

### DIFF
--- a/src/components/VmUserMessages/index.js
+++ b/src/components/VmUserMessages/index.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-
 import { connect } from 'react-redux'
 
 import { Notification, NotificationDrawer, MenuItem, Icon, Button } from 'patternfly-react'
+import OverlayTooltip from '../OverlayTooltip'
 
 import style from './style.css'
 
@@ -75,11 +75,13 @@ class VmUserMessages extends React.Component {
       : <span className='badge' id={`${idPrefix}-size`}>{messagesCount}</span>
     return (
       <li className='dropdown'>
-        <a className='dropdown-toggle nav-item-iconic' href='#' title={msg.messages()} onClick={hrefWithoutHistory(this.handleToggle)} id={`${idPrefix}-toggle`}>
-          <i className={`fa fa-bell ${style['usermessages-icon']}`} />
-          {badgeElement}
-          <span className='caret' id={`${idPrefix}-caret`} />
-        </a>
+        <OverlayTooltip id={`${idPrefix}-tooltip`} tooltip={msg.notifications()} placement='bottom'>
+          <a className='dropdown-toggle nav-item-iconic' href='#' onClick={hrefWithoutHistory(this.handleToggle)} id={`${idPrefix}-toggle`}>
+            <i className={`fa fa-bell ${style['usermessages-icon']}`} />
+            {badgeElement}
+            <span className='caret' id={`${idPrefix}-caret`} />
+          </a>
+        </OverlayTooltip>
         <NotificationDrawer hide={!this.state.show} expanded={this.state.expanded}>
           <NotificationDrawer.Title onCloseClick={this.handleToggle} onExpandClick={this.handleExpand} />
           <NotificationDrawer.PanelBody className={style['panel-body']}>
@@ -97,6 +99,7 @@ class VmUserMessages extends React.Component {
           </NotificationDrawer.PanelBody>
         </NotificationDrawer>
       </li>
+
     )
   }
 }

--- a/src/components/VmsPageHeader/UserMenu.js
+++ b/src/components/VmsPageHeader/UserMenu.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-
 import { connect } from 'react-redux'
 
 import { logout } from '_/actions'
@@ -8,14 +7,17 @@ import { logout } from '_/actions'
 import { msg } from '_/intl'
 import AboutDialog from '../About'
 import OptionsDialog from '../OptionsDialog'
+import OverlayTooltip from '_/components/OverlayTooltip'
 
 const UserMenu = ({ config, onLogout }) => {
   const idPrefix = 'usermenu'
   return (
     <li className='dropdown'>
-      <a className='dropdown-toggle nav-item-iconic' href='#' data-toggle='dropdown' title={config.getIn(['user', 'name'])} id={`${idPrefix}-user`}>
-        <i className='pficon pficon-user' /><span className='caret' />
-      </a>
+      <OverlayTooltip id={`${idPrefix}-tooltip`} tooltip={config.getIn(['user', 'name'])} placement='bottom'>
+        <a className='dropdown-toggle nav-item-iconic' href='#' data-toggle='dropdown' id={`${idPrefix}-user`}>
+          <i className='pficon pficon-user' /><span className='caret' />
+        </a>
+      </OverlayTooltip>
       <ul className='dropdown-menu'>
         <li>
           <OptionsDialog userId={config.getIn(['user', 'id'])} />

--- a/src/components/VmsPageHeader/index.js
+++ b/src/components/VmsPageHeader/index.js
@@ -9,6 +9,8 @@ import { hrefWithoutHistory } from '_/helpers'
 
 import { refresh } from '_/actions'
 import * as branding from '_/branding'
+import { msg } from '_/intl'
+import OverlayTooltip from '../OverlayTooltip'
 
 /**
  * Main application header on top of the page
@@ -22,20 +24,19 @@ const VmsPageHeader = ({ page, onRefresh }) => {
           <img className='obrand_mastheadLogo' src={branding.resourcesUrls.clearGif} />
         </a>
       </div>
-
       <div className='collapse navbar-collapse'>
         <ul className='nav navbar-nav navbar-right navbar-iconic'>
           <li>
-            <a href='#' className='nav-item-iconic' onClick={hrefWithoutHistory(() => onRefresh(page))} id={`${idPrefix}-refresh`}>
-              <i className='fa fa-refresh' />
-            </a>
+            <OverlayTooltip id={`${idPrefix}-tooltip`} tooltip={msg.refresh()} placement='bottom'>
+              <a href='#' className='nav-item-iconic' onClick={hrefWithoutHistory(() => onRefresh(page))} id={`${idPrefix}-refresh`}>
+                <i className='fa fa-refresh' />
+              </a>
+            </OverlayTooltip>
           </li>
-
           <UserMenu />
           <VmUserMessages />
         </ul>
       </div>
-
     </nav>
   )
 }

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -385,6 +385,7 @@ export const messages: { [messageId: string]: MessageType } = {
     message: 'This field is only available when the VM is running and the guest agent is installed and running.',
     description: 'Tooltip displayed next to \'notAvailable\' for fields that require the VM to be up and a running guest agent',
   },
+  notifications: 'Notifications',
   notEditableForPoolsOrPoolVms: 'Not editable for Pools or pool VMs.',
   noVmAvailable: 'No VM available.',
   noVmAvailableForLoggedUser: 'No VM is available for the logged user.',


### PR DESCRIPTION
Fixes: #949

The texts on the masthead changed and designed like patternfly 4 tooltips.
![admin_Hovering](https://user-images.githubusercontent.com/13103729/62863097-829d8b00-bd10-11e9-9fb3-889d5354d240.png)
![Notifications_Hover](https://user-images.githubusercontent.com/13103729/62863098-829d8b00-bd10-11e9-90e7-a12c5796b978.png)
![Refresh_Hovering](https://user-images.githubusercontent.com/13103729/62863100-829d8b00-bd10-11e9-9516-29cbc41079c9.png)


