### PR TITLE
Only run autogen.sh on yarn install if it is available

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "js-yaml": "3.13.1"
   },
   "scripts": {
-    "preinstall": "./autogen.sh --prefix=/usr --datarootdir=/share",
+    "preinstall": "test -e ./autogen.sh && ./autogen.sh --prefix=/usr --datarootdir=/share",
     "clean": "make distclean",
     "start": "node scripts/start.js",
     "prebuild": "yarn run test",


### PR DESCRIPTION
When ovirt-engine-nodejs-modules uses this project's
`package.json` and `yarn.lock` to generate it's cache,
the rest of the project is not available.  The `preinstall`
script needs to be sensitive to this situation.

...yarn preinstall will only run autogen.sh if it exists