### PR TITLE
Update STDCI configurations

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -1,8 +1,5 @@
 distros:
-  - fc29
   - fc30
-  - el7
   - el8
 release_branches:
-  master: [ "ovirt-master", "ovirt-4.3" ]
-
+  master: ovirt-master

--- a/automation/README.md
+++ b/automation/README.md
@@ -2,7 +2,6 @@ Continuous Integration Scripts
 ==============================
 
 This directory contains scripts for Continuous Integration provided by
-[oVirt Jenkins](http://jenkins.ovirt.org/)
-system and follows the standard defined in
-[Build and test standards](http://www.ovirt.org/CI/Build_and_test_standards)
-wiki page.
+[oVirt Jenkins](http://jenkins.ovirt.org/) system and follows the standard documented at the
+[Build and test standards](https://ovirt-infra-docs.readthedocs.io/en/latest/CI/Build_and_test_standards)
+page.

--- a/automation/build-artifacts.packages.el7
+++ b/automation/build-artifacts.packages.el7
@@ -1,1 +1,0 @@
-build.packages.el7

--- a/automation/build.packages.el7
+++ b/automation/build.packages.el7
@@ -1,5 +1,0 @@
-make
-autoconf
-automake
-git
-yum

--- a/automation/check-merged.packages
+++ b/automation/check-merged.packages
@@ -1,1 +1,0 @@
-build.packages

--- a/automation/check-merged.packages.el7
+++ b/automation/check-merged.packages.el7
@@ -1,1 +1,0 @@
-build.packages.el7

--- a/automation/check-merged.repos
+++ b/automation/check-merged.repos
@@ -1,1 +1,0 @@
-build.repos

--- a/automation/check-merged.sh
+++ b/automation/check-merged.sh
@@ -1,1 +1,0 @@
-build.sh

--- a/automation/check-patch.packages.el7
+++ b/automation/check-patch.packages.el7
@@ -1,1 +1,0 @@
-build.packages.el7

--- a/ovirt-web-ui.spec.in
+++ b/ovirt-web-ui.spec.in
@@ -17,7 +17,7 @@ Source0:        https://github.com/oVirt/ovirt-web-ui/archive/%{source_basename}
 BuildArch: noarch
 
 # nodejs-modules embeds yarn and ovirt-engine-nodejs (or nodejs on fc30+,el8)
-BuildRequires: ovirt-engine-nodejs-modules >= 2.0.11-5
+BuildRequires: ovirt-engine-nodejs-modules >= 2.0.17-1
 
 %description
 This package provides the VM Portal for %{product}.

--- a/ovirt-web-ui.spec.in
+++ b/ovirt-web-ui.spec.in
@@ -16,7 +16,7 @@ Source0:        https://github.com/oVirt/ovirt-web-ui/archive/%{source_basename}
 
 BuildArch: noarch
 
-# nodejs-modules embeds yarn and ovirt-engine-nodejs (or nodejs on fc30+,el8)
+# nodejs-modules embeds yarn and requires nodejs
 BuildRequires: ovirt-engine-nodejs-modules >= 2.0.17-1
 
 %description


### PR DESCRIPTION
  - removed el7 and fc29 build targets

  - removed el7 specific automation files

  - master branch only builds for `ovirt-master`

  - removed check-merged stage symlinked scripts since all stages
    run the same script (`automation/build.sh`) and it doesn't make
    sense to run `build.sh` twice on every merge

  - bump ovirt-engine-nodejs-modules req to 2.0.17-1