### PR TITLE
Create VM - Allow valid only calls to onUpdate functions in CreateVmWizard

### DIFF
--- a/ovirt-web-ui.spec.in
+++ b/ovirt-web-ui.spec.in
@@ -17,7 +17,7 @@ Source0:        https://github.com/oVirt/ovirt-web-ui/archive/%{source_basename}
 BuildArch: noarch
 
 # nodejs-modules embeds yarn and requires nodejs
-BuildRequires: ovirt-engine-nodejs-modules >= 2.0.21-1
+BuildRequires: ovirt-engine-nodejs-modules >= 2.0.32-1
 
 %description
 This package provides the VM Portal for %{product}.

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "classnames": "2.2.6",
     "connected-react-router": "4.3.0",
     "history": "4.7.2",
+    "immer": "7.0.7",
     "immutable": "3.8.2",
     "intl-messageformat": "2.2.0",
     "jquery": "3.4.1",

--- a/src/components/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/CreateVmWizard/CreateVmWizard.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux'
 import { Wizard, Button, Icon } from 'patternfly-react'
 import NavigationConfirmationModal from '../NavigationConfirmationModal'
 import merge from 'lodash/merge'
+import isEmpty from 'lodash/isEmpty'
 import { List } from 'immutable'
 
 import * as Actions from '_/actions'
@@ -177,7 +178,12 @@ class CreateVmWizard extends React.Component {
 
             onUpdate={({ valid = true, ...updatePayload }) => {
               this.handleListOnUpdate('network', 'nics', updatePayload)
+
+              const isPreventExitChanged = this.wizardStepsMap.network.preventExit === valid
               this.wizardStepsMap.network.preventExit = !valid
+              if (isEmpty(updatePayload) && isPreventExitChanged) {
+                this.forceUpdate()
+              }
             }}
           />
         ),
@@ -199,7 +205,12 @@ class CreateVmWizard extends React.Component {
 
             onUpdate={({ valid = true, ...updatePayload }) => {
               this.handleListOnUpdate('storage', 'disks', updatePayload)
+
+              const isPreventExitChanged = this.wizardStepsMap.storage.preventExit === valid
               this.wizardStepsMap.storage.preventExit = !valid
+              if (isEmpty(updatePayload) && isPreventExitChanged) {
+                this.forceUpdate()
+              }
             }}
           />
         ),
@@ -385,6 +396,10 @@ class CreateVmWizard extends React.Component {
   }
 
   handleListOnUpdate (stepName, listName, { remove, update, create }, setStateCallback) {
+    if (!remove && !update && !create) {
+      return
+    }
+
     this.setState(state => {
       let list = this.state.steps[stepName][listName].slice(0)
 

--- a/src/components/CreateVmWizard/steps/Networking.js
+++ b/src/components/CreateVmWizard/steps/Networking.js
@@ -384,11 +384,6 @@ class Networking extends React.Component {
     const enableCreate = vnicList.length > 0 && Object.keys(this.state.editing).length === 0
 
     const nicList = nics
-      .sort((a, b) =>
-        a.isFromTemplate && !b.isFromTemplate ? -1
-          : !a.isFromTemplate && b.isFromTemplate ? 1
-            : localeCompare(a.name, b.name)
-      )
       .concat(this.state.creating ? [ this.state.editing[this.state.creating] ] : [])
       .map(nic => ({
         ...nic,
@@ -397,6 +392,11 @@ class Networking extends React.Component {
           : msg.createVmNetUnknownVnicProfile(),
         device: enumMsg('NicInterface', nic.deviceType),
       }))
+      .sort((a, b) =>
+        a.isFromTemplate && !b.isFromTemplate ? -1
+          : !a.isFromTemplate && b.isFromTemplate ? 1
+            : localeCompare(a.name, b.name)
+      )
 
     return <div className={style['settings-container']} id={idPrefix}>
       { nicList.length === 0 && <React.Fragment>

--- a/src/components/CreateVmWizard/steps/Storage.js
+++ b/src/components/CreateVmWizard/steps/Storage.js
@@ -554,11 +554,6 @@ class Storage extends React.Component {
     const enableCreate = storageDomainList.length > 0 && !this.isEditingMode()
 
     const diskList = disks
-      .sort((a, b) => // template based then by name
-        a.isFromTemplate && !b.isFromTemplate ? -1
-          : !a.isFromTemplate && b.isFromTemplate ? 1
-            : localeCompare(a.name, b.name)
-      )
       .concat(this.state.creating ? [ this.state.editing[this.state.creating] ] : [])
       .map(disk => {
         const sd = storageDomainList.find(sd => sd.id === disk.storageDomainId)
@@ -579,6 +574,11 @@ class Storage extends React.Component {
           iface: enumMsg('DiskInterface', disk.iface),
         }
       })
+      .sort((a, b) => // template based then by name
+        a.isFromTemplate && !b.isFromTemplate ? -1
+          : !a.isFromTemplate && b.isFromTemplate ? 1
+            : localeCompare(a.name, b.name)
+      )
 
     return <div className={style['settings-container']} id={idPrefix}>
       { diskList.length === 0 && <React.Fragment>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6305,6 +6305,11 @@ immediate@~3.0.5:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
   integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
+immer@7.0.7:
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.7.tgz#9dfe713d49bf871cc59aedfce59b1992fa37a977"
+  integrity sha512-Q8yYwVADJXrNfp1ZUAh4XDHkcoE3wpdpb4mC5abDSajs2EbW8+cGdPyAnglMyLnm7EF6ojD2xBFX7L5i4TIytw==
+
 immutable@3.8.2, immutable@^3.8.1:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"


### PR DESCRIPTION
In order to better support input validation in the wizard steps, the `onUpdate` functions have been updated to allow calls that only
update the step's valid state.  Now, a step can flag itself as invalid thereby preventing navigation off the step until the input is fixed or canceled.

This change will enable consistent validation updates on #1219, #1221, #1233 