### PR TITLE
Allow opening console.vv in virt-viewer when clicking on VM console in Firefox

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -49,7 +49,12 @@ export function fileDownload ({ data, fileName = 'myFile.dat', mimeType = 'appli
       return navigator.msSaveBlob(new Blob([data], { type: mimeType }), fileName)
     } else if ('download' in a) { // html5 A[download]
       a.href = `data:${mimeType},${encodeURIComponent(data)}`
-      a.setAttribute('download', fileName)
+
+      // set the 'download' attribute for <a> element; we don't want to set it for FF
+      if (navigator.userAgent.indexOf('Firefox') === -1) {
+        a.setAttribute('download', fileName)
+      }
+
       document.body.appendChild(a)
       a.click()
       document.body.removeChild(a)


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1638217

Do not prompt for how to open the _console.vv_ file if the user selects _Remote_ or _virt-viewer_ as a default application in Firefox.

Browsers act differently when setting the `download` attribute of the HTML `<a>` element. For FF, we don't want to set this attribute, but in Chrome/Chromium we do want - to achieve the expected behavior.
Some more info about the `download` attribute: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a

**Before:**
![open_before](https://user-images.githubusercontent.com/13417815/86380505-7144d080-bc8c-11ea-8aa4-0bf996ab1112.png)


**After:**
![open_after](https://user-images.githubusercontent.com/13417815/86380513-74d85780-bc8c-11ea-97e5-ab44ab16dd28.png)

---

**Note:**
Don't forget to set the Remote or virt-viewer as a default app in Firefox general preferences, to allow opening _console.vv_ file automatically:
![always-ask](https://user-images.githubusercontent.com/13417815/86380720-b8cb5c80-bc8c-11ea-8583-8ee9023ea502.png)
