### PR TITLE
Fix create vm storage step moving bootable flag regression

### DIFF
--- a/src/components/CreateVmWizard/steps/Storage.js
+++ b/src/components/CreateVmWizard/steps/Storage.js
@@ -503,13 +503,15 @@ class Storage extends React.Component {
   handleRowConfirmChange (rowData) {
     const actionCreate = !!this.state.creating && this.state.creating === rowData.id
     const editedRow = this.state.editing[rowData.id]
-    let bootableDisk = this.props.disks.find(disk => disk.bootable)
 
-    // if the actual disk was set as bootable but there's already another bootable one
-    if (editedRow.bootable && bootableDisk) {
-      // no need to check if there's any bootable template disk, we cannot edit bootable flag of disks if there's any bootable template disk
-      bootableDisk.bootable = false // update the previously bootable disk, remove the bootable flag from it
-      this.props.onUpdate({ update: bootableDisk })
+    // if the edited disk is set bootable, make sure to remove bootable from the other disks
+    if (editedRow.bootable) {
+      const previousBootableDisk = this.props.disks.find(disk => disk.bootable)
+      if (previousBootableDisk) {
+        this.props.onUpdate({
+          update: { id: previousBootableDisk.id, bootable: false },
+        })
+      }
     }
 
     // TODO: Add field level validation for the edit or create fields


### PR DESCRIPTION
Resolves: #1267

A regression was introduced with making the VM state immutable. The storage step was directly updating one of the disks to remove the bootable flag before sending that object back through the `onUpdate` callback.  With immutable state via immer, the objects are set to read only and any updates to the object will throw a runtime error typically including the phrase "read only property".

The fix is simple.  Do not reuse the object.  Now `onUpdate` is called with a simple object created just to hold the update work.