### PR TITLE
CreateVmWizard - skip close wizard dialog confirmation after VM creation

### DIFF
--- a/src/components/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/CreateVmWizard/CreateVmWizard.js
@@ -276,8 +276,8 @@ class CreateVmWizard extends React.Component {
   }
 
   showCloseWizardDialog () {
-    const { wizardUpdated } = this.state
-    if (wizardUpdated) {
+    const { wizardUpdated, correlationId } = this.state
+    if (wizardUpdated && !correlationId) {
       this.setState(produce(draft => { draft.showCloseWizardDialog = true }))
     } else {
       this.hideAndResetState()


### PR DESCRIPTION
Fixes: #1277 .

Close confirmation modal appears when closing the CreateVMWizard modal even if the VM already created and there are no data which will lose.

I fixed that and now if the VM is already created the CreateVMWizard will close without confirmation and will skip the confirmation dialog.
WDYT?