### PR TITLE
Display Pool entities containing search term when filtering

### DIFF
--- a/src/components/VmsList/VmCardList.js
+++ b/src/components/VmsList/VmCardList.js
@@ -28,7 +28,10 @@ const VmCardList = ({ vms, alwaysShowPoolCard, fetchMoreVmsAndPools }) => {
 
   // Filter the Pools (only show a Pool card if the user can currently 'Take' a VM from it)
   const filteredPools = vms.get('pools')
-    .filter(pool => alwaysShowPoolCard || (pool.get('vmsCount') < pool.get('maxUserVms') && pool.get('size') > 0 && filterVms(pool, filters)))
+    .filter(pool =>
+      (alwaysShowPoolCard || (pool.get('vmsCount') < pool.get('maxUserVms') && pool.get('size') > 0)) &&
+      filterVms(pool, filters)
+    )
     .toList()
 
   // Display the VMs and Pools together, sorted nicely


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/1183

In the VM list, display the only those Pool entities which contain the current search term (not all of them as it was before for admins), treat VMs and Pool entities the same way for all user types when filtering. Always show Pool cards only when logged in as an admin user and not filtering.

---

**Before:**
![before](https://user-images.githubusercontent.com/13417815/90526075-3f21fc00-e170-11ea-8196-22e077ed0d9d.png)

**After:**
![after](https://user-images.githubusercontent.com/13417815/90526086-41845600-e170-11ea-873f-7759a6e6d5ba.png)

---

This PR fixes regression introduced in https://github.com/oVirt/ovirt-web-ui/pull/1241.