### PR TITLE
Update Dockerfile with yarn network timeout mitigations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY src /web-ui/src
 COPY branding /web-ui/branding
 
 WORKDIR /web-ui
-RUN yarn install
+RUN yarn config set network-timeout 90000
+RUN yarn install || yarn install || yarn install
 
 ENTRYPOINT ["yarn", "start"]


### PR DESCRIPTION
In some build environments yarn has problems downloading
dependencies due to network timeout errors.  This change
configures a longer network time and will attempt up to
three installs to help make sure docker containers will
build.

Refer to similar patch in ovirt-engine-nodejs-modules: https://gerrit.ovirt.org/#/c/107492/