### PR TITLE
Disable the Console action on a headless VM

### DIFF
--- a/src/components/VmActions/index.js
+++ b/src/components/VmActions/index.js
@@ -243,7 +243,7 @@ class VmActions extends React.Component {
       },
       {
         priority: 1,
-        actionDisabled: isPool || !canConsole(status) || vm.getIn(['actionInProgress', 'getConsole']),
+        actionDisabled: isPool || !canConsole(status) || vm.getIn(['actionInProgress', 'getConsole']) || vm.get('consoles').isEmpty(),
         shortTitle: msg.console(),
         tooltip: consoleProtocol,
         className: 'btn btn-default',


### PR DESCRIPTION
A headless VM will not have any associated consoles.  In that case,
set the general "Console" action to be disabled.

Fixes: #1139
Replaces: #1170