### PR TITLE
Apply ovirt 4.4 branding changes to GlobalErrorBoundary

### DIFF
--- a/src/GlobalErrorBoundary.js
+++ b/src/GlobalErrorBoundary.js
@@ -48,7 +48,7 @@ class GlobalErrorBoundary extends React.Component {
     if (this.state.hasError) {
       return (
         <div>
-          <nav className='navbar obrand_mastheadBackground obrand_topBorder navbar-pf-vertical'>
+          <nav className='navbar navbar-pf-vertical obrand_masthead'>
             <div className='navbar-header'>
               <a href='/' className='navbar-brand obrand_headerLogoLink' id='pageheader-logo'>
                 <img className='obrand_mastheadLogo' src={branding.resourcesUrls.clearGif} />


### PR DESCRIPTION
Follows up changes to `Header.js` in PR #1157 and applies the same masthead changes to the error page.