### PR TITLE
About Dialog - Add link to documentation

### DIFF
--- a/branding/fixed-strings.json
+++ b/branding/fixed-strings.json
@@ -2,5 +2,6 @@
   "BRAND_NAME": "oVirt",
   "LEGAL_INFO": "Released under",
   "LEGAL_INFO_LINK_TEXT": "Apache License 2.0",
-  "LEGAL_INFO_LINK_URL": "https://github.com/oVirt/ovirt-web-ui/blob/master/LICENSE"
+  "LEGAL_INFO_LINK_URL": "https://github.com/oVirt/ovirt-web-ui/blob/master/LICENSE",
+  "DOCUMENTATION_LINK": "https://ovirt.org/documentation"
 }

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -43,6 +43,10 @@ class AboutDialog extends React.Component {
       apiVersion = `${oVirtApiVersion.get('major')}.${oVirtApiVersion.get('minor')}`
     }
 
+    const docLink = msg.aboutDialogDocumentationLink({
+      link: `<strong><a href='${fixedStrings.DOCUMENTATION_LINK}' target='_blank' id='${idPrefix}-documentation-link'>${msg.aboutDialogDocumentationText()}</a></strong>`,
+    })
+
     return (
       <React.Fragment>
         <a href='#' id='about-modal' onClick={() => this.setState({ openModal: true })}>{msg.about()}</a>
@@ -58,6 +62,11 @@ class AboutDialog extends React.Component {
                   <li id={`${idPrefix}-version`}>Version <strong id={`${idPrefix}-version-value`}>{Product.version}-{Product.release}</strong></li>
                   <li id={`${idPrefix}-apiversion`}>{fixedStrings.BRAND_NAME} API Version <strong id={`${idPrefix}-apiversion-value`}>{apiVersion}</strong></li>
                   <li id={`${idPrefix}-issues`}>Please report issues on <strong><a href='https://github.com/oVirt/ovirt-web-ui/issues' target='_blank' id={`${idPrefix}-issues-link`}>GitHub Issue Tracker</a></strong></li>
+                  {fixedStrings.DOCUMENTATION_LINK &&
+                    <li id={`${idPrefix}-documentation`}>
+                      <span dangerouslySetInnerHTML={{ __html: docLink }} />
+                    </li>
+                  }
                 </ul>
               </div>
 

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -18,6 +18,8 @@ export const messages: { [messageId: string]: MessageType } = {
     message: 'About',
     description: 'About application',
   },
+  aboutDialogDocumentationLink: 'For further information see {link}',
+  aboutDialogDocumentationText: 'Documentation',
   actionFailed: '{action} failed',
   activeFilters: 'Active Filters:',
   actualStateVmIsIn: 'The actual state the virtual machine is in.',


### PR DESCRIPTION
Fixes: #134
Documentation added to About dialog:

![Documentation2](https://user-images.githubusercontent.com/13103729/63513480-0e709d80-c4ef-11e9-83b4-f8422c480473.png)
