### PR TITLE
Update build to use yarn from ovirt-engine-nodejs-modules

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -24,13 +24,13 @@ Please report bugs and feature requests to the [GitHub issue tracker](https://gi
 
 
 #### ovirt-engine packages
-Install `ovirt-engine-nodejs`, `ovirt-engine-nodejs-modules` and `ovirt-engine-yarn`
-from the `ovirt/tested` yum repo for your platform to use the same packages that will
-be used by CI to build the app.  (See [BZ 1427045](https://bugzilla.redhat.com/show_bug.cgi?id=1427045))
+Install `ovirt-engine-nodejs`, `ovirt-engine-nodejs-modules` from the `ovirt/tested`
+yum repo for your platform to use the same packages that will be used by CI to build
+the app.  (See [BZ 1427045](https://bugzilla.redhat.com/show_bug.cgi?id=1427045))
 
     REPO=fc28 # or the appropriate release and version for you
     dnf config-manager --add-repo http://resources.ovirt.org/repos/ovirt/tested/master/rpm/$REPO
-    dnf install ovirt-engine-nodejs ovirt-engine-nodejs-modules ovirt-engine-yarn
+    dnf install ovirt-engine-nodejs ovirt-engine-nodejs-modules
 
 To set PATH and the project's `node_modules` directory based on yarn offline cache
 and use these packages for development or building use:

--- a/Makefile.am
+++ b/Makefile.am
@@ -69,7 +69,7 @@ rpm:	srpm
 	@echo
 
 snapshot-rpm:
-	make rpm RELEASE_SUFFIX=".$$(date --utc +%Y%m%d).git$$(git rev-parse --short HEAD)"
+	make rpm RELEASE_SUFFIX=".$$(date --utc +%Y%m%d).git$$(git log --no-merges -1 --pretty=format:%h)"
 
 publish:
 	mkdir -p $(OVIRT_CACHE_DIR)
@@ -84,6 +84,8 @@ distclean-local:
 all: ovirt-web-ui
 
 ovirt-web-ui:
+	node --version
+	$(YARN) --version
 	$(YARN) run build
 	cp -rpv packaging/* build/
 	mv build/static build/index.jsp build/ovirt-web-ui.config build/ovirt-web-ui.war/

--- a/automation/build.packages.force
+++ b/automation/build.packages.force
@@ -1,3 +1,2 @@
 ovirt-engine-nodejs
 ovirt-engine-nodejs-modules
-ovirt-engine-yarn

--- a/automation/build.repos
+++ b/automation/build.repos
@@ -1,3 +1,2 @@
 ovirt-engine-nodejs_master,http://jenkins.ovirt.org/job/ovirt-engine-nodejs_master_build-artifacts-$distro-x86_64/lastSuccessfulBuild/artifact/exported-artifacts/
 ovirt-engine-nodejs-modules_master,https://jenkins.ovirt.org/job/ovirt-engine-nodejs-modules_standard-on-merge/lastSuccessfulBuild/artifact/build-artifacts.$distro.x86_64
-ovirt-engine-yarn_master,http://jenkins.ovirt.org/job/ovirt-engine-yarn_master_build-artifacts-$distro-x86_64/lastSuccessfulBuild/artifact/exported-artifacts/

--- a/configure.ac
+++ b/configure.ac
@@ -33,11 +33,9 @@ AM_INIT_AUTOMAKE([-Wall -Werror foreign -Wno-portability tar-pax])
 AC_ARG_VAR([RPMBUILD], [path to rpmbuild utility])
 AC_CHECK_PROGS([RPMBUILD], [rpmbuild])
 
-echo ${PATH}
 AC_ARG_VAR([YARN], [path to yarn utility])
 AC_CHECK_PROGS([YARN], [yarn])
-
-test -z "${YARN}" && AC_MSG_ERROR([YARN program not found (install ovirt-engine-yarn, ovirt-engine-nodejs-modules, ovirt-engine-nodejs])
+test -z "${YARN}" && AC_MSG_ERROR([YARN program not found (install ovirt-engine-nodejs, ovirt-engine-nodejs-modules])
 
 AC_CONFIG_FILES([
 	Makefile

--- a/ovirt-web-ui.spec.in
+++ b/ovirt-web-ui.spec.in
@@ -16,32 +16,25 @@ Source0:        https://github.com/oVirt/ovirt-web-ui/archive/%{source_basename}
 
 BuildArch: noarch
 
-# Keep ovirt-engine-{nodejs|nodejs-modules|yarn} at particular version unless tested on higher
+# Keep ovirt-engine-{nodejs|nodejs-modules} at particular version unless tested on higher
 BuildRequires: ovirt-engine-nodejs = 8.11.4
-BuildRequires: ovirt-engine-yarn = 1.7.0
-
-BuildRequires: ovirt-engine-nodejs-modules >= 2.0.1
+BuildRequires: ovirt-engine-nodejs-modules >= 2.0.2
 
 %description
 This package provides the VM Portal for %{product}.
 
 %prep
-# Use the ovirt-engine nodejs installation
-# export PATH="%{_datadir}/ovirt-engine-nodejs/bin:${PATH}"
-
 %setup -q -n"%{source_basename}-%{version}"
 rpm -qa | grep ovirt-engine-nodejs
 
 echo "=== Workaround: 'yarn check' is recently failing on requiring webpack >= v2. Manually"
 echo "=== verified that this is ok for recent code base but may be a real failure in the"
 echo "=== future. Please watch carefully for other potential types of errors."
-export IGNORE_YARN_CHECK=1
-source /usr/share/ovirt-engine-nodejs-modules/setup-env.sh
+IGNORE_YARN_CHECK=1 source /usr/share/ovirt-engine-nodejs-modules/setup-env.sh
 
 %build
-export PATH="%{_datadir}/ovirt-engine-nodejs/bin:%{_datadir}/ovirt-engine-yarn/bin:${PATH}"
+export PATH="%{_datadir}/ovirt-engine-nodejs/bin:%{_datadir}/ovirt-engine-nodejs-modules/bin:${PATH}"
 %configure
-export PATH="./node_modules/.bin:${PATH}"
 make
 
 %install


### PR DESCRIPTION
Now that version 2.0.2 of ovirt-engine-nodejs-modules has yarn
embedded, there is no need to use the ovirt-engine-yarn during
the build process.

  - Removed references to ovirt-engine-yarn in build scripts,
    documentation and error messages

  - Use `make rpm` and `make snapshot-rpm` targets instead of
    patching configure.ac on the fly for snapshot builds

  - make ovirt-web-ui target prints versions for `node` and `yarn` that
    will be used for the build

  - until ovirt-engine-nodejs-modules has an executable for
    yarn, patch in the yarn-*.js from nodejs-modules to do the job