### PR TITLE
Remove 'ovirt-4.2' from STDCI release branch config

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -3,5 +3,5 @@ distros:
   - fc28
   - el7
 release_branches:
-  master: [ "ovirt-master", "ovirt-4.3", "ovirt-4.2" ]
+  master: [ "ovirt-master", "ovirt-4.3" ]
 


### PR DESCRIPTION
CQ 4.2 has been removed.
Having 4.2 can cause unstable build-artifacts job.