### PR TITLE
Update zanata server and version

### DIFF
--- a/zanata.xml
+++ b/zanata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <config xmlns="http://zanata.org/namespace/config/">
-    <url>https://translate.zanata.org/</url>
+    <url>https://zanata.phx.ovirt.org/</url>
     <project>ovirt-web-ui</project>
-    <project-version>1.5</project-version>
+    <project-version>1.6</project-version>
     <project-type>gettext</project-type>
 
     <src-dir>extra/to-zanata</src-dir>


### PR DESCRIPTION
The project has migrated from the public unspported zanata
instance to an ovirt.org managed instance.  Project version
updated for translations correlating to ovirt-engine 4.4.

  server url: https://zanata.phx.ovirt.org
  project version: 1.6