### PR TITLE
1139 the 'console' operation is not disabled for a headlles vm

### DIFF
--- a/src/components/Toolbar/index.js
+++ b/src/components/Toolbar/index.js
@@ -42,15 +42,17 @@ const VmDetailToolbarConnected = connect(
 const VmConsoleToolbar = ({ match, vms, consoles }) => {
   if (vms.getIn(['vms', match.params.id])) {
     const consoleStatus = [INIT_CONSOLE, DOWNLOAD_CONSOLE]
+    const isConsoleDisabled = !consoleStatus.includes(consoles.getIn(['vms', match.params.id, 'consoleStatus']))
     return <div className={`${style['console-toolbar']} container-fluid`}>
       <div className={style['console-toolbar-actions']} style={{ marginRight: 'auto' }}>
         <VmConsoleSelector
           vmId={match.params.id}
           consoleId={match.params.console}
+          disabled={isConsoleDisabled}
           isConsolePage
         />
         <VmConsoleInstructionsModal
-          disabled={!consoleStatus.includes(consoles.getIn(['vms', match.params.id, 'consoleStatus']))} />
+          disabled={isConsoleDisabled} />
       </div>
       <div className={style['console-toolbar-actions']}>
         <div id='vm-console-toolbar-sendkeys' />

--- a/src/components/VmConsole/VmConsoleSelector.js
+++ b/src/components/VmConsole/VmConsoleSelector.js
@@ -84,6 +84,7 @@ VmConsoleSelector.propTypes = {
   consoles: PropTypes.object.isRequired,
   config: PropTypes.object.isRequired,
   onRDP: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired,
 }
 
 export default connect(

--- a/src/components/VmConsole/VmConsoleSelector.js
+++ b/src/components/VmConsole/VmConsoleSelector.js
@@ -13,7 +13,7 @@ import { getRDP } from '_/actions'
 import { isWindows } from '_/helpers'
 import style from './style.css'
 
-const VmConsoleSelector = ({ vmId, vms, consoles, config, consoleId, isConsolePage, onRDP }) => {
+const VmConsoleSelector = ({ vmId, vms, consoles, config, consoleId, disabled, isConsolePage, onRDP }) => {
   let actions = vms.getIn(['vms', vmId, 'consoles'])
   if (actions.size === 0) {
     return <div />
@@ -69,6 +69,7 @@ const VmConsoleSelector = ({ vmId, vms, consoles, config, consoleId, isConsolePa
       title={activeConsole}
       bsStyle='default'
       id='console-selector'
+      disabled={disabled}
     >
       { consoleItems }
     </DropdownButton>

--- a/test
+++ b/test
@@ -1,0 +1,1 @@
+“some test file”


### PR DESCRIPTION
Hey,
the change solving issue #1139
Fixed - In case of a running headless VM, the "Console" button in VM dashboard is not disabled/greyed.
