### PR TITLE
Fix error in Create Wizard with handleBasicOnUpdate

### DIFF
--- a/src/components/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/CreateVmWizard/CreateVmWizard.js
@@ -262,7 +262,7 @@ class CreateVmWizard extends React.Component {
 
   handleBasicOnUpdate (partialUpdate) {
     const { provisionSource, templateId } = this.state.steps.basic
-    const { provisionSource_, templateId_ } = partialUpdate
+    const { provisionSource: provisionSource_, templateId: templateId_ } = partialUpdate
 
     this.setState(state => {
       const extraUpdates = {}


### PR DESCRIPTION
Destructuring assignment from the `partialUpdate` was forcing
every change on basic details to reset nics and disks.  Fixed
up the assignment so the nics and disks reset happens only when
it is supposed to.