### PR TITLE
Create VM, Storage - force user to choose a storage domain for template disks if necessary

### DIFF
--- a/src/components/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/CreateVmWizard/CreateVmWizard.js
@@ -8,7 +8,7 @@ import { List } from 'immutable'
 import * as Actions from '_/actions'
 import { generateUnique } from '_/helpers'
 import { msg } from '_/intl'
-import { createTemplateList } from '_/components/utils'
+import { createStorageDomainList, createTemplateList } from '_/components/utils'
 
 import NavigationConfirmationModal from '../NavigationConfirmationModal'
 import BasicSettings from './steps/BasicSettings'
@@ -345,6 +345,7 @@ class CreateVmWizard extends React.Component {
         }
 
         if (resetDisks) {
+          const filteredStorageDomainList = createStorageDomainList(this.props.storageDomains, this.state.steps.basic.dataCenterId)
           draft.steps.storage = {
             updated: (draft.steps.storage.updated + 1),
             disks: !template
@@ -357,6 +358,7 @@ class CreateVmWizard extends React.Component {
                   diskId: disk.get('id'),
                   storageDomainId: disk.get('storageDomainId'),
                   canUserUseStorageDomain: this.props.storageDomains.getIn([ disk.get('storageDomainId'), 'canUserUseDomain' ], false),
+                  createdFromInvalidTemplate: !filteredStorageDomainList.find(sd => sd.id === disk.get('storageDomainId')),
 
                   bootable: disk.get('bootable'),
                   iface: disk.get('iface'),

--- a/src/components/CreateVmWizard/steps/Storage.js
+++ b/src/components/CreateVmWizard/steps/Storage.js
@@ -105,6 +105,12 @@ class Storage extends React.Component {
     this.isBootableDiskTemplate = this.isBootableDiskTemplate.bind(this)
     this.isEditingMode = this.isEditingMode.bind(this)
 
+    const invalidDisk = props.disks.find(disk => (disk.isFromTemplate && !disk.canUserUseStorageDomain))
+
+    if (invalidDisk) {
+      props.onUpdate({ valid: false })
+    }
+
     this.state = {
       editing: {},
       creating: false,
@@ -286,11 +292,26 @@ class Storage extends React.Component {
           const {
             storageDomainId: id,
             storageDomain: sd,
+            createdFromInvalidTemplate,
+            isFromTemplate,
           } = rowData
 
-          // TODO: if the disk's storage domain is not available to the user, highlight it
-          // TODO: like a validation error and force editing the SD before allowing the user to move
-          // TODO: forward to the next wizard step
+          if ((isFromTemplate && !sd.isOk) || createdFromInvalidTemplate) {
+            const { storageDomains, dataCenterId } = props
+            const storageDomainList = createStorageDomainList(storageDomains, dataCenterId, true)
+            if (!sd.isOk) {
+              storageDomainList.unshift({ id: '_', value: `-- ${msg.createVmStorageSelectStorageDomain()} --` })
+            }
+            return <SelectBox
+              id={`${idPrefix}-${rowData.id}-storage-domain-edit`}
+              items={storageDomainList}
+              selected={sd.isOk ? rowData.storageDomainId : '_'}
+              validationState={!sd.isOk && 'error'}
+              onChange={value => {
+                this.props.onUpdate({ valid: true, update: { ...rowData, storageDomainId: value } })
+              }}
+            />
+          }
           return <React.Fragment>
             { id === '_'
               ? `-- ${msg.createVmStorageSelectStorageDomain()} --`
@@ -305,7 +326,7 @@ class Storage extends React.Component {
           const storageDomainList = createStorageDomainList(storageDomains, dataCenterId, true)
           const row = this.state.editing[rowData.id]
 
-          if (storageDomainList.length > 1 || row.storageDomain === '_') {
+          if (storageDomainList.length > 1 || row.storageDomainId === '_') {
             storageDomainList.unshift({ id: '_', value: `-- ${msg.createVmStorageSelectStorageDomain()} --` })
           }
 
@@ -315,6 +336,7 @@ class Storage extends React.Component {
               items={storageDomainList}
               selected={row.storageDomainId}
               onChange={value => this.handleCellChange(rowData, 'storageDomainId', value)}
+              validationState={row.storageDomainId === '_' && 'error'}
             />
           )
         },
@@ -529,7 +551,7 @@ class Storage extends React.Component {
     const actionCreate = !!this.state.creating && this.state.creating === rowData.id
     const editedRow = this.state.editing[rowData.id]
 
-    if (editedRow.invalidSizeValue) return
+    if (editedRow.invalidSizeValue || editedRow.storageDomainId === '_') return
 
     // if the edited disk is set bootable, make sure to remove bootable from the other disks
     if (editedRow.bootable) {

--- a/src/components/SelectBox.js
+++ b/src/components/SelectBox.js
@@ -27,6 +27,7 @@ class SelectBox extends React.Component {
       items: getItems(props),
     }
     this.handleChange = this.handleChange.bind(this)
+    this.getValidationClass = this.getValidationClass.bind(this)
   }
 
   componentWillReceiveProps (nextProps) {
@@ -44,15 +45,26 @@ class SelectBox extends React.Component {
     }
   }
 
+  getValidationClass () {
+    const { validationState } = this.props
+    switch (validationState) {
+      case 'error':
+        return style['selectBox-has-error']
+      default:
+        return ''
+    }
+  }
+
   render () {
     const { id } = this.props
 
     const selectedItem = this.state.items.find(item => item.id === this.state.selected)
+    const validationClass = this.getValidationClass()
 
     return (
       <div style={{ width: '100%' }} id={id}>
         <div className='dropdown'>
-          <button className={`btn btn-default dropdown-toggle ${style['dropdown-button']}`} type='button' data-toggle='dropdown' id={`${id}-button-toggle`}>
+          <button className={`btn btn-default dropdown-toggle ${style['dropdown-button']} ${validationClass}`} type='button' data-toggle='dropdown' id={`${id}-button-toggle`}>
             <span className={style['dropdown-button-text']} id={`${id}-button-text`} title={selectedItem && selectedItem.value}>
               {selectedItem ? selectedItem.value : NOBREAK_SPACE}
             </span>
@@ -83,6 +95,7 @@ SelectBox.propTypes = {
   /* eslint-enable react/no-unused-prop-types */
   onChange: PropTypes.func.isRequired, // (selectedId: string) => any
   id: PropTypes.string,
+  validationState: PropTypes.oneOf([ false, 'default', 'error' ]),
 }
 
 export default SelectBox

--- a/src/components/sharedStyle.css
+++ b/src/components/sharedStyle.css
@@ -84,3 +84,12 @@
 .text-align-left {
   text-align: left;
 }
+/*
+ * SelectBox validationState classes
+ * compatible with PF3 FormControl component
+ */
+
+.selectBox-has-error,.selectBox-has-error:hover,.selectBox-has-error:focus {
+    /*pf-red-100*/
+    border-color: #cc0000;
+}


### PR DESCRIPTION
Fixes: #1230 

Hi I added validation to storage domain for template defined disks.
in case the template's disk should be located in storage domain which not allowed by the current user permissions the disks table in the Create Vm Wizard will be displayed with 'UNKNOWN' storage domain:
![image](https://user-images.githubusercontent.com/64131213/84657556-72cb7600-aee2-11ea-8f4e-d83dd96f19cf.png)


The user can create this vm with no validation or Error handling.
My new feature will prevent them from create the vm and force them to choose new storage domain according to their permissions, it will disable the next button as long as the user didn't change the storage domain:
Dropdown:
![image](https://user-images.githubusercontent.com/64131213/84658479-f6d22d80-aee3-11ea-9f13-f57358cdeb58.png)
Dropdown options:
![image](https://user-images.githubusercontent.com/64131213/84658697-4284d700-aee4-11ea-9dda-f7aaca5ff8e2.png)
After choosing:
![image](https://user-images.githubusercontent.com/64131213/84658732-54667a00-aee4-11ea-8228-c282708c2d7c.png)
What do you think?