### PR TITLE
Create VM Wizard - add to the "T" badge a tooltip to explain device source

### DIFF
--- a/src/components/CreateVmWizard/steps/Networking.js
+++ b/src/components/CreateVmWizard/steps/Networking.js
@@ -25,6 +25,7 @@ import _TableInlineEditRow from './_TableInlineEditRow'
 import SelectBox from '_/components/SelectBox'
 
 import style from './style.css'
+import OverlayTooltip from '_/components/OverlayTooltip'
 
 const NIC_INTERFACES = createNicInterfacesList()
 const NIC_INTERFACE_DEFAULT = 'virtio'
@@ -34,9 +35,11 @@ export const NicNameWithLabels = ({ id, nic }) => {
   return <React.Fragment>
     <span id={`${idPrefix}-name`}>{ nic.name }</span>
     { nic.isFromTemplate &&
-      <Label id={`${idPrefix}-from-template`} className={style['nic-label']}>
-        T
-      </Label>
+      <OverlayTooltip id={`${idPrefix}-template-defined-badge`} tooltip={msg.templateDefined()} placement='top'>
+        <Label id={`${idPrefix}-from-template`} className={style['nic-label']}>
+          T
+        </Label>
+      </OverlayTooltip>
     }
   </React.Fragment>
 }

--- a/src/components/CreateVmWizard/steps/Storage.js
+++ b/src/components/CreateVmWizard/steps/Storage.js
@@ -26,6 +26,7 @@ import _TableInlineEditRow from './_TableInlineEditRow'
 import SelectBox from '_/components/SelectBox'
 
 import style from './style.css'
+import OverlayTooltip from '_/components/OverlayTooltip'
 
 function getDefaultFormatType (vmOptimizedFor) {
   const format =
@@ -57,9 +58,11 @@ export const DiskNameWithLabels = ({ id, disk }) => {
   return <React.Fragment>
     <span id={`${idPrefix}-name`}>{ disk.name }</span>
     { disk.isFromTemplate &&
-      <TooltipLabel id={`${idPrefix}-from-template`}>
-        T
-      </TooltipLabel>
+      <OverlayTooltip id={`${idPrefix}-template-defined-badge`} tooltip={msg.templateDefined()} placement='top'>
+        <Label id={`${idPrefix}-from-template`} className={`${style['disk-label']}`}>
+          T
+        </Label>
+      </OverlayTooltip>
     }
     { disk.bootable &&
       <Label id={`${idPrefix}-bootable`} className={style['disk-label']} bsStyle='info'>

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -572,6 +572,7 @@ export const messages: { [messageId: string]: MessageType } = {
   sysPrepOptions: 'SysPrep Options',
   takeVm: 'Take a Virtual Machine',
   template: 'Template',
+  templateDefined: 'Template Defined',
   timeAgo: '{time} ago',
   timezone: 'Timezone',
   thisOperationCantBeUndone: 'This operation cannot be undone.',


### PR DESCRIPTION
Hi there,
In the Create VM Wizard when choosing template which includes disks or NICs those devices marked with a "T" badge:

![image](https://user-images.githubusercontent.com/64131213/82187442-6986c380-98ba-11ea-9184-be924f675716.png)

This "T" badge is not self explained, after a consultation with @lwrigh , in case of using the template name badge is a bad practice because we can't control the string's length, and the template name or just part of it is not self explained. the best solution and the most explained options are using "Template" badge or  using a "T" badge and adding tooltip with the string "Template defined" so I chose to implement the second option ( "T" badge with tooltip) because it's shorter than "Template" and the tooltip is more explained, screenshot of the implementation:

![image2](https://user-images.githubusercontent.com/64131213/82187942-237e2f80-98bb-11ea-8a11-bd7bcf6390d7.png)

please pay attention that the string "template defined" needs a translation to the other supported languages.

Fixes: #1204
