### PR TITLE
Increase parallel calls during login data fetch

### DIFF
--- a/src/sagas/login.js
+++ b/src/sagas/login.js
@@ -93,9 +93,12 @@ function* login (action) {
 
   // API checks passed.  Load user data and the initial app data
   console.group('Login Data Fetch')
+
   console.group('user checks and server config')
-  yield checkUserFilterPermissions()
-  yield fetchServerConfiguredValues()
+  yield all([
+    call(checkUserFilterPermissions),
+    call(fetchServerConfiguredValues),
+  ])
   console.log('\u2714 login checks and server config fetches are done:',
     yield select(state => pick(
       state.config.toJS(),

--- a/src/sagas/server-configs.js
+++ b/src/sagas/server-configs.js
@@ -13,13 +13,55 @@ import {
 import { callExternalAction } from './utils'
 
 export function* fetchServerConfiguredValues () {
-  yield all([
-    call(fetchCpuTopologyOptions),
-    call(fetchUSBFilter),
-    call(fetchUserSessionTimeoutInterval),
-    call(fetchWebsocketProxy),
-    call(fetchDefaultTimeZoneConfig),
+  const optionVersion = yield select(state => {
+    const ver = state.config.get('oVirtApiVersion')
+    return `${ver.get('major')}.${ver.get('minor')}`
+  })
+
+  const [
+    maxNumberOfSockets, maxNumberOfCores, maxNumberOfThreads, maxNumOfVmCpus,
+    usbFilter,
+    userSessionTimeout,
+    defaultGeneralTimezone, defaultWindowsTimezone,
+    websocketProxy,
+  ] = yield all([
+    callGetOption('MaxNumOfVmSockets', optionVersion, 16),
+    callGetOption('MaxNumOfCpuPerSocket', optionVersion, 16),
+    callGetOption('MaxNumOfThreadsPerCpu', optionVersion, 16),
+    callGetOption('MaxNumOfVmCpus', optionVersion, 1),
+
+    callExternalAction('getUSBFilter', Api.getUSBFilter, {}),
+
+    callGetOption('UserSessionTimeOutInterval', 'general', 30),
+
+    callGetOption('DefaultGeneralTimeZone', 'general', 'Etc/GMT'),
+    callGetOption('DefaultWindowsTimeZone', 'general', 'GMT Standard Time'),
+
+    callGetOption('WebSocketProxy', 'general', ''),
   ])
+
+  yield put(setCpuTopologyOptions({
+    maxNumberOfSockets: parseInt(maxNumberOfSockets, 10),
+    maxNumberOfCores: parseInt(maxNumberOfCores, 10),
+    maxNumberOfThreads: parseInt(maxNumberOfThreads, 10),
+    maxNumOfVmCpus: parseInt(maxNumOfVmCpus, 10),
+  }))
+
+  if (usbFilter) {
+    yield put(setUSBFilter({ usbFilter }))
+  }
+
+  yield put(setUserSessionTimeoutInternal(parseInt(userSessionTimeout, 10)))
+
+  yield put(setDefaultTimezone({
+    defaultGeneralTimezone,
+    defaultWindowsTimezone,
+  }))
+
+  if (websocketProxy) {
+    const [ host = '', port = '' ] = websocketProxy.split(':')
+    yield put(setWebsocket({ host, port }))
+  }
 }
 
 function callGetOption (name, version, defaultValue) {
@@ -29,58 +71,4 @@ function callGetOption (name, version, defaultValue) {
     Api.getOption,
     getOption(name, version, defaultValue)
   )
-}
-
-function* fetchCpuTopologyOptions () {
-  const optionVersion = yield select(state => {
-    const ver = state.config.get('oVirtApiVersion')
-    return `${ver.get('major')}.${ver.get('minor')}`
-  })
-
-  const [ maxNumberOfSockets, maxNumberOfCores, maxNumberOfThreads, maxNumOfVmCpus ] =
-    yield all([
-      callGetOption('MaxNumOfVmSockets', optionVersion, 16),
-      callGetOption('MaxNumOfCpuPerSocket', optionVersion, 16),
-      callGetOption('MaxNumOfThreadsPerCpu', optionVersion, 16),
-      callGetOption('MaxNumOfVmCpus', optionVersion, 1),
-    ])
-
-  yield put(setCpuTopologyOptions({
-    maxNumberOfSockets: parseInt(maxNumberOfSockets, 10),
-    maxNumberOfCores: parseInt(maxNumberOfCores, 10),
-    maxNumberOfThreads: parseInt(maxNumberOfThreads, 10),
-    maxNumOfVmCpus: parseInt(maxNumOfVmCpus, 10),
-  }))
-}
-
-function* fetchUSBFilter () {
-  const usbFilter = yield callExternalAction('getUSBFilter', Api.getUSBFilter, {})
-  if (usbFilter) {
-    yield put(setUSBFilter({ usbFilter }))
-  }
-}
-
-function* fetchUserSessionTimeoutInterval () {
-  const userSessionTimeout = yield callGetOption('UserSessionTimeOutInterval', 'general', 30)
-  yield put(setUserSessionTimeoutInternal(parseInt(userSessionTimeout, 10)))
-}
-
-function* fetchDefaultTimeZoneConfig () {
-  const [ defaultGeneralTimezone, defaultWindowsTimezone ] =
-  yield all([
-    yield callGetOption('DefaultGeneralTimeZone', 'general', 'Etc/GMT'),
-    yield callGetOption('DefaultWindowsTimeZone', 'general', 'GMT Standard Time'),
-  ])
-  yield put(setDefaultTimezone({
-    defaultGeneralTimezone,
-    defaultWindowsTimezone,
-  }))
-}
-
-function* fetchWebsocketProxy () {
-  const data = yield callGetOption('WebSocketProxy', 'general', '')
-  if (data) {
-    const [ host = '', port = '' ] = data.split(':')
-    yield put(setWebsocket({ host, port }))
-  }
 }


### PR DESCRIPTION
Resolves #1210

Increase parallel calls during login data fetch:
  - Fetch user permissions and server config values in parallel
  - Server config values are all fetched in parallel

This should max out the number of fetches that can be done at the same time (a browser limit).