### PR TITLE
added explicitly width value to disk size FormControl field

### DIFF
--- a/src/components/CreateVmWizard/steps/Storage.js
+++ b/src/components/CreateVmWizard/steps/Storage.js
@@ -201,6 +201,7 @@ class Storage extends React.Component {
               id={`${idPrefix}-${value}-size-edit`}
               type='number'
               defaultValue={sizeGiB}
+              className={style['disk-size-form-control-edit']}
               onBlur={e => this.handleCellChange(rowData, 'size', e.target.value)}
             />
             <span className={style['disk-size-edit-label']}>GiB</span>

--- a/src/components/CreateVmWizard/steps/style.css
+++ b/src/components/CreateVmWizard/steps/style.css
@@ -111,6 +111,10 @@
   display: flex;
   align-items: center;
 }
+.disk-size-form-control-edit {
+  width: 0;
+  flex-grow: 1;
+}
 
 .disk-size-edit .disk-size-edit-label {
   margin: 0 3px;


### PR DESCRIPTION
"On the "Create Virtual Machine" wizard -> "Storage" step, when adding/editing a Disk by clicking the checkmark box, the "Storage Domain" field looks like overriding a value beneath:"

![](https://user-images.githubusercontent.com/18169498/82301957-a25d9000-99c1-11ea-9e26-33607469d591.png)

the problem happens only in FF browser, in chrome it looks good.

the problem was the <FormControl>  component's width, the component took 100% of the table's cell and "pushed" the <span> tag with the units to the left and the tag covered by the "Storage Domain" field.

I added explicitly width value to the component.
now it's not looks like the "Storage Domain" field overriding a value beneath.

Chrome:
![image](https://user-images.githubusercontent.com/64131213/82322473-91eaec80-99a4-11ea-90e4-0fef23630cab.png)

FF:
![image](https://user-images.githubusercontent.com/64131213/82322636-d6768800-99a4-11ea-9a05-a42e8f141ee6.png)


Fixes: #1214 