### PR TITLE
Changes the disks' display order 

### DIFF
--- a/src/components/VmDisks/utils.js
+++ b/src/components/VmDisks/utils.js
@@ -4,7 +4,7 @@ import { localeCompare } from '_/helpers'
 
 /*
  * Sort an Immutable List of Maps (set of disks) for display on the VmDisks list.
- * Bootable drives sort first, then sorted number aware alphabetically.
+ * Drives Sorted by disk name.
  */
 export function sortDisksForDisplay (disks, locale = appLocale) {
   return disks.sort((a, b) => { return localeCompare(a.get('name'), b.get('name'), locale) })

--- a/src/components/VmDisks/utils.js
+++ b/src/components/VmDisks/utils.js
@@ -7,12 +7,5 @@ import { localeCompare } from '_/helpers'
  * Bootable drives sort first, then sorted number aware alphabetically.
  */
 export function sortDisksForDisplay (disks, locale = appLocale) {
-  return disks.sort((a, b) => {
-    const aBoot = a.get('bootable')
-    const bBoot = b.get('bootable')
-
-    return (aBoot && !bBoot) ? -1 : (
-      (!aBoot && bBoot) ? 1 : localeCompare(a.get('name'), b.get('name'), locale)
-    )
-  })
+  return disks.sort((a, b) => { return localeCompare(a.get('name'), b.get('name'), locale) })
 }

--- a/src/components/VmDisks/utils.test.js
+++ b/src/components/VmDisks/utils.test.js
@@ -16,8 +16,8 @@ const samples = [
     ]),
     expect: fromJS([
       { bootable: true, name: 'Alpha' },
-      { bootable: true, name: 'Xray' },
       { bootable: false, name: 'Beta' },
+      { bootable: true, name: 'Xray' },
       { bootable: false, name: 'Yankee' },
       { bootable: false, name: 'Zulu' },
     ]),


### PR DESCRIPTION
Hi,
I changed the function that sorts the disks' display order in the disks card component.
the change solving issue #1146 
now the disks sorted only by their name.

Fixes #1146
