### PR TITLE
Refactor various dialog components' trigger prop

### DIFF
--- a/src/components/VmDetails/cards/DisksCard/DiskImageEditor.js
+++ b/src/components/VmDetails/cards/DisksCard/DiskImageEditor.js
@@ -249,7 +249,7 @@ class DiskImageEditor extends Component {
     const diskSize = disk && (disk.get('lunSize') ? disk.get('lunSize') : disk.get('provisionedSize'))
 
     return <React.Fragment>
-      {React.cloneElement(trigger, { onClick: this.open })}
+      { trigger({ onClick: this.open }) }
 
       <Modal
         dialogClassName={style['editor-modal']}
@@ -442,7 +442,7 @@ DiskImageEditor.propTypes = {
   suggestedStorageDomain: PropTypes.string,
 
   storageDomainList: PropTypes.object.isRequired,
-  trigger: PropTypes.element.isRequired,
+  trigger: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
 
   storageDomains: PropTypes.object.isRequired,

--- a/src/components/VmDetails/cards/DisksCard/DiskListItem.js
+++ b/src/components/VmDetails/cards/DisksCard/DiskListItem.js
@@ -117,13 +117,13 @@ const DiskListItem = ({
           id={`${idPrefix}-delete-modal`}
           severity='danger'
           onDelete={() => { onDelete(vm.get('id'), view.id) }}
-          trigger={
+          trigger={({ onClick }) => (
             <OverlayTooltip id={`${idPrefix}-action-delete-tooltip`} tooltip={msg.diskDeleteTooltip()}>
-              <a id={`${idPrefix}-action-delete`} className={itemStyle['item-action']}>
+              <a id={`${idPrefix}-action-delete`} className={itemStyle['item-action']} onClick={onClick}>
                 <Icon type='pf' name='delete' />
               </a>
             </OverlayTooltip>
-          }
+          )}
         >
           <span
             dangerouslySetInnerHTML={{

--- a/src/components/VmDetails/cards/DisksCard/DiskListItem.js
+++ b/src/components/VmDetails/cards/DisksCard/DiskListItem.js
@@ -92,13 +92,13 @@ const DiskListItem = ({
           disk={disk}
           storageDomainList={storageDomainList}
           onSave={onEdit}
-          trigger={
+          trigger={({ onClick }) => (
             <OverlayTooltip id={`${idPrefix}-action-edit-tooltip`} tooltip={msg.diskEditTooltip()}>
-              <a id={`${idPrefix}-action-edit`} className={itemStyle['item-action']}>
+              <a id={`${idPrefix}-action-edit`} className={itemStyle['item-action']} onClick={onClick} >
                 <Icon type='pf' name='edit' />
               </a>
             </OverlayTooltip>
-          }
+          )}
         />
       }
       { !canEdit &&

--- a/src/components/VmDetails/cards/DisksCard/index.js
+++ b/src/components/VmDetails/cards/DisksCard/index.js
@@ -151,14 +151,14 @@ class DisksCard extends React.Component {
                     suggestedStorageDomain={suggestedStorageDomain}
                     storageDomainList={filteredStorageDomainList}
                     onSave={this.onCreateConfirm}
-                    trigger={
+                    trigger={({ onClick }) => (
                       <div className={itemStyle['create-block']}>
-                        <a href='#' id={`${idPrefix}-new-disk-action`}>
+                        <a href='#' id={`${idPrefix}-new-disk-action`} onClick={onClick}>
                           <Icon className={itemStyle['create-icon']} type='fa' name='plus' />
                           <span className={itemStyle['create-text']} >{msg.diskActionCreateNew()}</span>
                         </a>
                       </div>
-                    }
+                    )}
                   />
                 </Col>
               </Row>

--- a/src/components/VmDetails/cards/NicsCard/NicEditor.js
+++ b/src/components/VmDetails/cards/NicsCard/NicEditor.js
@@ -166,7 +166,7 @@ class NicEditor extends Component {
       )
 
     return <React.Fragment>
-      {React.cloneElement(trigger, { onClick: this.open })}
+      { trigger({ onClick: this.open }) }
 
       <Modal
         id={modalId}
@@ -294,7 +294,7 @@ NicEditor.propTypes = {
   nextNicName: PropTypes.string,
 
   vnicProfileList: PropTypes.object.isRequired,
-  trigger: PropTypes.element.isRequired,
+  trigger: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
 }
 

--- a/src/components/VmDetails/cards/NicsCard/NicListItem.js
+++ b/src/components/VmDetails/cards/NicsCard/NicListItem.js
@@ -105,13 +105,13 @@ const NicListItem = ({ idPrefix, nic, vmStatus, vnicProfileList, isEditing, onEd
         <DeleteConfirmationModal
           id={`${idPrefix}-delete-modal`}
           onDelete={() => { onDelete(nic.id) }}
-          trigger={
+          trigger={({ onClick }) => (
             <OverlayTooltip id={`${idPrefix}-delete-tooltip`} tooltip={msg.nicDeleteTooltip()}>
-              <a id={`${idPrefix}-delete-action`} className={itemStyle['item-action']}>
+              <a id={`${idPrefix}-delete-action`} className={itemStyle['item-action']} onClick={onClick}>
                 <Icon type='pf' name='delete' />
               </a>
             </OverlayTooltip>
-          }
+          )}
         >
           <span
             dangerouslySetInnerHTML={{

--- a/src/components/VmDetails/cards/NicsCard/NicListItem.js
+++ b/src/components/VmDetails/cards/NicsCard/NicListItem.js
@@ -81,13 +81,13 @@ const NicListItem = ({ idPrefix, nic, vmStatus, vnicProfileList, isEditing, onEd
           vmStatus={vmStatus}
           vnicProfileList={vnicProfileList}
           onSave={onEdit}
-          trigger={
+          trigger={({ onClick }) => (
             <OverlayTooltip id={`${idPrefix}-edit-tooltip`} tooltip={msg.nicEditTooltip()}>
-              <a id={`${idPrefix}-edit-action`} className={itemStyle['item-action']}>
+              <a id={`${idPrefix}-edit-action`} className={itemStyle['item-action']} onClick={onClick}>
                 <Icon type='pf' name='edit' />
               </a>
             </OverlayTooltip>
-          }
+          )}
         />
       }
       { !canEdit &&

--- a/src/components/VmDetails/cards/NicsCard/index.js
+++ b/src/components/VmDetails/cards/NicsCard/index.js
@@ -142,14 +142,14 @@ class NicsCard extends React.Component {
                     nextNicName={this.state.nextNicName}
                     vnicProfileList={this.state.filteredVnicList}
                     onSave={this.onCreateConfirm}
-                    trigger={
+                    trigger={({ onClick }) => (
                       <div className={itemStyle['create-block']}>
-                        <a href='#' id={`${idPrefix}-new-button`}>
+                        <a href='#' id={`${idPrefix}-new-button`} onClick={onClick}>
                           <Icon className={itemStyle['create-icon']} type='fa' name='plus' />
                           <span className={itemStyle['create-text']} >{msg.nicActionCreateNew()}</span>
                         </a>
                       </div>
-                    }
+                    )}
                   />
                 </Col>
               </Row>

--- a/src/components/VmDetails/cards/SnapshotsCard/RestoreConfirmationModal.js
+++ b/src/components/VmDetails/cards/SnapshotsCard/RestoreConfirmationModal.js
@@ -5,8 +5,8 @@ import Immutable from 'immutable'
 
 import { Icon, MessageDialog } from 'patternfly-react'
 import { msg } from '_/intl'
+import { getMinimizedString, escapeHtml } from '_/components/utils'
 import { restoreVmSnapshot } from './actions'
-import { getMinimizedString, escapeHtml } from '../../../utils'
 
 const MAX_DESCRIPTION_SIZE = 150
 
@@ -33,16 +33,15 @@ class RestoreConfirmationModal extends React.Component {
   }
 
   render () {
-    const { snapshot, trigger, snapshots, disabled, id } = this.props
+    const { snapshot, trigger, snapshots, id } = this.props
 
     const icon = <Icon type='pf' name='warning-triangle-o' />
-    const clonedTrigger = React.cloneElement(trigger, { onClick: this.open, disabled })
     const snapshotsThatWillBeDeleted = snapshots.filter((s) => s.get('date') > snapshot.get('date'))
     const minDescription = escapeHtml(getMinimizedString(snapshot.get('description'), MAX_DESCRIPTION_SIZE))
 
     return (
       <React.Fragment>
-        {clonedTrigger}
+        { trigger({ onClick: this.open })}
         <MessageDialog
           id={id}
           show={this.state.showModal}
@@ -75,12 +74,12 @@ class RestoreConfirmationModal extends React.Component {
 }
 
 RestoreConfirmationModal.propTypes = {
+  id: PropsTypes.string.isRequired,
   snapshot: PropsTypes.object.isRequired,
   vmId: PropsTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
-  id: PropsTypes.string.isRequired,
+  trigger: PropsTypes.func.isRequired,
+
   snapshots: PropsTypes.object.isRequired,
-  trigger: PropsTypes.node.isRequired,
-  disabled: PropsTypes.bool,
   onRestore: PropsTypes.func.isRequired,
 }
 

--- a/src/components/VmDetails/cards/SnapshotsCard/SnapshotDetail.js
+++ b/src/components/VmDetails/cards/SnapshotsCard/SnapshotDetail.js
@@ -63,14 +63,6 @@ const SnapshotDetail = ({ snapshot, vmId, restoreDisabled, id, isPoolVm, ...othe
   const nicsToShow = nicsToRender.slice(0, 2)
   const additionalNics = nicsToRender.slice(2)
 
-  const restoreButton = isPoolVm
-    ? <OverlayTrigger placement='top' overlay={<Tooltip id={`${id}-restore-tt`}>{ msg.vmPoolSnapshotRestoreUnavailable() }</Tooltip>}>
-      <span>
-        <Button bsStyle='default' id={`${id}-restore`} disabled style={{ pointerEvents: 'none' }}>{ msg.snapshotRestore() }</Button>
-      </span>
-    </OverlayTrigger>
-    : <Button bsStyle='default' id={`${id}-restore`}>{ msg.snapshotRestore() }</Button>
-
   return <Popover
     id={id}
     title={
@@ -204,11 +196,22 @@ const SnapshotDetail = ({ snapshot, vmId, restoreDisabled, id, isPoolVm, ...othe
     </div>
     <div style={{ textAlign: 'left' }}>
       <RestoreConfirmationModal
-        snapshot={snapshot}
         id={`${id}-restore-modal`}
+        snapshot={snapshot}
         vmId={vmId}
-        disabled={restoreDisabled}
-        trigger={restoreButton}
+        trigger={({ onClick }) =>
+          isPoolVm ? (
+            <OverlayTrigger placement='top' overlay={<Tooltip id={`${id}-restore-tt`}>{ msg.vmPoolSnapshotRestoreUnavailable() }</Tooltip>}>
+              <span>
+                <Button bsStyle='default' id={`${id}-restore`} disabled style={{ pointerEvents: 'none' }}>{ msg.snapshotRestore() }</Button>
+              </span>
+            </OverlayTrigger>
+          ) : (
+            <Button bsStyle='default' id={`${id}-restore`} onClick={onClick} disabled={restoreDisabled}>
+              { msg.snapshotRestore() }
+            </Button>
+          )
+        }
       />
     </div>
   </Popover>

--- a/src/components/VmDetails/cards/SnapshotsCard/SnapshotItem.js
+++ b/src/components/VmDetails/cards/SnapshotsCard/SnapshotItem.js
@@ -134,16 +134,15 @@ class SnapshotItem extends React.Component {
           <RestoreConfirmationModal
             key='restore'
             id={`${this.props.id}-restore-modal`}
-            disabled={isRestoreDisabled}
             snapshot={this.props.snapshot}
             vmId={this.props.vmId}
-            trigger={
-              <SnapshotAction key='restore' id={`${this.props.id}-restore`} >
+            trigger={({ onClick }) => (
+              <SnapshotAction key='restore' id={`${this.props.id}-restore`} onClick={onClick} disabled={isRestoreDisabled}>
                 <OverlayTooltip placement={this.state.isMobile ? 'right' : 'left'} id={`${this.props.id}-restore-tt`} tooltip={msg.snapshotRestore()}>
                   <Icon type='fa' name='play-circle' />
                 </OverlayTooltip>
               </SnapshotAction>
-            }
+            )}
           />
         )
 

--- a/src/components/VmDetails/cards/SnapshotsCard/SnapshotItem.js
+++ b/src/components/VmDetails/cards/SnapshotsCard/SnapshotItem.js
@@ -104,61 +104,73 @@ class SnapshotItem extends React.Component {
     const isRestoreDisabled = isActionsDisabled || !this.props.isVmDown || this.props.isPoolVm
     if (!this.props.snapshot.get('isActive')) {
       // Info popover
-      buttons.push(<OverlayTrigger
-        overlay={
-          <SnapshotDetail key='detail' id={`${this.props.id}-info-popover`} snapshot={this.props.snapshot} vmId={this.props.vmId} restoreDisabled={isRestoreDisabled} isPoolVm={this.props.isPoolVm} />
-        }
-        placement={this.state.isMobile || this.state.isTablet ? 'top' : 'left'}
-        trigger='click'
-        rootClose
-        key='info'
-      >
-        <a id={`${this.props.id}-info`}>
-          <OverlayTooltip placement={this.state.isMobile ? 'right' : 'left'} id={`${this.props.id}-info-tt`} tooltip={msg.details()}>
-            <Icon type='pf' name='info' />
-          </OverlayTooltip>
-        </a>
-      </OverlayTrigger>)
+      buttons.push(
+        <OverlayTrigger
+          overlay={
+            <SnapshotDetail key='detail'
+              id={`${this.props.id}-info-popover`}
+              snapshot={this.props.snapshot}
+              vmId={this.props.vmId}
+              restoreDisabled={isRestoreDisabled}
+              isPoolVm={this.props.isPoolVm}
+            />
+          }
+          placement={this.state.isMobile || this.state.isTablet ? 'top' : 'left'}
+          trigger='click'
+          rootClose
+          key='info'
+        >
+          <a id={`${this.props.id}-info`}>
+            <OverlayTooltip placement={this.state.isMobile ? 'right' : 'left'} id={`${this.props.id}-info-tt`} tooltip={msg.details()}>
+              <Icon type='pf' name='info' />
+            </OverlayTooltip>
+          </a>
+        </OverlayTrigger>
+      )
 
       if (!this.props.hideActions) {
         // Restore action
-        buttons.push(<RestoreConfirmationModal
-          key='restore'
-          disabled={isRestoreDisabled}
-          snapshot={this.props.snapshot}
-          vmId={this.props.vmId}
-          id={`${this.props.id}-restore-modal`}
-          trigger={
-            <SnapshotAction key='restore' id={`${this.props.id}-restore`} >
-              <OverlayTooltip placement={this.state.isMobile ? 'right' : 'left'} id={`${this.props.id}-restore-tt`} tooltip={msg.snapshotRestore()}>
-                <Icon type='fa' name='play-circle' />
-              </OverlayTooltip>
-            </SnapshotAction>
-          }
-        />)
-        // Delete action
-        buttons.push(<DeleteConfirmationModal
-          key='delete'
-          disabled={isActionsDisabled}
-          id={`${this.props.id}-delete-modal`}
-          trigger={
-            <SnapshotAction key='delete' id={`${this.props.id}-delete`}>
-              <OverlayTooltip placement={this.state.isMobile ? 'right' : 'left'} id={`${this.props.id}-delete-tt`} tooltip={msg.snapshotDelete()}>
-                <Icon type='pf' name='delete' />
-              </OverlayTooltip>
-            </SnapshotAction>
-          }
-          onDelete={this.props.onSnapshotDelete}
-        >
-          <div
-            dangerouslySetInnerHTML={{
-              __html: msg.areYouSureYouWantToDeleteSnapshot({
-                snapshotName: `"<strong>${escapeHtml(this.props.snapshot.get('description'))}</strong>"`,
-              }),
-            }}
+        buttons.push(
+          <RestoreConfirmationModal
+            key='restore'
+            id={`${this.props.id}-restore-modal`}
+            disabled={isRestoreDisabled}
+            snapshot={this.props.snapshot}
+            vmId={this.props.vmId}
+            trigger={
+              <SnapshotAction key='restore' id={`${this.props.id}-restore`} >
+                <OverlayTooltip placement={this.state.isMobile ? 'right' : 'left'} id={`${this.props.id}-restore-tt`} tooltip={msg.snapshotRestore()}>
+                  <Icon type='fa' name='play-circle' />
+                </OverlayTooltip>
+              </SnapshotAction>
+            }
           />
-          <div>{msg.thisOperationCantBeUndone()}</div>
-        </DeleteConfirmationModal>)
+        )
+
+        // Delete action
+        buttons.push(
+          <DeleteConfirmationModal
+            key='delete'
+            id={`${this.props.id}-delete-modal`}
+            onDelete={this.props.onSnapshotDelete}
+            trigger={({ onClick }) => (
+              <SnapshotAction key='delete' id={`${this.props.id}-delete`} disabled={isActionsDisabled} onClick={onClick}>
+                <OverlayTooltip placement={this.state.isMobile ? 'right' : 'left'} id={`${this.props.id}-delete-tt`} tooltip={msg.snapshotDelete()}>
+                  <Icon type='pf' name='delete' />
+                </OverlayTooltip>
+              </SnapshotAction>
+            )}
+          >
+            <div
+              dangerouslySetInnerHTML={{
+                __html: msg.areYouSureYouWantToDeleteSnapshot({
+                  snapshotName: `"<strong>${escapeHtml(this.props.snapshot.get('description'))}</strong>"`,
+                }),
+              }}
+            />
+            <div>{msg.thisOperationCantBeUndone()}</div>
+          </DeleteConfirmationModal>
+        )
       }
 
       // Status tooltip

--- a/src/components/VmModals/DeleteConfirmationModal.js
+++ b/src/components/VmModals/DeleteConfirmationModal.js
@@ -28,7 +28,7 @@ class DeleteConfirmationModal extends React.Component {
   }
 
   render () {
-    const { children, trigger, disabled, id, severity = 'normal' } = this.props
+    const { children, trigger, id, severity = 'normal' } = this.props
 
     const primary = Array.isArray(children) ? children[0] : children
     const secondary = Array.isArray(children) ? children.slice(1) : undefined
@@ -40,7 +40,7 @@ class DeleteConfirmationModal extends React.Component {
 
     return (
       <React.Fragment>
-        {React.cloneElement(trigger, { onClick: this.handleTriggerClick, disabled })}
+        { trigger({ onClick: this.handleTriggerClick }) }
         <MessageDialog
           id={id}
           show={this.state.show}
@@ -61,8 +61,7 @@ class DeleteConfirmationModal extends React.Component {
 }
 DeleteConfirmationModal.propTypes = {
   id: PropTypes.string.isRequired,
-  trigger: PropTypes.node.isRequired,
-  disabled: PropTypes.bool,
+  trigger: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
   onDelete: PropTypes.func.isRequired,
   onClose: PropTypes.func,

--- a/src/components/VmNics/index.js
+++ b/src/components/VmNics/index.js
@@ -41,6 +41,9 @@ class VmNic extends React.Component {
         ({vnicProfile ? `${vnicProfile.getIn(['network', 'name'])}/${vnicProfile.get('name')}` : `${msg.noNetwork()}`})
       </span>
     )
+    const areYouSure = msg.areYouSureYouWantToDeleteNic({
+      nicName: `"<strong>${this.props.nic.get('name')}</strong>"`,
+    })
 
     return (
       <li>
@@ -55,14 +58,14 @@ class VmNic extends React.Component {
           </span>
           { showSettings &&
             <DeleteConfirmationModal
-              trigger={
-                <Button bsStyle='default' bsSize='small' disabled={isUp}>
+              trigger={({ onClick }) => (
+                <Button bsStyle='default' bsSize='small' disabled={isUp} onClick={onClick}>
                   {msg.delete()}
                 </Button>
-              }
+              )}
               onDelete={this.handleDelete}
             >
-              <p dangerouslySetInnerHTML={{ __html: msg.areYouSureYouWantToDeleteNic({ nicName: `"<strong>${this.props.nic.get('name')}</strong>"` }) }} />
+              <p dangerouslySetInnerHTML={{ __html: areYouSure }} />
               <p>{msg.thisOperationCantBeUndone()}</p>
             </DeleteConfirmationModal>
           }


### PR DESCRIPTION
Converted the `trigger` prop on dialog components the use the technique to be a render function instead of an element.  The `trigger` render function takes `onClick` as an argument and needs to assign that event passed handler to the correct tag for the dialogs to open.

Applied the refactor to:
  - `DiskImageEditor`
  - `NicEditor`
  - `DeleteConfirmationModal`
  - `RestoreConfirmationModal`

Fixes: #1123

**NOTE**: The `Action` component in `src/components/VmActions/Action.js` uses a very similar pattern but with the children prop.  I'm not changing the `Action` component at this time since its use looks ok.