### PR TITLE
Update UPDATE_VMS reducer to handle `copySubResources` properly

### DIFF
--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -122,17 +122,20 @@ import {
   isNumber,
 } from '_/utils'
 
-const vmFetchAdditionalList =
-  [
-    'cdroms',
-    'sessions',
-    'disk_attachments.disk',
-    'graphics_consoles',
-    'nics',
-    'snapshots',
-    'statistics',
-    'permissions',
-  ]
+const VM_FETCH_ADDITIONAL_DEEP = [
+  'cdroms',
+  'disk_attachments.disk',
+  'graphics_consoles',
+  'nics',
+  'permissions',
+  'sessions',
+  'snapshots',
+  'statistics',
+]
+
+const VM_FETCH_ADDITIONAL_SHALLOW = [
+  'graphics_consoles',
+]
 
 export const EVERYONE_GROUP_ID = 'eee00000-0000-0000-0000-123456789eee'
 
@@ -271,7 +274,7 @@ export function* transformAndPermitVm (vm) {
 function* fetchVmsByPage (action) {
   const { shallowFetch, page } = action.payload
 
-  action.payload.additional = shallowFetch ? ['graphics_consoles'] : vmFetchAdditionalList
+  action.payload.additional = shallowFetch ? VM_FETCH_ADDITIONAL_SHALLOW : VM_FETCH_ADDITIONAL_DEEP
 
   const vmsOnPage = yield callExternalAction('getVmsByPage', Api.getVmsByPage, action)
   if (vmsOnPage && vmsOnPage['vm']) {
@@ -296,7 +299,7 @@ function* fetchVmsByCount (action) {
   const { shallowFetch } = action.payload
   const fetchedVmIds = []
 
-  action.payload.additional = shallowFetch ? [ 'graphics_consoles' ] : vmFetchAdditionalList
+  action.payload.additional = shallowFetch ? VM_FETCH_ADDITIONAL_SHALLOW : VM_FETCH_ADDITIONAL_DEEP
 
   const allVms = yield callExternalAction('getVmsByCount', Api.getVmsByCount, action)
   if (allVms && allVms['vm']) {
@@ -328,7 +331,7 @@ function* putPermissionsInDisk (disk) {
 export function* fetchSingleVm (action) {
   const { vmId, shallowFetch } = action.payload
 
-  action.payload.additional = shallowFetch ? [ 'graphics_consoles' ] : vmFetchAdditionalList
+  action.payload.additional = shallowFetch ? VM_FETCH_ADDITIONAL_SHALLOW : VM_FETCH_ADDITIONAL_DEEP
 
   const vm = yield callExternalAction('getVm', Api.getVm, action, true)
   let internalVm = null


### PR DESCRIPTION
Fixes: #1224 

Simplify UPDATE_VMS reducer handling of 'copySubResources':
  - The incoming vms are plain JS objects.  It is easier to handle copying of existing sub-resources from the current copy of the VM in redux to the incoming VM updates when they're both JS objects.

Minor refactor of VM fetch additional/follow items:
  - This makes the list of additional items to be followed when a VMis fetched slightly more explicit.
