### PR TITLE
Fix action menu render error and console error on VmsList page

### DIFF
--- a/src/components/VmsList/BaseCard.js
+++ b/src/components/VmsList/BaseCard.js
@@ -56,15 +56,19 @@ class BaseCardTitle extends React.Component {
   render () {
     const { url, name } = this.props
     if (url) {
-      return (<Link to={url} className={style['vm-detail-link']}>
-        <p className={`${style['vm-name']} ${style['crop']}`} title={name} data-toggle='tooltip' id={`${this.context}-name`}>
-          {name}
-        </p>
-      </Link>)
+      return (
+        <Link to={url} className={style['vm-detail-link']}>
+          <div className={`${style['vm-name']} ${style['crop']}`} title={name} data-toggle='tooltip' id={`${this.context}-name`}>
+            {name}
+          </div>
+        </Link>
+      )
     }
-    return (<p className={`${style['vm-name']} ${style['crop']}`} title={name} data-toggle='tooltip' id={`${this.context}-name`}>
-      {name}
-    </p>)
+    return (
+      <div className={`${style['vm-name']} ${style['crop']}`} title={name} data-toggle='tooltip' id={`${this.context}-name`}>
+        {name}
+      </div>
+    )
   }
 }
 
@@ -81,9 +85,9 @@ class BaseCardStatus extends React.Component {
     const { children } = this.props
 
     return (
-      <p className={`${style['vm-status']}`} id={`${this.context}-status`}>
+      <div className={`${style['vm-status']}`} id={`${this.context}-status`}>
         {children}
-      </p>
+      </div>
     )
   }
 }

--- a/src/components/VmsList/style.css
+++ b/src/components/VmsList/style.css
@@ -27,11 +27,13 @@
 .vm-name {
     font-size: 0.8em;
     min-height: 0.8em;
+    margin-bottom: 10px;
 }
 
 .vm-status {
     font-size: 0.8em;
     min-height: 46px;
+    margin-bottom: 10px;
 }
 
 .selectedVm {


### PR DESCRIPTION
Fixes #1130 

Issues addressed:
  - Action menu on the VM Cards list page were showing some actions
    as normal buttons in a split button, instead of as a normal menu
    item.  Item `classNames` have been explicitly set to fix this.

  - Console error messages were being logged for two items:

    - Using `<p>` tags on the `BaseCardTitle` and `BaseCardStatus`
      components were causing errors with child content.  Converted
      the tag to `<div>` and adjusted styles as necessary.

    - Because of the use of `{...rest}` in a few `VmActions`
      components, extra properties were being passed to child
      components causing errors.  `VmDropdownActions` now explicitly
      passes down the props needed.

VM Card action menu is back to normal after this PR:
![Selection_028](https://user-images.githubusercontent.com/3985964/67052763-28a0b380-f10d-11e9-8168-cb54441a42b1.png)
