### PR TITLE
Fix DiskImageEditor storage domain list

### DIFF
--- a/src/components/VmDetails/cards/DisksCard/DiskImageEditor.js
+++ b/src/components/VmDetails/cards/DisksCard/DiskImageEditor.js
@@ -78,7 +78,7 @@ class DiskImageEditor extends Component {
     super(props)
     this.state = {
       showModal: false,
-      storageDomainSelectList: createStorageDomainList(props.storageDomainList, undefined, true),
+      storageDomainSelectList: createStorageDomainList(props.storageDomainList, props.dataCenterId, true),
 
       id: undefined,
       values: {
@@ -135,7 +135,7 @@ class DiskImageEditor extends Component {
 
     this.setState({
       showModal: true,
-      storageDomainSelectList: createStorageDomainList(this.props.storageDomainList, true),
+      storageDomainSelectList: createStorageDomainList(this.props.storageDomainList, this.props.dataCenterId, true),
       ...diskInfo,
     })
     this.changesMade = false
@@ -446,10 +446,12 @@ DiskImageEditor.propTypes = {
   onSave: PropTypes.func.isRequired,
 
   storageDomains: PropTypes.object.isRequired,
+  dataCenterId: PropTypes.string.isRequired,
 }
 
 export default connect(
-  (state) => ({
+  (state, { vm }) => ({
     storageDomains: state.storageDomains,
+    dataCenterId: state.clusters.getIn([ vm.getIn([ 'cluster', 'id' ]), 'dataCenterId' ]),
   })
 )(DiskImageEditor)


### PR DESCRIPTION
A regression was introduced in the create VM code such that
the storage domain list on the disk editor/creator modal showed
as blank.  This has been fixed by adding the proper data center
filtering to the list generation.

Now, the storage domain list will only show storage domains available
for use by the logged in user in the VM's cluster's data center.