### PR TITLE
Create VM - BasicSettings, select automatically single option menu

### DIFF
--- a/src/components/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/CreateVmWizard/CreateVmWizard.js
@@ -28,6 +28,11 @@ const DEFAULT_STATE = {
       startOnCreation: false,
       initEnabled: false,
       optimizedFor: 'desktop',
+      topology: {
+        sockets: 1,
+        cores: 1,
+        threads: 1,
+      },
     },
     network: {
       nics: [],

--- a/src/components/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/CreateVmWizard/CreateVmWizard.js
@@ -8,7 +8,7 @@ import { List } from 'immutable'
 import * as Actions from '_/actions'
 import { generateUnique } from '_/helpers'
 import { msg } from '_/intl'
-import { createTemplateList } from '_/components/utils'
+import { handleClusterIdChange } from './helpers'
 
 import NavigationConfirmationModal from '../NavigationConfirmationModal'
 import BasicSettings from './steps/BasicSettings'
@@ -68,22 +68,19 @@ const DEFAULT_STATE = {
  * Given the set of clusters and VM templates available to the user, build the initial
  * new VM state for the create wizard.
  */
-function getInitialState (clusters, templates, blankTemplateId, operatingSystems) {
+function getInitialState ({ clusters, templates, blankTemplateId, operatingSystems, storageDomains, defaultGeneralTimezone, defaultWindowsTimezone }) {
   // 1 cluster available? select it by default
-  let clusterId
+  let changes = {}
   if (clusters.size === 1) {
-    clusterId = clusters.first().get('id')
+    changes.clusterId = clusters.first().get('id')
   }
 
   // 1 template available (Blank only) on the default cluster? set the source to 'iso'
-  let provisionSource = 'template'
-  let templateId
-  if (clusterId) {
-    const templateList = createTemplateList(templates, clusterId)
-    if (templateList.length === 1 && templateList[0].id === blankTemplateId) {
-      provisionSource = 'iso'
-    } else {
-      templateId = blankTemplateId
+  changes.provisionSource = 'template'
+  if (changes.clusterId) {
+    changes = {
+      ...changes,
+      ...handleClusterIdChange(changes.clusterId, { blankTemplateId, defaultValues: DEFAULT_STATE.steps.basic, clusters, templates, operatingSystems, storageDomains, defaultGeneralTimezone, defaultWindowsTimezone }),
     }
   }
   const blankTemplate = templates.get(blankTemplateId)
@@ -116,9 +113,7 @@ function getInitialState (clusters, templates, blankTemplateId, operatingSystems
     draft.steps.basic = {
       ...draft.steps.basic,
       ...blankTemplateValues,
-      clusterId,
-      provisionSource,
-      templateId,
+      ...changes,
     }
   })
 
@@ -153,7 +148,7 @@ class CreateVmWizard extends React.Component {
   constructor (props) {
     super(props)
 
-    this.state = getInitialState(props.clusters, props.templates, props.blankTemplateId, props.operatingSystems)
+    this.state = getInitialState(props)
     this.hideAndResetState = this.hideAndResetState.bind(this)
     this.hideAndNavigate = this.hideAndNavigate.bind(this)
     this.handleBasicOnUpdate = this.handleBasicOnUpdate.bind(this)
@@ -288,9 +283,8 @@ class CreateVmWizard extends React.Component {
   }
 
   hideAndResetState () {
-    const { onHide, clusters, templates, blankTemplateId, operatingSystems } = this.props
-    this.setState(getInitialState(clusters, templates, blankTemplateId, operatingSystems))
-    onHide()
+    this.setState(getInitialState(this.props))
+    this.props.onHide()
   }
 
   hideAndNavigate () {
@@ -512,16 +506,24 @@ CreateVmWizard.propTypes = {
   show: PropTypes.bool,
   onHide: PropTypes.func,
 
+  // todo remove the "eslint-disable-next-line"s below when updating the eslint to newer version
+  // eslint-disable-next-line react/no-unused-prop-types
   clusters: PropTypes.object.isRequired,
   storageDomains: PropTypes.object.isRequired,
   templates: PropTypes.object.isRequired,
+  // eslint-disable-next-line react/no-unused-prop-types
   blankTemplateId: PropTypes.string.isRequired,
   userMessages: PropTypes.object.isRequired,
   actionResults: PropTypes.object.isRequired,
+  // eslint-disable-next-line react/no-unused-prop-types
   operatingSystems: PropTypes.object.isRequired,
 
   onCreate: PropTypes.func,
   navigateToVm: PropTypes.func,
+  // eslint-disable-next-line react/no-unused-prop-types
+  defaultGeneralTimezone: PropTypes.string.isRequired,
+  // eslint-disable-next-line react/no-unused-prop-types
+  defaultWindowsTimezone: PropTypes.string.isRequired,
 }
 
 export default connect(
@@ -533,6 +535,8 @@ export default connect(
     userMessages: state.userMessages,
     actionResults: state.vms.get('correlationResult'),
     operatingSystems: state.operatingSystems,
+    defaultGeneralTimezone: state.config.get('defaultGeneralTimezone'),
+    defaultWindowsTimezone: state.config.get('defaultWindowsTimezone'),
   }),
   (dispatch) => ({
     onCreate: (basic, nics, disks, correlationId) => dispatch(

--- a/src/components/CreateVmWizard/helpers.js
+++ b/src/components/CreateVmWizard/helpers.js
@@ -1,22 +1,67 @@
-import { createTemplateList } from '_/components/utils'
+import { createIsoList, createTemplateList } from '_/components/utils'
 import timezones from '_/components/utils/timezones.json'
 import { isWindows } from '_/helpers'
 
-const handleClusterIdChange = (clusterId, blankTemplateId, { templates, clusters, defaultValues, operatingSystems, defaultGeneralTimezone, defaultWindowsTimezone }) => {
+const handleClusterIdChange = (clusterId, { blankTemplateId, defaultValues, clusters, templates, operatingSystems, storageDomains, defaultGeneralTimezone, defaultWindowsTimezone }) => {
   let changes = {}
   const templateList = clusterId ? createTemplateList(templates, clusterId) : []
   changes.dataCenterId = clusterId ? clusters.getIn([clusterId, 'dataCenterId']) : undefined
   changes.clusterId = clusterId
-  changes.provisionSource =
-    (templateList.length === 1 && templateList[0].id === blankTemplateId)
-      ? 'iso'
-      : 'template'
-  changes.templateId = templateList.length === 1 ? blankTemplateId : undefined
-  changes = { ...changes, ...handleProvisionSourceChange(changes.provisionSource, defaultValues, { defaultGeneralTimezone, defaultWindowsTimezone, templates, operatingSystems }) }
+
+  if (clusterId === undefined) {
+    changes = { ...changes, ...handleProvisionSourceChange('template', { defaultValues, defaultGeneralTimezone, defaultWindowsTimezone, templates, operatingSystems }) }
+    return changes
+  }
+
+  if (templateList.length > 1) {
+    // cluster includes more than one non blank template
+    changes = {
+      ...changes,
+      ...handleProvisionSourceChange('template', { defaultValues, defaultGeneralTimezone, defaultWindowsTimezone, templates, operatingSystems }),
+    }
+    if (templateList.length === 2) {
+      // cluster includes only one non blank template
+      const selectedTemplate = templateList.find(t => t.id !== blankTemplateId)
+      changes = {
+        ...changes,
+        ...(selectedTemplate ? handleTemplateIdChange(selectedTemplate.id, defaultValues.optimizedFor, { templates, operatingSystems, defaultGeneralTimezone, defaultWindowsTimezone }) : {}),
+      }
+    }
+    return changes
+  }
+  if (templateList.length === 1 && templateList[0].id === blankTemplateId) {
+    // cluster includes only one template (Blank)
+    const isoList = createIsoList(storageDomains, changes.dataCenterId)
+
+    if (isoList.length > 0) {
+      // cluster includes at least one iso cd
+      changes = {
+        ...changes,
+        ...handleProvisionSourceChange('iso', { defaultValues, defaultGeneralTimezone, defaultWindowsTimezone, templates, operatingSystems }),
+      }
+      if (isoList.length === 1) {
+        // cluster includes only one iso cd
+        changes.isoImage = isoList[0].file.id
+      }
+    } else {
+      // cluster does not include any non blank template or iso cd
+      changes = {
+        ...changes,
+        ...handleProvisionSourceChange('template', { defaultValues, defaultGeneralTimezone, defaultWindowsTimezone, templates, operatingSystems }),
+        ...handleTemplateIdChange(blankTemplateId, defaultValues.optimizedFor, { templates, operatingSystems, defaultGeneralTimezone, defaultWindowsTimezone }),
+      }
+    }
+    return changes
+  }
+  // fallback should never hit
+  changes.isoImage = undefined
+  changes.provisionSource = 'template'
+  changes.isoImage = undefined
+  changes.templateId = blankTemplateId
   return changes
 }
 
-const handleProvisionSourceChange = (provisionSource, defaultValues, { defaultGeneralTimezone, defaultWindowsTimezone, templates, operatingSystems }) => {
+const handleProvisionSourceChange = (provisionSource, { defaultValues, defaultGeneralTimezone, defaultWindowsTimezone, templates, operatingSystems }) => {
   const changes = {}
   changes.provisionSource = provisionSource
   changes.isoImage = undefined
@@ -30,13 +75,13 @@ const handleProvisionSourceChange = (provisionSource, defaultValues, { defaultGe
 
   // when changing Provision type to ISO, set the default time zone according to the OS
   if (changes.provisionSource === 'iso') {
-    changes.timeZone = checkTimeZone(changes.operatingSystemId, changes.templateId, defaultGeneralTimezone, defaultWindowsTimezone, { templates, operatingSystems })
+    changes.timeZone = checkTimeZone(changes.operatingSystemId, changes.templateId, { defaultGeneralTimezone, defaultWindowsTimezone, templates, operatingSystems })
     changes.initTimezone = '' // reset the sysprep timezone value, we don't support cloud-init TZ yet
   }
   return changes
 }
 
-const handleTemplateIdChange = (templateId, optimizedFor, { templates, operatingSystems, defaultGeneralTimezone, defaultWindowsTimezone }) => {
+const handleTemplateIdChange = (templateId, defaultOptimizedFor, { templates, operatingSystems, defaultGeneralTimezone, defaultWindowsTimezone }) => {
   const changes = {}
   const template = templates.find(t => t.get('id') === templateId)
   changes.templateId = template.get('id')
@@ -44,13 +89,13 @@ const handleTemplateIdChange = (templateId, optimizedFor, { templates, operating
   changes.memory = template.get('memory') / (1024 ** 2) // stored in bytes, input in Mib
   changes.cpus = template.getIn([ 'cpu', 'vCPUs' ])
   changes.topology = template.getIn([ 'cpu', 'topology' ]).toJS()
-  changes.optimizedFor = template.get('type', optimizedFor)
+  changes.optimizedFor = template.get('type', defaultOptimizedFor)
   changes.operatingSystemId = operatingSystems
     .find(os => os.get('name') === template.getIn([ 'os', 'type' ]))
     .get('id')
 
   // Check template's timezone compatibility with the template's OS, set the timezone corresponding to the template's OS
-  changes.timeZone = checkTimeZone(changes.operatingSystemId, changes.templateId, defaultGeneralTimezone, defaultWindowsTimezone, { templates, operatingSystems })
+  changes.timeZone = checkTimeZone(changes.operatingSystemId, changes.templateId, { defaultGeneralTimezone, defaultWindowsTimezone, templates, operatingSystems })
   changes.cloudInitEnabled = template.getIn(['cloudInit', 'enabled'])
   changes.initHostname = template.getIn(['cloudInit', 'hostName'])
   changes.initSshKeys = template.getIn(['cloudInit', 'sshAuthorizedKeys'])
@@ -69,9 +114,8 @@ const handleTemplateIdChange = (templateId, optimizedFor, { templates, operating
   return changes
 }
 
-const checkTimeZone = (osId, templateId, defaultGeneralTimezone, defaultWindowsTimezone, { templates, operatingSystems }) => {
+const checkTimeZone = (osId, templateId, { defaultGeneralTimezone, defaultWindowsTimezone, templates, operatingSystems }) => {
   const template = templateId ? templates.get(templateId) : undefined
-
   let timeZone = {
     name: defaultGeneralTimezone,
   }

--- a/src/components/CreateVmWizard/steps/BasicSettings.js
+++ b/src/components/CreateVmWizard/steps/BasicSettings.js
@@ -220,13 +220,11 @@ class BasicSettings extends React.Component {
     let changes = {}
     switch (field) {
       case 'clusterId':
-        const { blankTemplateId } = this.props
-        changes = handleClusterIdChange(value, blankTemplateId, this.props)
+        changes = handleClusterIdChange(value, this.props)
         break
 
       case 'provisionSource':
-        const { defaultValues } = this.props
-        changes = handleProvisionSourceChange(value, defaultValues, this.props)
+        changes = handleProvisionSourceChange(value, this.props)
         break
 
       case 'templateId':
@@ -236,8 +234,8 @@ class BasicSettings extends React.Component {
 
       case 'operatingSystemId':
         changes[field] = value
-        const { data: { templateId }, defaultGeneralTimezone, defaultWindowsTimezone } = this.props
-        changes.timeZone = checkTimeZone(value, templateId, defaultGeneralTimezone, defaultWindowsTimezone, this.props)
+        const { data: { templateId } } = this.props
+        changes.timeZone = checkTimeZone(value, templateId, this.props)
         // only when changing the OS from one Windows to other Windows
         changes.initTimezone = this.props.data.cloudInitEnabled && this.props.data.enableInitTimezone && isOsWindows(value, this.props.operatingSystems)
           ? this.props.data.lastInitTimezone // set the sysprep timezone as the last selected sysprep timezone
@@ -634,12 +632,15 @@ class BasicSettings extends React.Component {
 BasicSettings.propTypes = {
   id: PropTypes.string,
   data: PropTypes.shape(BASIC_DATA_SHAPE),
+  // todo remove the 'eslint-disable-next-line' below when updating the eslint to newer version
+  // eslint-disable-next-line react/no-unused-prop-types
   defaultValues: PropTypes.shape(BASIC_DATA_SHAPE),
 
   dataCenters: PropTypes.object.isRequired,
   clusters: PropTypes.object.isRequired,
   operatingSystems: PropTypes.object.isRequired,
   templates: PropTypes.object.isRequired,
+  // eslint-disable-next-line react/no-unused-prop-types
   blankTemplateId: PropTypes.string.isRequired,
   storageDomains: PropTypes.object.isRequired,
   maxNumOfVmCpus: PropTypes.number.isRequired,
@@ -651,7 +652,9 @@ BasicSettings.propTypes = {
 
   onUpdate: PropTypes.func.isRequired,
 
+  // eslint-disable-next-line react/no-unused-prop-types
   defaultGeneralTimezone: PropTypes.string.isRequired,
+  // eslint-disable-next-line react/no-unused-prop-types
   defaultWindowsTimezone: PropTypes.string.isRequired,
 }
 


### PR DESCRIPTION
Fixes: #1252
**Depends on**: https://github.com/oVirt/ovirt-web-ui/pull/1291 (MERGED)

In the CreateVMWizard dialog -> "Basic settings" step the user had to select an option from list menu even if there is only one option allowed to the user.
It could be annoying and unnecessary, in this PR lists with single option will be automatically selected.

There are few changes which not related to the auto select and used to avoid the dialog close confirmation if the user not changed anything and the only changes were done are from the "auto select" feature, those changes made to maintain the behavior which created in #1231 .