### PR TITLE
Maximize Notification Drawer after clicking on toggle expand button

### DIFF
--- a/src/components/VmUserMessages/Bellicon.js
+++ b/src/components/VmUserMessages/Bellicon.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+
+import { hrefWithoutHistory } from '_/helpers'
+import { msg } from '_/intl'
+import OverlayTooltip from '../OverlayTooltip'
+
+const Bellicon = ({ userMessages, handleclick }) => {
+  const messagesCount = userMessages.get('records').size
+  const idPrefix = `usermsgs`
+  const badgeElement = messagesCount === 0
+    ? null
+    : <span className='badge' id={`${idPrefix}-size`}>{messagesCount}</span>
+
+  return (
+    <li>
+      <OverlayTooltip id={`${idPrefix}-tooltip`} tooltip={msg.notifications()} placement='bottom'>
+        <a className='dropdown-toggle nav-item-iconic' href='#' onClick={hrefWithoutHistory(handleclick)} id={`${idPrefix}-toggle`}>
+          <i className='fa fa-bell' />
+          {badgeElement}
+          <span className='caret' id={`${idPrefix}-caret`} />
+        </a>
+      </OverlayTooltip>
+    </li>
+  )
+}
+Bellicon.propTypes = {
+  handleclick: PropTypes.func.isRequired,
+  userMessages: PropTypes.object.isRequired,
+}
+
+export default connect(
+  (state) => ({
+    userMessages: state.userMessages,
+  })
+)(Bellicon)

--- a/src/components/VmUserMessages/index.js
+++ b/src/components/VmUserMessages/index.js
@@ -1,14 +1,13 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
 import { Notification, NotificationDrawer, MenuItem, Icon, Button } from 'patternfly-react'
-import OverlayTooltip from '../OverlayTooltip'
 
 import style from './style.css'
 
 import { clearUserMessages, dismissEvent } from '_/actions'
-import { hrefWithoutHistory, getFormatedDateTime } from '_/helpers'
+import { getFormatedDateTime } from '_/helpers'
 import { msg } from '_/intl'
 
 const UserMessage = ({ record, id, onDismissMessage }) => {
@@ -34,86 +33,54 @@ UserMessage.propTypes = {
   onDismissMessage: PropTypes.func.isRequired,
 }
 
-class VmUserMessages extends React.Component {
-  constructor (props) {
-    super(props)
-    this.state = {
-      show: false,
-      expand: false,
-    }
-    this.handleToggle = this.handleToggle.bind(this)
-    this.handleExpand = this.handleExpand.bind(this)
-  }
+const VmUserMessages = ({ userMessages, onClearMessages, onDismissMessage, onClose, show }) => {
+  const [expanded, setExpanded] = useState(false)
 
-  handleToggle () {
-    this.setState((prevState) => ({ show: !prevState.show }))
-  }
+  const idPrefix = `usermsgs`
 
-  handleExpand () {
-    this.setState((prevState) => ({ expanded: !prevState.expanded }))
-  }
+  const messagesCount = userMessages.get('records').size
+  const messagesList = messagesCount
+    ? userMessages.get('records').map(r => (
+      <UserMessage
+        key={`msg-${r.get('time')}`}
+        record={r}
+        id={`${idPrefix}-msg-${r.get('time')}-dropdown`}
+        onDismissMessage={() => onDismissMessage(r.toJS())}
+      />
+    ))
+    : <NotificationDrawer.EmptyState title={msg.noMessages()} />
 
-  render () {
-    const { userMessages, onClearMessages, onDismissMessage } = this.props
-
-    const idPrefix = `usermsgs`
-
-    const messagesCount = userMessages.get('records').size
-    const messagesList = messagesCount
-      ? userMessages.get('records').map(r => (
-        <UserMessage
-          key={`msg-${r.get('time')}`}
-          record={r}
-          id={`${idPrefix}-msg-${r.get('time')}-dropdown`}
-          onDismissMessage={() => onDismissMessage(r.toJS())}
-        />
-      ))
-      : <NotificationDrawer.EmptyState title={msg.noMessages()} />
-
-    const badgeElement = messagesCount === 0
-      ? null
-      : <span className='badge' id={`${idPrefix}-size`}>{messagesCount}</span>
-    return (
-      <li className='dropdown'>
-        <OverlayTooltip id={`${idPrefix}-tooltip`} tooltip={msg.notifications()} placement='bottom'>
-          <a className='dropdown-toggle nav-item-iconic' href='#' onClick={hrefWithoutHistory(this.handleToggle)} id={`${idPrefix}-toggle`}>
-            <i className='fa fa-bell' />
-            {badgeElement}
-            <span className='caret' id={`${idPrefix}-caret`} />
-          </a>
-        </OverlayTooltip>
-        <NotificationDrawer hide={!this.state.show} expanded={this.state.expanded}>
-          <NotificationDrawer.Title onCloseClick={this.handleToggle} onExpandClick={this.handleExpand} />
-          <NotificationDrawer.PanelBody className={style['panel-body']}>
-            <div className={style['notifications-list']}>
-              {messagesList}
-            </div>
-            { messagesCount > 0 &&
-              <NotificationDrawer.PanelAction className={style['action-panel']}>
-                <NotificationDrawer.PanelActionLink data-toggle='clear-all'>
-                  <Button bsStyle='link' onClick={onClearMessages}>
-                    <Icon type='pf' name='close' />
-                    { msg.clearAll() }
-                  </Button>
-                </NotificationDrawer.PanelActionLink>
-              </NotificationDrawer.PanelAction>
-            }
-          </NotificationDrawer.PanelBody>
-        </NotificationDrawer>
-      </li>
-
-    )
-  }
+  return (
+    <NotificationDrawer hide={!show} expanded={expanded}>
+      <NotificationDrawer.Title onCloseClick={onClose} onExpandClick={() => setExpanded(!expanded)} />
+      <NotificationDrawer.PanelBody className={style['panel-body']}>
+        <div className={style['notifications-list']}>
+          {messagesList}
+        </div>
+        { messagesCount > 0 &&
+          <NotificationDrawer.PanelAction className={style['action-panel']}>
+            <NotificationDrawer.PanelActionLink data-toggle='clear-all'>
+              <Button bsStyle='link' onClick={onClearMessages}>
+                <Icon type='pf' name='close' />
+                { msg.clearAll() }
+              </Button>
+            </NotificationDrawer.PanelActionLink>
+          </NotificationDrawer.PanelAction>
+        }
+      </NotificationDrawer.PanelBody>
+    </NotificationDrawer>
+  )
 }
 VmUserMessages.propTypes = {
   userMessages: PropTypes.object.isRequired,
   onClearMessages: PropTypes.func.isRequired,
   onDismissMessage: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+  show: PropTypes.bool.isRequired,
 }
 
 export default connect(
   (state) => ({
-    config: state.config,
     userMessages: state.userMessages,
   }),
   (dispatch) => ({

--- a/src/components/VmsPageHeader/index.js
+++ b/src/components/VmsPageHeader/index.js
@@ -1,9 +1,10 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 
 import { connect } from 'react-redux'
 
 import VmUserMessages from '../VmUserMessages'
+import Bellicon from '../VmUserMessages/Bellicon'
 import UserMenu from './UserMenu'
 import Header from '../Header'
 import { hrefWithoutHistory } from '_/helpers'
@@ -16,10 +17,13 @@ import OverlayTooltip from '../OverlayTooltip'
  * Main application header on top of the page
  */
 const VmsPageHeader = ({ page, onRefresh }) => {
+  const [show, setShow] = useState(false)
   const idPrefix = `pageheader`
+
   return (
     <Header>
       <div className='collapse navbar-collapse'>
+        <VmUserMessages show={show} onClose={() => setShow(!show)} />
         <ul className='nav navbar-nav navbar-right navbar-iconic'>
           <li>
             <OverlayTooltip id={`${idPrefix}-tooltip`} tooltip={msg.refresh()} placement='bottom'>
@@ -29,7 +33,7 @@ const VmsPageHeader = ({ page, onRefresh }) => {
             </OverlayTooltip>
           </li>
           <UserMenu />
-          <VmUserMessages />
+          <Bellicon handleclick={() => setShow(!show)} />
         </ul>
       </div>
     </Header>


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/1182

There was a problem with Notification Drawer, after clicking on the toggle expand button: the drawer did not maximize and right from the VMs list, a blank area appeared. This happened due to patternfly react `NotificationDrawer` component implementation, especially its style and placing the component in the DOM. 

We need to place the component in the right place to make it work and to display it properly, it shouldn't be in `<ul>` element (unordered list) where the remaining icons like icon for refreshing the page and some settings for the user (and some more stuff) are. See more about the [NotificationDrawer component](https://www.patternfly.org/v3/pattern-library/communication/notification-drawer/#code).

The solution is to split `VmUserMessages` component in two and move Notification Drawer out of `<ul>` element, to display it maximized and working properly, (not only) after clicking on the toggle expand button. This is needed because the original `VmUserMessages` component contained both the icon and the patternfly component for the drawer. I've created a new componend called `BellIcon` to represent only the bell icon and stuff related to it and the original `VmUserMessages` now contains the Notification Drawer by itself. Maybe we could override or hack the original patternfly drawer's css somehow but I don't consider this as a good solution.

---

**Before:**
![notif_before](https://user-images.githubusercontent.com/13417815/80727378-ef0e2380-8b05-11ea-9ee3-4ce82136a5ca.png)

**After:**
![notif_after](https://user-images.githubusercontent.com/13417815/80727403-f59c9b00-8b05-11ea-85b7-331513b73111.png)
