### PR TITLE
Create VM, Network - add validation to NIC name

### DIFF
--- a/src/components/CreateVmWizard/steps/style.css
+++ b/src/components/CreateVmWizard/steps/style.css
@@ -147,6 +147,10 @@ table tbody tr td.kebab-menu-cell {
   padding: 2px 10px 1px;
 }
 
+.form-group-edit{
+  margin-bottom: 0;
+}
+
 /*
  * Summary Review
  */

--- a/src/components/utils/validation.js
+++ b/src/components/utils/validation.js
@@ -90,3 +90,23 @@ export function isVmNameValid (nameCandidate: string): boolean {
 export function isDiskNameValid (nameCandidate: string): boolean {
   return isVmNameValid(nameCandidate)
 }
+
+/**
+ * check if the name's length between 1 to 50 characters
+ * and contains only uppercase, lowercase, hyphens and underscores
+ */
+export function isNicNameValid (name: string): boolean {
+  return /^[a-zA-Z0-9_\-\\.]{1,50}$/.test(name)
+}
+
+/**
+ * check if the nicEditing name is unique to the given nicList
+ */
+export function isNicNameUnique (nicList: Object, nicEditing: Object): boolean {
+  const nicsMatchEditingName = nicList.filter((nic) => nic.name === nicEditing.name)
+
+  const nameUnique = nicsMatchEditingName.length === 0 ||
+    (nicsMatchEditingName.length === 1 && nicsMatchEditingName[0].id === nicEditing.id)
+
+  return nameUnique
+}

--- a/src/components/utils/validation.test.js
+++ b/src/components/utils/validation.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { isHostNameValid, isVmNameValid } from './validation'
+import { isHostNameValid, isVmNameValid, isNicNameValid, isNicNameUnique } from './validation'
 
 describe('check host names', function () {
   it('valid host names', function () {
@@ -34,5 +34,45 @@ describe('check VM names', function () {
     expect(isVmNameValid('AC/DC')).toEqual(false)
     expect(isVmNameValid('  abc  ')).toEqual(false)
     expect(isVmNameValid('veryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongname')).toEqual(false)
+  })
+})
+
+describe('check NIC names', function () {
+  it('valid NIC names', function () {
+    expect(isNicNameValid('SomeName')).toEqual(true)
+    expect(isNicNameValid('1Ab')).toEqual(true)
+    expect(isNicNameValid('A_c')).toEqual(true)
+    expect(isNicNameValid('c1-b')).toEqual(true)
+    expect(isNicNameValid('A10-_.b')).toEqual(true)
+  })
+  it('invalid NIC names ', function () {
+    expect(isNicNameValid('SomeBadName?')).toEqual(false)
+    expect(isNicNameValid('The Worst name Ever!')).toEqual(false)
+    expect(isNicNameValid('')).toEqual(false)
+    expect(isNicNameValid('N@me$)')).toEqual(false)
+    expect(isNicNameValid('A1 b1')).toEqual(false)
+  })
+})
+describe('check NIC name uniqueness', function () {
+  const nicList = [
+    { id: '1', name: 'nic1' },
+    { id: '2', name: 'nic2' },
+    { id: '3', name: 'nic3' },
+    { id: '4', name: 'nic4' },
+  ]
+  it('duplicate name on create new NIC', function () {
+    expect(isNicNameUnique(nicList, { id: 'a', name: 'nic4' })).toEqual(false)
+  })
+  it('duplicate name on update NIC', function () {
+    expect(isNicNameUnique(nicList, { id: '4', name: 'nic3' })).toEqual(false)
+  })
+  it('unique name on update NIC same name', function () {
+    expect(isNicNameUnique(nicList, nicList[3])).toEqual(true)
+  })
+  it('unique name on update NIC new name', function () {
+    expect(isNicNameUnique(nicList, { id: '4', name: 'nic5' })).toEqual(true)
+  })
+  it('unique name on create new NIC', function () {
+    expect(isNicNameUnique(nicList, { id: '5', name: 'nic5' })).toEqual(true)
   })
 })

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -165,6 +165,7 @@ export const messages: { [messageId: string]: MessageType } = {
   createVmWizardStepTitleNetwork: 'Networking',
   createVmWizardStepTitleReview: 'Review',
   createVmWizardStepTitleStorage: 'Storage',
+  createVmWizardNetVNICNameRules: 'NIC name must be unique, 50 or less alphanumeric characters or "-_."',
   currentlyInsertedIsoInCdDrive: 'Currently inserted ISO in CD drive',
   customIcon: 'Custom icon of the virtual machine.',
   customScript: 'Custom script',


### PR DESCRIPTION
Fixes: #1205 

Hi there,
I added new validations to the "NIC's name" field, to notify the user about the validation status I made few visual changes too.
the changes are:
1. New information tooltip in the "NIC's name" cell which explains to the users the NIC's name rules (maybe we need new message formulation).

![image](https://user-images.githubusercontent.com/64131213/82751146-4f018e00-9d83-11ea-857d-c7aff6fe7225.png)

2. On edit/ create row state I used patternfly 4 components instead the old components (`TextInput`, `InputGroup`,  `FormSelect`, `FormSelectOption`), the `TextInput` component lets us to notify users that the name failed in the validation checks, the rest of components used for uniformity.

![image](https://user-images.githubusercontent.com/64131213/82751173-81ab8680-9d83-11ea-821b-4dcd1cea1034.png)

3. I added 2 tests for the propriety of the name and its uniqueness. the tests are the `isNicsNameValid` and `isNICsNameUnique` functions.

@sgratch @sjd78 @lwrigh  what do you think about that changes?