### PR TITLE
Use the latest commit hash for snapshot rpms

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -76,8 +76,10 @@ rpm:	srpm
 	@echo "rpm(s) available at '$(TMPREPOS)'"
 	@echo
 
+snapshot-rpm: SNAPSHOT_DATE = $(shell date --utc +%Y%m%d)
+snapshot-rpm: SNAPSHOT_COMMIT ?= $(shell git log -1 --pretty=format:%h)
 snapshot-rpm:
-	make rpm RELEASE_SUFFIX=".$$(date --utc +%Y%m%d).git$$(git log --no-merges -1 --pretty=format:%h)"
+	make rpm RELEASE_SUFFIX=".$(SNAPSHOT_DATE).git$(SNAPSHOT_COMMIT)"
 
 publish:
 	mkdir -p $(OVIRT_CACHE_DIR)

--- a/automation/build.sh
+++ b/automation/build.sh
@@ -21,6 +21,15 @@ export PATH="/usr/share/ovirt-engine-nodejs/bin:/usr/share/ovirt-engine-nodejs-m
 
 ./autogen.sh --prefix=/usr --datarootdir=/share
 if [[ "${version_release}" == "0" ]]; then
+  IFS='|' read -ra HEAD  <<< $(git log -1 --pretty=tformat:"%H|%ce|%s" )
+  IFS='|' read -ra HEAD_ <<< $(git log -1 --pretty=tformat:"%H|%ce|%s" --skip=1)
+
+  pr_merge_email="noreply@github.com"
+  pr_merge_commit="^Merge ${HEAD_[0]} into [0-9a-f]{40}$"
+  if [[ ${HEAD[1]} == $pr_merge_email ]] && [[ ${HEAD[2]} =~ $pr_merge_commit ]]; then
+    export SNAPSHOT_COMMIT="${HEAD_[0]:0:7}"
+  fi
+
   make snapshot-rpm
 else
   make rpm


### PR DESCRIPTION
To align with the commit hash STDCI builds report, have snapshot
rpms use the most recent non-github pull request auto merge commit.

Accessing a pull request via `+refs/pull/1234/merge` causes a temporary
merge commit to be generated.  STDCI scripts uses this style to pull
PRs from github, so that temporary merge commit needs to be ignored.

We want the rpm file names to contain the commit hash of the latest
commit on the github repo / pull request.  Any github pull request
auto merge commits should be ignored when determining the latest
upstream commit.

On jenkins, the reported "myhead" commit id will be for the temporary/generated PR merge commit done by github.  The rpm's git commit hash will match the actual last commit id of the pull request (or the head commit of master).

For example, the [jenkins check-patch job 1170](https://jenkins.ovirt.org/job/oVirt_ovirt-web-ui_standard-check-pr/1170/) has the comment `GitHub pull request #1189 of commit cdaeffa975c3ac8ca1d0eb856b8d0af8b9365a99, no merge conflicts.`  The built rpms will have the first 7 characters of the commit it in the filename.