### PR TITLE
Fix `statusPerDataCenter` calculation in storageDomains sagas

### DIFF
--- a/src/sagas/storageDomains.js
+++ b/src/sagas/storageDomains.js
@@ -29,11 +29,13 @@ export function* fetchDataCentersAndStorageDomains (action) {
   // figure out the domain's status per data center
   const sdById = storageDomains.reduce((acc, sd) => ({ ...acc, [sd.id]: sd }), {})
   for (const dataCenter of dataCenters) {
-    for (const storageDomainId of Object.keys(dataCenter.storageDomains)) {
-      const sd = sdById[ storageDomainId ]
-      sd.statusPerDataCenter = {
-        ...sd.statusPerDataCenter,
-        [dataCenter.id]: dataCenter.storageDomains[storageDomainId].status,
+    for (const [ storageDomainId, { type } ] of Object.entries(dataCenter.storageDomains)) {
+      if (type === 'data' || type === 'iso') {
+        const sd = sdById[ storageDomainId ]
+        sd.statusPerDataCenter = {
+          ...sd.statusPerDataCenter,
+          [dataCenter.id]: dataCenter.storageDomains[storageDomainId].status,
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes: #1186

Since only 'data' and 'iso' storage domains are fetched in the
`fetchDataAndIsoStorageDomains` saga, if a data center contained
another type of storage domain (i.e. 'export'), the code that
calculates a storage domain's status per data center would fail.

Now, the code in `fetchDataCentersAndStorageDomains` will only
cross reference statuses for 'data' and 'iso' type storage domains.