### PR TITLE
Display only those Pool entities which contain search term

### DIFF
--- a/src/components/VmsList/Vms.js
+++ b/src/components/VmsList/Vms.js
@@ -44,7 +44,7 @@ class Vms extends React.Component {
 
     // Filter the Pools (only show a Pool card if the user can currently 'Take' a VM from it)
     const filteredPools = vms.get('pools')
-      .filter(pool => alwaysShowPoolCard || (pool.get('vmsCount') < pool.get('maxUserVms') && pool.get('size') > 0 && filterVms(pool, filters)))
+      .filter(pool => (alwaysShowPoolCard || (pool.get('vmsCount') < pool.get('maxUserVms') && pool.get('size') > 0)) && filterVms(pool, filters))
       .toList()
 
     // Display the VMs and Pools together, sorted nicely


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/1183

In the VM list, display the only those Pool entities which contain the current search term (not all of them as it was before for admins), treat VMs and Pool entities the same way for all user types when filtering. Always show Pool cards only when logged in as an admin user and not filtering.

In detail, the point of the fix is that we always need to execute `filterVms(pool, filters)`, not only when `alwaysShowPoolCard` was `false` (for non-admin users).
 
---

**Before:**
![vm_before](https://user-images.githubusercontent.com/13417815/80529251-7ab57200-8997-11ea-8841-95efff6969e4.png)
![pool2_before](https://user-images.githubusercontent.com/13417815/80529291-8b65e800-8997-11ea-8de7-e14b98020f43.png)

**After:**
![vm_after](https://user-images.githubusercontent.com/13417815/80529258-7f7a2600-8997-11ea-8c91-2acc3ca3cfe6.png)
![pool2_after](https://user-images.githubusercontent.com/13417815/80529298-902a9c00-8997-11ea-9e60-f69a1b842e0b.png)
