### PR TITLE
Change 'automation/build.repos' for ovirt-engine-nodejs-modules

### DIFF
--- a/automation/build.repos
+++ b/automation/build.repos
@@ -1,3 +1,3 @@
 ovirt-engine-nodejs_master,http://jenkins.ovirt.org/job/ovirt-engine-nodejs_master_build-artifacts-$distro-x86_64/lastSuccessfulBuild/artifact/exported-artifacts/
-ovirt-engine-nodejs-modules_master,http://jenkins.ovirt.org/job/ovirt-engine-nodejs-modules_master_build-artifacts-$distro-x86_64/lastSuccessfulBuild/artifact/exported-artifacts/
+ovirt-engine-nodejs-modules_master,https://jenkins.ovirt.org/job/ovirt-engine-nodejs-modules_standard-on-merge/lastSuccessfulBuild/artifact/build-artifacts.$distro.x86_64
 ovirt-engine-yarn_master,http://jenkins.ovirt.org/job/ovirt-engine-yarn_master_build-artifacts-$distro-x86_64/lastSuccessfulBuild/artifact/exported-artifacts/


### PR DESCRIPTION
ovirt-engine-nodejs-modules changed CI version to STDCI V2. The
repo location used for our CI has to change to match the V2
location.