### PR TITLE
Create VM, Storage - add support for arrow keys in edit disk size field

### DIFF
--- a/src/components/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/CreateVmWizard/CreateVmWizard.js
@@ -464,7 +464,11 @@ class CreateVmWizard extends React.Component {
           <Button bsStyle='default' onClick={this.showCloseWizardDialog}>
             { msg.createVmWizardButtonCancel() }
           </Button>
-          <Button bsStyle='default' onClick={this.wizardClickBack} disabled={activeStepIndex === 0 || isPrimaryClose}>
+          <Button
+            bsStyle='default'
+            onClick={this.wizardClickBack}
+            disabled={activeStepIndex === 0 || isPrimaryClose || stepNavigation[activeStep.id].preventExit}
+          >
             <Icon type='fa' name='angle-left' />
             { msg.createVmWizardButtonBack() }
           </Button>

--- a/src/components/CreateVmWizard/steps/style.css
+++ b/src/components/CreateVmWizard/steps/style.css
@@ -112,7 +112,6 @@
   align-items: center;
 }
 .disk-size-form-control-edit {
-  width: 0;
   flex-grow: 1;
 }
 
@@ -154,6 +153,10 @@ table tbody tr td.kebab-menu-cell {
 .review-content {
   margin: 0 auto;
   width: 80%;
+}
+
+.form-group-edit{
+  margin-bottom: 0;
 }
 
 .review-progress {


### PR DESCRIPTION
Hi there,
I was investigate the issue #1215  and I found why the value is not changed when using arrows, the described behavior refers only to FF (in chrome it worked before the changes and it will keep work after them).

In the disk size field we are using `onBlur` event to update the state and the arrows don't focus the field (in chrome it focus the field) so when the user change another field or confirm the changes and save the row the state is not updated because no event fired.

So why not using `onChange` event? Using `onChange` event instead `onBlur` is a good solution in case of using the arrows , but it cause another problem in case the user setting the field by typing, for any single character typed the page will re-render and the field will lose focus so the user need to refocus the field for any single character typed, and it's annoying.

So the solution I found is to update the state in `onChange` event only if the disk size field is not focused (using arrows), in case it's focused (using typing) the state will not update on `onChange` event but will update when the `onBlur` event handler will be triggered.

It a little bit complex solution but it works great and gives the requested behavior.

Fixes: #1215 