### PR TITLE
Enable Shutdown button for a suspended VM

### DIFF
--- a/src/vm-status.js
+++ b/src/vm-status.js
@@ -3,7 +3,7 @@ export function canStart (state) {
 }
 
 export function canShutdown (state) {
-  return ['up', 'migrating', 'reboot_in_progress', 'paused', 'powering_up', 'powering_down', 'not_responding'].includes(state)
+  return ['up', 'migrating', 'reboot_in_progress', 'paused', 'powering_up', 'powering_down', 'not_responding', 'suspended'].includes(state)
 }
 
 export function canRestart (state) {


### PR DESCRIPTION
**Fixes:** https://github.com/oVirt/ovirt-web-ui/issues/1227

If a VM is suspended (run VM -> suspend it -> wait until the status is suspended), the only action available for the VM was to run it unlike in Admin Portal where you can also shut it down. In this PR, I am fixing this by adding missing `'suspended'` in the array of VM statuses for _Shutdown_ button being enabled in VM details page. With this change, we achieve the shutdown action being available for a suspended VM again.

**Related comment** (and PR): https://github.com/oVirt/ovirt-web-ui/pull/581#issuecomment-384895425
_"The shutdown and force stop should be available in all this VM states: up, powering up, powering down, reboot in progress, migrating, **suspended**, paused, not responding."_

---

**Before:**
![suspend_before](https://user-images.githubusercontent.com/13417815/84879318-5880cc00-b08b-11ea-9653-35e1511edd6d.png)

**After:**
![suspend_after](https://user-images.githubusercontent.com/13417815/84879328-5c145300-b08b-11ea-8efe-72c9d593394b.png)
