### PR TITLE
Update VM name filter to match anywhere in the VM name

### DIFF
--- a/src/utils/vms-filters.js
+++ b/src/utils/vms-filters.js
@@ -2,7 +2,7 @@ import { getOsHumanName } from '../components/utils'
 import { enumMsg } from '_/intl'
 
 const compareMap = {
-  name: (item, filter) => !!filter.find(n => item.get('name').startsWith(n)),
+  name: (item, filter) => !!filter.find(n => item.get('name').includes(n)),
   os: (item, filter) => getOsHumanName(item.getIn(['os', 'type'])) === filter,
   status: (item, filter) => enumMsg('VmStatus', item.get('status')) === filter,
 }


### PR DESCRIPTION
hi I just change the filter methods from startsWith to includes.

Fixes: #1127 