### PR TITLE
CreateVmWizard - Network and Storage table edit row action buttons updates

### DIFF
--- a/src/components/CreateVmWizard/steps/Networking.js
+++ b/src/components/CreateVmWizard/steps/Networking.js
@@ -21,6 +21,7 @@ import {
   MenuItem,
   Table,
 } from 'patternfly-react'
+import _TableInlineEditRow from './_TableInlineEditRow'
 import SelectBox from '_/components/SelectBox'
 
 import style from './style.css'
@@ -424,7 +425,7 @@ class Networking extends React.Component {
             columns={this.columns}
             components={{
               body: {
-                row: Table.InlineEditRow,
+                row: _TableInlineEditRow,
               },
             }}
           >

--- a/src/components/CreateVmWizard/steps/Storage.js
+++ b/src/components/CreateVmWizard/steps/Storage.js
@@ -22,6 +22,7 @@ import {
   Table,
   Label,
 } from 'patternfly-react'
+import _TableInlineEditRow from './_TableInlineEditRow'
 import SelectBox from '_/components/SelectBox'
 
 import style from './style.css'
@@ -529,7 +530,7 @@ class Storage extends React.Component {
             columns={this.columns}
             components={{
               body: {
-                row: Table.InlineEditRow,
+                row: _TableInlineEditRow, // Table.InlineEditRow,
               },
             }}
           >

--- a/src/components/CreateVmWizard/steps/_TableInlineEditRow.js
+++ b/src/components/CreateVmWizard/steps/_TableInlineEditRow.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import TableConfirmButtonsRow from 'patternfly-react/dist/js/components/Table/TableConfirmButtonsRow'
+
+const TableInlineEditRow = props => {
+  const buttonsPosition = (window, rowDimensions) => {
+    const position = {}
+
+    if (props.last) {
+      position.bottom = window.height - rowDimensions.top - 1
+    } else {
+      position.top = rowDimensions.bottom
+    }
+    position.right = 75 // window.width - rowDimensions.right + 10
+
+    console.info('button position', position)
+    return position
+  }
+
+  const buttonsClassName = props.last ? 'top' : 'bottom'
+
+  return <TableConfirmButtonsRow {...props} buttonsPosition={buttonsPosition} buttonsClassName={buttonsClassName} />
+}
+
+TableInlineEditRow.shouldComponentUpdate = true
+
+TableInlineEditRow.defaultProps = {
+  ...TableConfirmButtonsRow.defaultProps,
+  last: false,
+}
+
+TableInlineEditRow.propTypes = {
+  /** Function that determines whether values or edit components should be rendered */
+  isEditing: PropTypes.func,
+  /** Confirm edit callback */
+  onConfirm: PropTypes.func,
+  /** Cancel edit callback */
+  onCancel: PropTypes.func,
+  /** Flag to indicate last row */
+  last: PropTypes.bool,
+  /** Row cells */
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+  /** Message text inputs for i18n */
+  messages: PropTypes.shape({
+    confirmButtonLabel: PropTypes.string,
+    cancelButtonLabel: PropTypes.string,
+  }),
+}
+
+export default TableInlineEditRow


### PR DESCRIPTION
Custom table edit row component so the location of the the confirm and cancel buttons during a Nic or Disk edit can be controlled.

