### PR TITLE
Create VM Wizard - add ability to tab through edit fields in Storage and Networking steps 

### DIFF
--- a/src/components/CreateVmWizard/steps/Networking.js
+++ b/src/components/CreateVmWizard/steps/Networking.js
@@ -384,20 +384,20 @@ class Networking extends React.Component {
     const vnicList = createVNicProfileList(vnicProfiles, { dataCenterId, cluster })
     const enableCreate = vnicList.length > 0 && Object.keys(this.state.editing).length === 0
 
-    const nicList = nics
+    const nicList = [...nics]
+      .sort((a, b) => // template based then by name.
+        a.isFromTemplate && !b.isFromTemplate ? -1
+          : !a.isFromTemplate && b.isFromTemplate ? 1
+            : localeCompare(a.name, b.name)
+      )
       .concat(this.state.creating ? [ this.state.editing[this.state.creating] ] : [])
       .map(nic => ({
-        ...nic,
+        ...(this.state.editing[nic.id] ? this.state.editing[nic.id] : nic),
         vnic: vnicList.find(vnic => vnic.id === nic.vnicProfileId)
           ? vnicList.find(vnic => vnic.id === nic.vnicProfileId).value
           : msg.createVmNetUnknownVnicProfile(),
         device: enumMsg('NicInterface', nic.deviceType),
       }))
-      .sort((a, b) =>
-        a.isFromTemplate && !b.isFromTemplate ? -1
-          : !a.isFromTemplate && b.isFromTemplate ? 1
-            : localeCompare(a.name, b.name)
-      )
     const components = {
       body: {
         row: _TableInlineEditRow,

--- a/src/components/CreateVmWizard/steps/Networking.js
+++ b/src/components/CreateVmWizard/steps/Networking.js
@@ -345,6 +345,7 @@ class Networking extends React.Component {
 
   // Cancel the creation or editing of a row by throwing out edit state
   handleRowCancelChange (rowData) {
+    this.components = undefined // remove the current reference to make the table re-render
     this.setState(state => {
       const editing = state.editing
       delete editing[rowData.id]
@@ -397,6 +398,12 @@ class Networking extends React.Component {
           : !a.isFromTemplate && b.isFromTemplate ? 1
             : localeCompare(a.name, b.name)
       )
+    const components = {
+      body: {
+        row: _TableInlineEditRow,
+      },
+    }
+    this.components = this.components || components // if the table should (re)render the value of this.components should be undefined
 
     return <div className={style['settings-container']} id={idPrefix}>
       { nicList.length === 0 && <React.Fragment>
@@ -426,11 +433,7 @@ class Networking extends React.Component {
             dataTable
             inlineEdit
             columns={this.columns}
-            components={{
-              body: {
-                row: _TableInlineEditRow,
-              },
-            }}
+            components={this.components}
           >
             <Table.Header />
             <Table.Body

--- a/src/components/CreateVmWizard/steps/Storage.js
+++ b/src/components/CreateVmWizard/steps/Storage.js
@@ -559,9 +559,15 @@ class Storage extends React.Component {
     const filteredStorageDomainList = createStorageDomainList(storageDomains, dataCenterId)
     const enableCreate = storageDomainList.length > 0 && !this.isEditingMode()
 
-    const diskList = disks
+    const diskList = [...disks]
+      .sort((a, b) => // template based then by name.
+        a.isFromTemplate && !b.isFromTemplate ? -1
+          : !a.isFromTemplate && b.isFromTemplate ? 1
+            : localeCompare(a.name, b.name)
+      )
       .concat(this.state.creating ? [ this.state.editing[this.state.creating] ] : [])
       .map(disk => {
+        disk = this.state.editing[disk.id] ? this.state.editing[disk.id] : disk // update editing changes from state after sorting
         const sd = storageDomainList.find(sd => sd.id === disk.storageDomainId)
         const isSdOk = sd && filteredStorageDomainList.find(filtered => filtered.id === sd.id) !== undefined
 
@@ -580,11 +586,6 @@ class Storage extends React.Component {
           iface: enumMsg('DiskInterface', disk.iface),
         }
       })
-      .sort((a, b) => // template based then by name
-        a.isFromTemplate && !b.isFromTemplate ? -1
-          : !a.isFromTemplate && b.isFromTemplate ? 1
-            : localeCompare(a.name, b.name)
-      )
     const components = {
       body: {
         row: _TableInlineEditRow, // Table.InlineEditRow,

--- a/src/components/CreateVmWizard/steps/Storage.js
+++ b/src/components/CreateVmWizard/steps/Storage.js
@@ -520,6 +520,7 @@ class Storage extends React.Component {
 
   // Cancel the creation or editing of a row by throwing out edit state
   handleRowCancelChange (rowData) {
+    this.components = undefined
     this.setState(state => {
       const editing = state.editing
       delete editing[rowData.id]
@@ -584,6 +585,12 @@ class Storage extends React.Component {
           : !a.isFromTemplate && b.isFromTemplate ? 1
             : localeCompare(a.name, b.name)
       )
+    const components = {
+      body: {
+        row: _TableInlineEditRow, // Table.InlineEditRow,
+      },
+    }
+    this.components = this.components || components // if the table should (re)render the value of this.components should be undefined
 
     return <div className={style['settings-container']} id={idPrefix}>
       { diskList.length === 0 && <React.Fragment>
@@ -613,11 +620,7 @@ class Storage extends React.Component {
             dataTable
             inlineEdit
             columns={this.columns}
-            components={{
-              body: {
-                row: _TableInlineEditRow, // Table.InlineEditRow,
-              },
-            }}
+            components={this.components}
           >
             <Table.Header />
             <Table.Body


### PR DESCRIPTION
This PR added support in navigation between edit fields using keyboard:
1.Tab - move to the next field.
2. Shift+Tab - move to the previous field.

I used React refs to control the fields' focus.

![tabThroughExample-2020-07-28_12 01 37](https://user-images.githubusercontent.com/64131213/88654930-b2d36a80-d0d6-11ea-86d1-9ce804adf7ec.gif)


Fixes: #1248 