### PR TITLE
Tweak the navbar icons

### DIFF
--- a/src/components/VmUserMessages/index.js
+++ b/src/components/VmUserMessages/index.js
@@ -77,7 +77,7 @@ class VmUserMessages extends React.Component {
       <li className='dropdown'>
         <OverlayTooltip id={`${idPrefix}-tooltip`} tooltip={msg.notifications()} placement='bottom'>
           <a className='dropdown-toggle nav-item-iconic' href='#' onClick={hrefWithoutHistory(this.handleToggle)} id={`${idPrefix}-toggle`}>
-            <i className={`fa fa-bell ${style['usermessages-icon']}`} />
+            <i className='fa fa-bell' />
             {badgeElement}
             <span className='caret' id={`${idPrefix}-caret`} />
           </a>

--- a/src/components/VmUserMessages/style.css
+++ b/src/components/VmUserMessages/style.css
@@ -3,8 +3,3 @@
     padding: 0;
     background-color: #fff;
 }
-
-.usermessages-icon {
-    float: left;
-    padding-right: calc(4px + 3px); /* Got it from '.navbar-pf-vertical .nav .nav-item-iconic > .pficon-user' to make it more visual similar */
-}

--- a/src/components/VmsPageHeader/UserMenu.js
+++ b/src/components/VmsPageHeader/UserMenu.js
@@ -15,7 +15,7 @@ const UserMenu = ({ config, onLogout }) => {
     <li className='dropdown'>
       <OverlayTooltip id={`${idPrefix}-tooltip`} tooltip={config.getIn(['user', 'name'])} placement='bottom'>
         <a className='dropdown-toggle nav-item-iconic' href='#' data-toggle='dropdown' id={`${idPrefix}-user`}>
-          <i className='pficon pficon-user' /><span className='caret' />
+          <i className='fa fa-user' /><span className='caret' />
         </a>
       </OverlayTooltip>
       <ul className='dropdown-menu'>

--- a/src/index-nomodules.css
+++ b/src/index-nomodules.css
@@ -57,10 +57,6 @@ body {
  *         gets shorter or a scrollbar is added to the page
  */
 
-.navbar {
-  min-height: 62px;
-}
-
 .navbar-pf-vertical {
   flex-shrink: 0;
 }
@@ -68,6 +64,10 @@ body {
 .navbar-pf-vertical .nav .nav-item-iconic .badge {
   margin-left: -2px !important;
   margin-right: 0;
+}
+
+.navbar-pf-vertical .nav .nav-item-iconic .caret {
+  margin-left: 4px;
 }
 
 .breadcrumb {
@@ -147,10 +147,6 @@ body {
 .message-dialog-pf .modal-body {
     display: -ms-flexbox;
     display: flex;
-}
-
-.navbar-nav > .dropdown {
-  position: inherit;
 }
 
 .drawer-pf .blank-slate-pf .blank-slate-pf-title {


### PR DESCRIPTION
  - Main icons layout correctly

  - Mouse hover background highlighting takes the same spaces for all icons (not a few pixels too short)

  - Drop down caret icons are spaced the same distance from their nav icons as in ovirt webadmin