### PR TITLE
Fix regression in GlobalErrorBoundary

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ window.combobox = require('patternfly-bootstrap-combobox/js/bootstrap-combobox.j
 
 function renderApp (store: Object, errorBridge: Object) {
   ReactDOM.render(
-    <GlobalErrorBoundary errorBridge={errorBridge}>
+    <GlobalErrorBoundary errorBridge={errorBridge} store={store}>
       <Provider store={store}>
         <IntlProvider locale={locale} messages={getSelectedMessages()}>
           <App history={store.history} />


### PR DESCRIPTION
 - The regression with the `GlobalErrorBoundary` came up while triaging a bug.  Any unhandled errors need to be trapped and the error screen needs to be correct to avoid a "white screen of death".
 - Logout logic now uses the logout sagas (when the redux store is available) or the configured logout URL (when no redux store is available)