### PR TITLE
Fix ToastNotifications dismissals

### DIFF
--- a/src/components/ToastNotifications.js
+++ b/src/components/ToastNotifications.js
@@ -8,15 +8,20 @@ import { setNotificationNotified } from '_/actions'
 import style from './sharedStyle.css'
 
 function normalizeType (theType) {
-  const isExpected = ['error', 'warning', 'success', 'info', 'danger'].includes(String(theType).toLowerCase())
+  theType = String(theType).toLowerCase()
+  const isExpected = ['error', 'warning', 'success', 'info', 'danger'].includes(theType)
   return isExpected ? theType : 'warning'
 }
 
 const ToastNotifications = ({ userMessages, onDismissNotification }) => {
   return <ToastNotificationList>
-
     { userMessages.get('records').filter(r => !r.get('notified')).map(r =>
-      <TimedToastNotification className={style['toast-margin-top']} type={normalizeType(r.get('type'))} onDismiss={() => onDismissNotification(r.get('time'))} key={r.get('time')}>
+      <TimedToastNotification
+        className={style['toast-margin-top']}
+        type={normalizeType(r.get('type'))}
+        onDismiss={() => onDismissNotification(r.get('id'))}
+        key={r.get('time')}
+      >
         <span>
           {r.get('message')}
         </span>


### PR DESCRIPTION
PR #1111 changed the id used to set a user message as "notified"
from the message's time to the message's id.  The ToastNotifications
dispatch needed to also get this update.

Fixes #1142 