### PR TITLE
Create VM Wizard - add indicators to missing/invalid fields on BasicSettings step

### DIFF
--- a/src/components/SelectBox.js
+++ b/src/components/SelectBox.js
@@ -27,6 +27,7 @@ class SelectBox extends React.Component {
       items: getItems(props),
     }
     this.handleChange = this.handleChange.bind(this)
+    this.getValidationClass = this.getValidationClass.bind(this)
   }
 
   componentWillReceiveProps (nextProps) {
@@ -44,15 +45,26 @@ class SelectBox extends React.Component {
     }
   }
 
+  getValidationClass () {
+    const { validationState } = this.props
+    switch (validationState) {
+      case 'error':
+        return style['selectBox-has-error']
+      default:
+        return ''
+    }
+  }
+
   render () {
     const { id } = this.props
 
     const selectedItem = this.state.items.find(item => item.id === this.state.selected)
+    const validationClass = this.getValidationClass()
 
     return (
       <div style={{ width: '100%' }} id={id}>
         <div className='dropdown'>
-          <button className={`btn btn-default dropdown-toggle ${style['dropdown-button']}`} type='button' data-toggle='dropdown' id={`${id}-button-toggle`}>
+          <button className={`btn btn-default dropdown-toggle ${style['dropdown-button']} ${validationClass}`} type='button' data-toggle='dropdown' id={`${id}-button-toggle`}>
             <span className={style['dropdown-button-text']} id={`${id}-button-text`} title={selectedItem && selectedItem.value}>
               {selectedItem ? selectedItem.value : NOBREAK_SPACE}
             </span>
@@ -83,6 +95,7 @@ SelectBox.propTypes = {
   /* eslint-enable react/no-unused-prop-types */
   onChange: PropTypes.func.isRequired, // (selectedId: string) => any
   id: PropTypes.string,
+  validationState: PropTypes.oneOf([ false, 'default', 'error' ]),
 }
 
 export default SelectBox

--- a/src/components/sharedStyle.css
+++ b/src/components/sharedStyle.css
@@ -84,3 +84,12 @@
 .text-align-left {
   text-align: left;
 }
+/*
+ * SelectBox validationState classes
+ * compatible with PF3 FormControl component
+ */
+
+.selectBox-has-error,.selectBox-has-error:hover,.selectBox-has-error:focus {
+    /*pf-red-100*/
+    border-color: #cc0000;
+}


### PR DESCRIPTION
Due to users' complains that is not clear enough why the next button is still disabled, I made the basic setting step bit more interactive and for any field after setting VM's name the dialog will indicate which field is the next missing/invalid field.

To support the interactivity I edited the `SelectBox` component and I added validation capability to the component, I tried to stick to PF3 `<FormControl/>` component's appearance and interface, you can see it in commit 0daaf5b.

I would like to hear your opinion, about the new behavior, and if you have any UX suggestions like "make them all blink together" or suggestions about the `selectBox` validations' appearance.

The new  dialog:
![BasicSettingsIndicators-2020-08-10_20 20 00 (1)](https://user-images.githubusercontent.com/64131213/89870731-f9d55b80-dbbe-11ea-9343-6a688ae88d76.gif)

Fixes: #1251