### PR TITLE
CreateVMWizard - adjusting row's spacers to create consistency between edit and create modes

### DIFF
--- a/src/components/CreateVmWizard/steps/Networking.js
+++ b/src/components/CreateVmWizard/steps/Networking.js
@@ -245,7 +245,7 @@ class Networking extends React.Component {
                 }
 
                 { !hideKebab && !templateDefined &&
-                  <Table.Cell>
+                  <Table.Cell className={style['kebab-menu-cell']}>
                     <DropdownKebab
                       id={kebabId}
                       className={style['action-kebab']}

--- a/src/components/CreateVmWizard/steps/Storage.js
+++ b/src/components/CreateVmWizard/steps/Storage.js
@@ -330,7 +330,7 @@ class Storage extends React.Component {
                 }
 
                 { !hideKebab && !templateDefined &&
-                  <Table.Cell>
+                  <Table.Cell className={style['kebab-menu-cell']}>
                     <DropdownKebab
                       id={kebabId}
                       className={style['action-kebab']}

--- a/src/components/CreateVmWizard/steps/style.css
+++ b/src/components/CreateVmWizard/steps/style.css
@@ -128,6 +128,10 @@
   font-size: 75%;
 }
 
+table tbody tr td.kebab-menu-cell {
+  padding: 2px 10px 1px;
+}
+
 /*
  * Summary Review
  */


### PR DESCRIPTION
I seted the row height to be consistent between add mode to create mode,
I added an explicitly padding value to adjust row's height.
Screenshots 
before:
![image](https://user-images.githubusercontent.com/64131213/89413166-083ff500-d731-11ea-89e6-2e06be7104d6.png)

after:
![image](https://user-images.githubusercontent.com/64131213/89413549-ad5acd80-d731-11ea-9cf3-c0d4b1567883.png)


Fixes: #1250 
 