### PR TITLE
Update autogen/automake configurations and yarn integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
   - docker
 
 script:
-  - ./autogen.sh --prefix=/usr --datarootdir=/share
   - yarn run build
   - docker build --tag web-ui .
   - docker run -d --rm -it -e ENGINE_URL=https://localhost/ovirt-engine -p 3000:3000 --name web-ui web-ui
@@ -26,5 +25,6 @@ script:
       fi
       sleep 2
     done
+
 node_js:
   - "8"

--- a/Makefile.am
+++ b/Makefile.am
@@ -41,13 +41,21 @@ DISTCLEANFILES = $(PACKAGE)-$(VERSION).tar.gz \
 	configure \
 	install-sh \
 	missing \
-	Makefile.in
+	Makefile.in \
+	.bash_history \
+	mocker-*.cfg
 
 DISTCLEANDIRS = autom4te.cache \
 	engine-plugin \
 	tmp.repos \
 	build \
-	dockerbuild
+	extra \
+	.zanata-cache \
+	dockerbuild \
+	.node-gyp \
+	exported-artifacts \
+	rpmbuild \
+	node_modules
 
 TMPREPOS = tmp.repos
 RPMBUILD_ARGS :=

--- a/package.json
+++ b/package.json
@@ -113,13 +113,13 @@
     "lodash": "4.17.14",
     "js-yaml": "3.13.1"
   },
-  "autogenTest": "Makefile",
-  "autogenCmd": "./autogen.sh --prefix=/usr --datarootdir=/share",
   "scripts": {
-    "start": "(test -e $npm_package_autogenTest || $npm_package_autogenCmd) && node scripts/start.js",
+    "preinstall": "./autogen.sh --prefix=/usr --datarootdir=/share",
+    "clean": "make distclean",
+    "start": "node scripts/start.js",
     "prebuild": "yarn run test",
     "build": "node scripts/build.js",
-    "pretest": "(test -e $npm_package_autogenTest || $npm_package_autogenCmd) && node scripts/pretest.js",
+    "pretest": "node scripts/pretest.js",
     "test": "jest --no-watchman",
     "test:watch": "yarn run pretest && jest --watch --no-watchman",
     "eslint": "eslint -c config/eslint.js src",


### PR DESCRIPTION
  - Update automake to clean up mock_runner generated files

  - Update yarn scripts to run `./autogen.sh` before `yarn install`

  - Added script `yarn clean` to run automake's `distclean`

  - No need for travis CI to invoke autogen.sh since `yarn install`
    is doing that now

Now when you install `node_modules/`, automake will also update. This
will help cover changes in automake configs and help reduce any related
errors.