### PR TITLE
Make VM time zone format compatible with the VM OS when creating a VM, display time zone in the Review report step

### DIFF
--- a/src/components/CreateVmWizard/steps/BasicSettings.js
+++ b/src/components/CreateVmWizard/steps/BasicSettings.js
@@ -255,7 +255,6 @@ class BasicSettings extends React.Component {
       case 'templateId':
         const template = this.props.templates.find(t => t.get('id') === value)
         changes.templateId = template.get('id')
-        changes.timeZone = template.get('timeZone').toJS()
 
         changes.memory = template.get('memory') / (1024 ** 2) // stored in bytes, input in Mib
         changes.cpus = template.getIn([ 'cpu', 'vCPUs' ])
@@ -264,6 +263,8 @@ class BasicSettings extends React.Component {
           .find(os => os.get('name') === template.getIn([ 'os', 'type' ]))
           .get('id')
 
+        // Check template's timezone compatibility with the template's OS, set the timezone corresponding to the template's OS
+        changes.timeZone = this.checkTimeZone(changes.operatingSystemId, changes.templateId)
         changes.cloudInitEnabled = template.getIn(['cloudInit', 'enabled'])
         changes.initHostname = template.getIn(['cloudInit', 'hostName'])
         changes.initSshKeys = template.getIn(['cloudInit', 'sshAuthorizedKeys'])

--- a/src/components/CreateVmWizard/steps/BasicSettings.js
+++ b/src/components/CreateVmWizard/steps/BasicSettings.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { localeCompare } from '_/helpers'
+import { localeCompare, isWindows } from '_/helpers'
 import { msg } from '_/intl'
 import { isNumberInRange } from '_/utils'
 import { BASIC_DATA_SHAPE } from '../dataPropTypes'
@@ -18,6 +18,8 @@ import {
 import { Form, FormControl, Checkbox } from 'patternfly-react'
 import { Grid, Row, Col } from '_/components/Grid'
 import SelectBox from '_/components/SelectBox'
+
+import timezones from '_/components/utils/timezones.json'
 
 import style from './style.css'
 
@@ -113,6 +115,7 @@ export const optimizedForMap = {
 class BasicSettings extends React.Component {
   constructor (props) {
     super(props)
+    this.checkTimeZone = this.checkTimeZone.bind(this)
     this.handleChange = this.handleChange.bind(this)
     this.validateForm = this.validateForm.bind(this)
     this.validateVmName = this.validateVmName.bind(this)
@@ -125,6 +128,35 @@ class BasicSettings extends React.Component {
         'startOnCreation', 'cloudInitEnabled',
       ],
     }
+  }
+
+  checkTimeZone (osId, templateId) {
+    const { defaultGeneralTimezone, defaultWindowsTimezone } = this.props
+    const template = templateId ? this.props.templates.get(templateId) : undefined
+
+    let timeZone = {
+      name: defaultGeneralTimezone,
+    }
+    const osType = this.props.operatingSystems.getIn([ osId, 'name' ])
+
+    if (template && template.getIn(['timeZone', 'name'])) {
+      timeZone = template.get('timeZone').toJS()
+    }
+
+    const isWindowsTimeZone = timeZone && timezones.find(timezone => timezone.id === timeZone.name)
+    const isWindowsVm = isWindows(osType)
+
+    if (isWindowsVm && !isWindowsTimeZone) {
+      timeZone = {
+        name: defaultWindowsTimezone,
+      }
+    }
+    if (!isWindowsVm && isWindowsTimeZone) {
+      timeZone = {
+        name: defaultGeneralTimezone,
+      }
+    }
+    return timeZone
   }
 
   validateForm (dataSet) {
@@ -213,11 +245,17 @@ class BasicSettings extends React.Component {
         changes.cpus = this.props.defaultValues.cpus
         changes.optimizedFor = this.props.defaultValues.optimizedFor
         changes.cloudInitEnabled = this.props.defaultValues.initEnabled
+
+        // when changing Provision type to ISO, set the default time zone according to the OS
+        if (changes.provisionSource === 'iso') {
+          changes.timeZone = this.checkTimeZone(changes.operatingSystemId, changes.templateId)
+        }
         break
 
       case 'templateId':
         const template = this.props.templates.find(t => t.get('id') === value)
         changes.templateId = template.get('id')
+        changes.timeZone = template.get('timeZone').toJS()
 
         changes.memory = template.get('memory') / (1024 ** 2) // stored in bytes, input in Mib
         changes.cpus = template.getIn([ 'cpu', 'vCPUs' ])
@@ -231,6 +269,11 @@ class BasicSettings extends React.Component {
         changes.initSshKeys = template.getIn(['cloudInit', 'sshAuthorizedKeys'])
         changes.initTimezone = template.getIn(['cloudInit', 'timezone'])
         changes.initCustomScript = template.getIn(['cloudInit', 'customScript'])
+        break
+
+      case 'operatingSystemId':
+        changes[field] = value
+        changes.timeZone = this.checkTimeZone(value, this.props.data.templateId)
         break
 
       case 'memory':
@@ -524,6 +567,9 @@ BasicSettings.propTypes = {
   maxMemorySizeInMiB: PropTypes.number.isRequired,
 
   onUpdate: PropTypes.func.isRequired,
+
+  defaultGeneralTimezone: PropTypes.string.isRequired,
+  defaultWindowsTimezone: PropTypes.string.isRequired,
 }
 
 export default connect(
@@ -536,5 +582,7 @@ export default connect(
     storageDomains: state.storageDomains,
     maxNumOfVmCpus: state.config.get('maxNumOfVmCpus', 384),
     maxMemorySizeInMiB: 4194304, // TODO: 4TiB, no config option pulled as of 2019-Mar-22
+    defaultGeneralTimezone: state.config.get('defaultGeneralTimezone'),
+    defaultWindowsTimezone: state.config.get('defaultWindowsTimezone'),
   })
 )(BasicSettings)

--- a/src/components/CreateVmWizard/steps/SummaryReview.js
+++ b/src/components/CreateVmWizard/steps/SummaryReview.js
@@ -54,6 +54,7 @@ const ReviewBasic = ({ id, dataCenters, clusters, isos, templates, operatingSyst
       </React.Fragment>
     }
 
+    <Item id={`${id}-timezone`} label={msg.timezone()}>{basic.timeZone.name}</Item>
     <Item id={`${id}-os`} label={msg.operatingSystem()}>{vmOS.get('description')}</Item>
     <Item id={`${id}-memory`} label={msg.memory()}>{userFormatOfBytes(basic.memory, 'MiB').str}</Item>
     <Item id={`${id}-cpus`} label={msg.cpus()}>

--- a/src/sagas/vmChanges.js
+++ b/src/sagas/vmChanges.js
@@ -63,6 +63,10 @@ function* composeAndCreateVm ({ payload: { basic, nics, disks }, meta: { correla
     name: basic.name,
     os: { type: osType },
     type: basic.optimizedFor,
+    time_zone: {
+      name: basic.timeZone.name,
+      utc_offset: basic.timeZone.offset,
+    },
 
     initialization: basic.cloudInitEnabled
       ? {


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/1198

In this PR I:
- make VM time zone format compatible with the selected VM OS by implementing the [fix](https://github.com/oVirt/ovirt-web-ui/pull/1118) previously done for editing an existing VM - this change is related to the "Basic Settings" (first) step of the Create VM Wizard. I've used the `checkTimeZone` function for the case when:
  - changing or selecting the VM OS
  - changing _Provision Source_ to _ISO_ (set the default time zone according to the OS, as we don't have any specific info about the selected iso image)
  - changing or selecting the Template, because we need to check template's timezone compatibility with the template's OS and then to set the timezone corresponding to the template's OS if needed
- make the current Time zone displayed in the "Review" report step of the Create VM Wizard (last step)

---

**Before:**
![tz_before](https://user-images.githubusercontent.com/13417815/82832322-051bc380-9ebb-11ea-83fe-8980d387144c.png)

**After:**
![tz_after](https://user-images.githubusercontent.com/13417815/82832328-0947e100-9ebb-11ea-8e80-d4585c97c366.png)
