### PR TITLE
Display proper VM CPU Load considering the number of vCPUs

### DIFF
--- a/src/components/VmDetails/cards/UtilizationCard/CpuCharts.js
+++ b/src/components/VmDetails/cards/UtilizationCard/CpuCharts.js
@@ -25,8 +25,8 @@ import NoLiveData from './NoLiveData'
  * as a sparkline. Sparkline vales to go from oldest far left to most current on far
  * right.
  */
-const CpuCharts = ({ cpuStats, isRunning, id }) => {
-  const cpuUsed = cpuStats['current.guest'].datum
+const CpuCharts = ({ cpuStats, isRunning, id, vcpus }) => {
+  const cpuUsed = cpuStats['current.total'].datum / vcpus // the average value considering the number of VM CPUs, same as in Admin Portal
   const cpuAvailable = 100 - cpuUsed
 
   // NOTE: CPU history comes sorted from newest to oldest
@@ -83,6 +83,7 @@ CpuCharts.propTypes = {
   id: PropTypes.string.isRequired,
   cpuStats: PropTypes.object.isRequired,
   isRunning: PropTypes.bool,
+  vcpus: PropTypes.number.isRequired,
 }
 
 export default CpuCharts

--- a/src/components/VmDetails/cards/UtilizationCard/index.js
+++ b/src/components/VmDetails/cards/UtilizationCard/index.js
@@ -19,6 +19,8 @@ const UtilizationCard = ({ vm }) => {
   const stats = vm.has('statistics') ? vm.get('statistics').toJS() : undefined
   const isRunning = [ 'up' ].includes(vm.get('status'))
 
+  const vCpus = vm.getIn(['cpu', 'vCPUs'])
+
   const idPrefix = 'vmdetail-utilization'
 
   return (
@@ -33,7 +35,7 @@ const UtilizationCard = ({ vm }) => {
           <Col className={style['row-col-charts-box']}>
             <Col className={style['col-charts-box']}>
               { stats.cpu
-                ? <CpuCharts cpuStats={stats.cpu} isRunning={isRunning} id={`${idPrefix}-cpu`} />
+                ? <CpuCharts cpuStats={stats.cpu} isRunning={isRunning} id={`${idPrefix}-cpu`} vcpus={vCpus} />
                 : <NoLiveData message={msg.loadingTripleDot()} id={`${idPrefix}-cpu-no-data`} />
               }
             </Col>


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/1256

In the actual VM Portal UI, we were displaying `cpu.current.guest` which represents how much cpu time VM's process uses regarding all of the CPUs. This value can be more than 100% so the numbers displayed in the UI were OK. The problem is that the users don't want to see this value. They want to see VM CPU Load, the average value considering the number of VM CPUs, the same as it is in Admin Portal.

To achieve this, I had to make a small calculation and to use the number of sockets and cores of a VM.

**More info** (you have to be logged in to see all the necessary details): https://access.redhat.com/solutions/337013

---

**In the Admin Portal (proper values):**
![admin_portal](https://user-images.githubusercontent.com/13417815/88945590-764a6f00-d28e-11ea-9b7b-befd39b82d2c.png)

**VM Portal, before:**
![before](https://user-images.githubusercontent.com/13417815/88945606-79455f80-d28e-11ea-8cb0-bf89889d0ba3.png)

**VM Portal, after:**
![after](https://user-images.githubusercontent.com/13417815/88945611-7c405000-d28e-11ea-8738-7212dabc9cb1.png)
