### PR TITLE
Add initial favicon to index.hbs, branding and config updates as needed

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -216,6 +216,7 @@ module.exports = {
       filename: 'index.html',
       inject: true,
       template: `!!handlebars!${paths.appHtml}`,
+      publicPath: '/',
       jspSSO: false,
     }),
 

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -213,6 +213,7 @@ module.exports = {
       filename: 'index.jsp',
       inject: true,
       template: `!!handlebars!${paths.appHtml}`,
+      publicPath,
       jspSSO: true,
       minify: {
         removeComments: true,

--- a/src/index.js
+++ b/src/index.js
@@ -81,16 +81,22 @@ function fetchToken (): { token: string, username: string, domain: string, userI
 }
 
 function addBrandedResources () {
-  addLinkElement('shortcut icon', branding.resourcesUrls.favicon)
-  addLinkElement('stylesheet', branding.resourcesUrls.brandStylesheet)
-  addLinkElement('stylesheet', branding.resourcesUrls.baseStylesheet)
+  addLinkElement('branding-favicon', 'shortcut icon', branding.resourcesUrls.favicon)
+  addLinkElement('branding-brand-style', 'stylesheet', branding.resourcesUrls.brandStylesheet)
+  addLinkElement('branding-base-style', 'stylesheet', branding.resourcesUrls.baseStylesheet)
 }
 
-function addLinkElement (rel: string, href: string) {
-  const linkElement = window.document.createElement('link')
-  linkElement.rel = rel
-  linkElement.href = href
-  window.document.head.appendChild(linkElement)
+function addLinkElement (id: string, rel: string, href: string) {
+  const link = window.document.querySelector(`head link#${id}[rel='${rel}']`)
+  if (link) {
+    link.href = href
+  } else {
+    const newLink = window.document.createElement('link')
+    newLink.id = id
+    newLink.rel = rel
+    newLink.href = href
+    window.document.head.appendChild(newLink)
+  }
 }
 
 function SagaErrorBridge (storeRootTask: Task) {

--- a/static/index.hbs
+++ b/static/index.hbs
@@ -13,6 +13,8 @@
     <meta http-equiv="Access-Control-Allow-Origin" content="*">
     <title>VM Portal</title>
 
+    <link id="branding-favicon" rel="shortcut icon" href="{{htmlWebpackPlugin.options.publicPath}}branding/images/favicon.ico" />
+
   {{#if htmlWebpackPlugin.options.jspSSO}}
     <!-- In prod mode, JSP code will inject SSO tokens on the server side. -->
     <script type="text/javascript">


### PR DESCRIPTION
  - Branding on web-ui is simpler than on webadmin.  All of the branding
    files need to follow the same path names.  This lets us pre-populate
    the favicon with an expected path.

  - branding code (in `src/index.js) has been updated so it only creates
    new link elements if they don't already exist.  This will prevent
    a second load of favicon.ico if the expected path is the real path.

  - Webpack configs for HtmlWebpackPlugin no contain the "public path"
    of the app.  The template prefixes this path on the favicon path
    so it works on both the dev server and in a production deploy.

 Fixes: https://github.com/oVirt/ovirt-web-ui/issues/1206