### PR TITLE
Add Timezone dropdown in the sysprep options of Create VM Wizard

### DIFF
--- a/src/components/CreateVmWizard/steps/BasicSettings.js
+++ b/src/components/CreateVmWizard/steps/BasicSettings.js
@@ -518,13 +518,12 @@ class BasicSettings extends React.Component {
               />
             </FieldRow>
 
-            {/* TODO: Swap out for a proper timezone drop down once PR #1004 is merged */}
             <FieldRow label={msg.sysPrepTimezone()} id={`${idPrefix}-sysPrepTimezone`} vertical>
-              <FormControl
-                id={`${idPrefix}-sysPrepTimezone-edit`}
-                type='text'
-                defaultValue={data.initTimezone}
-                onChange={e => this.handleChange('initTimezone', e.target.value)}
+              <SelectBox
+                id={`${idPrefix}-sysprep-timezone-select`}
+                items={timezones}
+                selected={data.initTimezone}
+                onChange={selectedId => this.handleChange('initTimezone', selectedId)}
               />
             </FieldRow>
 


### PR DESCRIPTION
**Related comment:** https://github.com/oVirt/ovirt-web-ui/pull/1220#issuecomment-656896190

In this PR, I'm adding the drop down to handle the Timezone in the sysprep options, in the Basic settings of the Create VM Wizard. Also I am removing the old TZ field.

After creating a VM with sysprep enabled and some chosen TZ, the chosen TZ is already displayed as expected, when viewing the VM. Looks like nothing else needs to be done. However, I'm not sure about the expected behavior in some special cases, for example if the user chooses some TZ in the drop down and then they decide to leave the drop down empty. For now, this can be solved for example by choosing a different template and then choosing the expected one and enabling the sysprep options again. But this resets all the values of sysprep options. Not sure if this is an expected behavior. 

**Before:**
Timezone field, we were able to write there anything:
![tz_before1](https://user-images.githubusercontent.com/13417815/87669720-c4c81b80-c76e-11ea-8f94-15b6ca72b700.png)
Review step of the Create VM Wizard:
![tz_before2](https://user-images.githubusercontent.com/13417815/87669739-c8f43900-c76e-11ea-8b43-61b836a5eb41.png)

**After:**
New Timezone dropdown, empty drop down is allowed:
![tz_after1](https://user-images.githubusercontent.com/13417815/87669762-d27da100-c76e-11ea-861f-3dae759b98f3.png)
![tz_after2](https://user-images.githubusercontent.com/13417815/87669774-d5789180-c76e-11ea-87c4-56a47a4d232f.png)
Review step of the Create VM Wizard:
![tz_after3](https://user-images.githubusercontent.com/13417815/87669784-d90c1880-c76e-11ea-8611-6b5699508ac4.png)
After creating the VM, we can see the same Timezone already set, when viewing the VM's options:
![tz_after4](https://user-images.githubusercontent.com/13417815/87669795-de696300-c76e-11ea-9807-a8fdc7b47ec4.png)
