### PR TITLE
update STDCI, add distros fc30 and el8

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -1,7 +1,8 @@
 distros:
   - fc29
-  - fc28
+  - fc30
   - el7
+  - el8
 release_branches:
   master: [ "ovirt-master", "ovirt-4.3" ]
 

--- a/automation/build.packages.force
+++ b/automation/build.packages.force
@@ -1,2 +1,0 @@
-ovirt-engine-nodejs
-ovirt-engine-nodejs-modules

--- a/automation/build.repos
+++ b/automation/build.repos
@@ -1,2 +1,5 @@
-ovirt-engine-nodejs_master,http://jenkins.ovirt.org/job/ovirt-engine-nodejs_master_build-artifacts-$distro-x86_64/lastSuccessfulBuild/artifact/exported-artifacts/
+# normally ovirt "tested" repo is enough as we want packages pass through OST
+ovirt-tested,https://resources.ovirt.org/repos/ovirt/tested/master/rpm/$distro/
+
+# but we keep requiring latest jenkins build of ovirt-node-js-modules since we build in a lock-step
 ovirt-engine-nodejs-modules_master,https://jenkins.ovirt.org/job/ovirt-engine-nodejs-modules_standard-on-merge/lastSuccessfulBuild/artifact/build-artifacts.$distro.x86_64

--- a/ovirt-web-ui.spec.in
+++ b/ovirt-web-ui.spec.in
@@ -16,9 +16,8 @@ Source0:        https://github.com/oVirt/ovirt-web-ui/archive/%{source_basename}
 
 BuildArch: noarch
 
-# Keep ovirt-engine-{nodejs|nodejs-modules} at particular version unless tested on higher
-BuildRequires: ovirt-engine-nodejs = 8.11.4
-BuildRequires: ovirt-engine-nodejs-modules >= 2.0.8
+# nodejs-modules embeds yarn and ovirt-engine-nodejs (or nodejs on fc30+,el8)
+BuildRequires: ovirt-engine-nodejs-modules >= 2.0.11-5
 
 %description
 This package provides the VM Portal for %{product}.


### PR DESCRIPTION
  - drop fc28

  - introduce fc30, el8

  - simplify dependencies

  - retain force install of ovirt-engine-nodejs-modules to minimize
    the time between a build of nodejs-modules and when it gets applied
    to the CI in this project (it is the quickest way to have a pre-seed
    build picked up)

  - see [1] for the example set of changes made in the
    ovirt-engine-ui-extensions package to affect the same changes

[1] - https://gerrit.ovirt.org/103582