### PR TITLE
Refresh scheduler delay <= 0 disables background refresh

### DIFF
--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -134,6 +134,7 @@ import {
   canUserUseCluster,
   canUserUseVnicProfile,
   getUserPermits,
+  isNumber,
 } from '_/utils'
 
 const vmFetchAdditionalList =
@@ -890,6 +891,10 @@ function* startSchedulerWithFixedDelay (action) {
 let _SchedulerCount = 0
 
 function* schedulerWithFixedDelay (delayInSeconds = AppConfiguration.schedulerFixedDelayInSeconds) {
+  if (!isNumber(delayInSeconds) || delayInSeconds <= 0) {
+    return
+  }
+
   const myId = _SchedulerCount++
   console.log(`⏰ schedulerWithFixedDelay[${myId}] starting fixed delay scheduler`)
 


### PR DESCRIPTION
This will allow the background auto refresh to be disabled by configuration.

The value of the refresh delay will also be verified to be numeric to prevent scheduler delay configuration issues from killing the app.