### PR TITLE
Add advanced CPU topology settings in Basic Settings step

### DIFF
--- a/src/components/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/CreateVmWizard/CreateVmWizard.js
@@ -96,12 +96,14 @@ function getInitialState (clusters, templates, blankTemplateId, operatingSystems
     const memoryInB = blankTemplate.get('memory')
     const cpus = blankTemplate.getIn([ 'cpu', 'vCPUs' ])
     const initEnabled = blankTemplate.getIn([ 'cloudInit', 'enabled' ])
+    const topology = blankTemplate.getIn([ 'cpu', 'topology' ]).toJS()
 
     blankTemplateValues = {
       operatingSystemId,
       memory: memoryInB / (1024 ** 2), // bytes to MiB
       cpus,
       initEnabled,
+      topology,
     }
   }
 

--- a/src/components/CreateVmWizard/dataPropTypes.js
+++ b/src/components/CreateVmWizard/dataPropTypes.js
@@ -24,6 +24,12 @@ export const BASIC_DATA_SHAPE = {
   initTimezone: PropTypes.string,
   initAdminPassword: PropTypes.string,
   initCustomScript: PropTypes.string,
+
+  topology: PropTypes.exact({
+    cores: PropTypes.number.isRequired,
+    sockets: PropTypes.number.isRequired,
+    threads: PropTypes.number.isRequired,
+  }),
 }
 
 // interface is subset of: http://ovirt.github.io/ovirt-engine-api-model/master/#types/nic_interface

--- a/src/components/CreateVmWizard/steps/BasicSettings.js
+++ b/src/components/CreateVmWizard/steps/BasicSettings.js
@@ -17,7 +17,13 @@ import {
   isVmNameValid,
 } from '_/components/utils'
 
-import { ExpandCollapse, Form, FormControl, Checkbox } from 'patternfly-react'
+import {
+  ExpandCollapse,
+  FieldLevelHelp,
+  Form,
+  FormControl,
+  Checkbox,
+} from 'patternfly-react'
 import { Grid, Row, Col } from '_/components/Grid'
 import SelectBox from '_/components/SelectBox'
 
@@ -38,6 +44,7 @@ const FieldRow = ({
   labelCols = 3,
   fieldCols = 7,
   children,
+  tooltip,
 }) => (
   <Row className={`
       form-group
@@ -61,6 +68,12 @@ const FieldRow = ({
       <React.Fragment>
         <Col cols={labelCols} className={`control-label ${style['col-label']}`}>
           {label}
+          { tooltip &&
+            <FieldLevelHelp
+              content={tooltip}
+              inline
+            />
+          }
         </Col>
         <Col cols={fieldCols} className={style['col-data']} id={id}>{children}</Col>
       </React.Fragment>
@@ -77,6 +90,7 @@ FieldRow.propTypes = {
   labelCols: PropTypes.number,
   fieldCols: PropTypes.number,
   children: PropTypes.node.isRequired,
+  tooltip: PropTypes.string,
 }
 
 const SubHeading = ({ children }) => (
@@ -395,6 +409,12 @@ class BasicSettings extends React.Component {
       maxNumberOfCores: maxNumOfCores,
       maxNumberOfThreads: maxNumOfThreads,
     })
+    // for Threads per Core tooltip
+    const clusterId = data.clusterId || '_'
+    const cluster = clusters && clusters.get(clusterId)
+    const threadsTooltip = cluster && cluster.get('architecture') === 'ppc64'
+      ? msg.recomendedPower8ValuesForThreads({ threads: maxNumOfThreads })
+      : msg.recomendedValuesForThreads({ threads: maxNumOfThreads })
 
     // ----- RENDER -----
     return <Form horizontal id={idPrefix}>
@@ -616,6 +636,7 @@ class BasicSettings extends React.Component {
             fieldCols={3}
             label={msg.threadsPerCores()}
             id={`${idPrefix}-topology-threads`}
+            tooltip={threadsTooltip}
           >
             <SelectBox
               id={`${idPrefix}-topology-threads-edit`}

--- a/src/components/CreateVmWizard/steps/BasicSettings.js
+++ b/src/components/CreateVmWizard/steps/BasicSettings.js
@@ -593,31 +593,37 @@ class BasicSettings extends React.Component {
       <ExpandCollapse id={`${idPrefix}-advanced-options`} textCollapsed={msg.advancedCpuTopologyOptions()} textExpanded={msg.advancedCpuTopologyOptions()}>
         <Grid className={style['settings-container']}>
           <FieldRow label={msg.virtualSockets()} id={`${idPrefix}-topology-sockets`}>
-            <SelectBox
-              id={`${idPrefix}-topology-sockets-edit`}
-              items={this.mapVCpuTopologyItems(vCpuTopologyDividers.sockets)}
-              selected={data.topology.sockets.toString()}
-              onChange={selectedId => { this.handleChange('topology', selectedId, { vcpu: 'sockets' }) }}
-            />
+            <div className={style['topology-column']}>
+              <SelectBox
+                id={`${idPrefix}-topology-sockets-edit`}
+                items={this.mapVCpuTopologyItems(vCpuTopologyDividers.sockets)}
+                selected={data.topology.sockets.toString()}
+                onChange={selectedId => { this.handleChange('topology', selectedId, { vcpu: 'sockets' }) }}
+              />
+            </div>
           </FieldRow>
           <FieldRow label={msg.coresPerSockets()} id={`${idPrefix}-topology-cores`}>
-            <SelectBox
-              id={`${idPrefix}-topology-cores-edit`}
-              items={this.mapVCpuTopologyItems(vCpuTopologyDividers.cores)}
-              selected={data.topology.cores.toString()}
-              onChange={selectedId => { this.handleChange('topology', selectedId, { vcpu: 'cores' }) }}
-            />
+            <div className={style['topology-column']}>
+              <SelectBox
+                id={`${idPrefix}-topology-cores-edit`}
+                items={this.mapVCpuTopologyItems(vCpuTopologyDividers.cores)}
+                selected={data.topology.cores.toString()}
+                onChange={selectedId => { this.handleChange('topology', selectedId, { vcpu: 'cores' }) }}
+              />
+            </div>
           </FieldRow>
           <FieldRow
             label={msg.threadsPerCores()}
             id={`${idPrefix}-topology-threads`}
           >
-            <SelectBox
-              id={`${idPrefix}-topology-threads-edit`}
-              items={this.mapVCpuTopologyItems(vCpuTopologyDividers.threads)}
-              selected={data.topology.threads.toString()}
-              onChange={selectedId => { this.handleChange('topology', selectedId, { vcpu: 'threads' }) }}
-            />
+            <div className={style['topology-column']}>
+              <SelectBox
+                id={`${idPrefix}-topology-threads-edit`}
+                items={this.mapVCpuTopologyItems(vCpuTopologyDividers.threads)}
+                selected={data.topology.threads.toString()}
+                onChange={selectedId => { this.handleChange('topology', selectedId, { vcpu: 'threads' }) }}
+              />
+            </div>
           </FieldRow>
         </Grid>
       </ExpandCollapse>

--- a/src/components/CreateVmWizard/steps/BasicSettings.js
+++ b/src/components/CreateVmWizard/steps/BasicSettings.js
@@ -35,6 +35,8 @@ const FieldRow = ({
   rowClassName = '',
   vertical = false,
   validationState = null,
+  labelCols = 3,
+  fieldCols = 7,
   children,
 }) => (
   <Row className={`
@@ -47,7 +49,7 @@ const FieldRow = ({
   >
     { vertical &&
       <React.Fragment>
-        <Col offset={3} cols={7} className={style['col-data']} id={id}>
+        <Col offset={labelCols} cols={fieldCols} className={style['col-data']} id={id}>
           <div className={style['col-label-vertical']}>
             {label}
           </div>
@@ -57,10 +59,10 @@ const FieldRow = ({
     }
     { !vertical &&
       <React.Fragment>
-        <Col cols={3} className={`control-label ${style['col-label']}`}>
+        <Col cols={labelCols} className={`control-label ${style['col-label']}`}>
           {label}
         </Col>
-        <Col cols={7} className={style['col-data']} id={id}>{children}</Col>
+        <Col cols={fieldCols} className={style['col-data']} id={id}>{children}</Col>
       </React.Fragment>
     }
   </Row>
@@ -72,6 +74,8 @@ FieldRow.propTypes = {
   rowClassName: PropTypes.string,
   vertical: PropTypes.bool,
   validationState: PropTypes.oneOf(['success', 'warning', 'error', null]),
+  labelCols: PropTypes.number,
+  fieldCols: PropTypes.number,
   children: PropTypes.node.isRequired,
 }
 
@@ -592,38 +596,33 @@ class BasicSettings extends React.Component {
       {/* Advanced CPU Topology Options */}
       <ExpandCollapse id={`${idPrefix}-advanced-options`} textCollapsed={msg.advancedCpuTopologyOptions()} textExpanded={msg.advancedCpuTopologyOptions()}>
         <Grid className={style['settings-container']}>
-          <FieldRow label={msg.virtualSockets()} id={`${idPrefix}-topology-sockets`}>
-            <div className={style['topology-column']}>
-              <SelectBox
-                id={`${idPrefix}-topology-sockets-edit`}
-                items={this.mapVCpuTopologyItems(vCpuTopologyDividers.sockets)}
-                selected={data.topology.sockets.toString()}
-                onChange={selectedId => { this.handleChange('topology', selectedId, { vcpu: 'sockets' }) }}
-              />
-            </div>
+          <FieldRow fieldCols={3} label={msg.virtualSockets()} id={`${idPrefix}-topology-sockets`}>
+            <SelectBox
+              id={`${idPrefix}-topology-sockets-edit`}
+              items={this.mapVCpuTopologyItems(vCpuTopologyDividers.sockets)}
+              selected={data.topology.sockets.toString()}
+              onChange={selectedId => { this.handleChange('topology', selectedId, { vcpu: 'sockets' }) }}
+            />
           </FieldRow>
-          <FieldRow label={msg.coresPerSockets()} id={`${idPrefix}-topology-cores`}>
-            <div className={style['topology-column']}>
-              <SelectBox
-                id={`${idPrefix}-topology-cores-edit`}
-                items={this.mapVCpuTopologyItems(vCpuTopologyDividers.cores)}
-                selected={data.topology.cores.toString()}
-                onChange={selectedId => { this.handleChange('topology', selectedId, { vcpu: 'cores' }) }}
-              />
-            </div>
+          <FieldRow fieldCols={3} label={msg.coresPerSockets()} id={`${idPrefix}-topology-cores`}>
+            <SelectBox
+              id={`${idPrefix}-topology-cores-edit`}
+              items={this.mapVCpuTopologyItems(vCpuTopologyDividers.cores)}
+              selected={data.topology.cores.toString()}
+              onChange={selectedId => { this.handleChange('topology', selectedId, { vcpu: 'cores' }) }}
+            />
           </FieldRow>
           <FieldRow
+            fieldCols={3}
             label={msg.threadsPerCores()}
             id={`${idPrefix}-topology-threads`}
           >
-            <div className={style['topology-column']}>
-              <SelectBox
-                id={`${idPrefix}-topology-threads-edit`}
-                items={this.mapVCpuTopologyItems(vCpuTopologyDividers.threads)}
-                selected={data.topology.threads.toString()}
-                onChange={selectedId => { this.handleChange('topology', selectedId, { vcpu: 'threads' }) }}
-              />
-            </div>
+            <SelectBox
+              id={`${idPrefix}-topology-threads-edit`}
+              items={this.mapVCpuTopologyItems(vCpuTopologyDividers.threads)}
+              selected={data.topology.threads.toString()}
+              onChange={selectedId => { this.handleChange('topology', selectedId, { vcpu: 'threads' }) }}
+            />
           </FieldRow>
         </Grid>
       </ExpandCollapse>

--- a/src/components/CreateVmWizard/steps/SummaryReview.js
+++ b/src/components/CreateVmWizard/steps/SummaryReview.js
@@ -2,10 +2,12 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Alert, Icon, Spinner, Label } from 'patternfly-react'
+import { InfoCircleIcon } from '@patternfly/react-icons'
 
 import { msg, enumMsg } from '_/intl'
 import { templateNameRenderer, userFormatOfBytes } from '_/helpers'
 import { Grid, Row, Col } from '_/components/Grid'
+import OverlayTooltip from '_/components/OverlayTooltip'
 import { sortNicsDisks } from '_/components/utils'
 
 import { BASIC_DATA_SHAPE, NIC_SHAPE, STORAGE_SHAPE } from '../dataPropTypes'
@@ -61,8 +63,17 @@ const ReviewBasic = ({ id, dataCenters, clusters, isos, templates, operatingSyst
     <Item id={`${id}-memory`} label={msg.memory()}>{userFormatOfBytes(basic.memory, 'MiB').str}</Item>
     <Item id={`${id}-cpus`} label={msg.cpus()}>
       { basic.cpus }
-      {/* TODO: Include topology (as a popover?) */}
-    </Item>
+      <OverlayTooltip
+        id={`${id}-summary-vcpus-tooltip`}
+        tooltip={msg.totalCpuTooltip({
+          cores: basic.topology.cores,
+          sockets: basic.topology.sockets,
+          threads: basic.topology.threads,
+        })}
+        placement={'top'}
+      >
+        <InfoCircleIcon className={style['info-circle-icon']} />
+      </OverlayTooltip>    </Item>
     <Item id={`${id}-optimizedFor`} label={msg.optimizedFor()}>{optimizedForMap[basic.optimizedFor].value}</Item>
   </React.Fragment>
 }

--- a/src/components/CreateVmWizard/steps/style.css
+++ b/src/components/CreateVmWizard/steps/style.css
@@ -59,6 +59,10 @@
   margin-left: -15px;
 }
 
+.topology-column {
+  max-width: 40%;
+}
+
 /*
  * Networking
  */

--- a/src/components/CreateVmWizard/steps/style.css
+++ b/src/components/CreateVmWizard/steps/style.css
@@ -59,10 +59,6 @@
   margin-left: -15px;
 }
 
-.topology-column {
-  max-width: 40%;
-}
-
 /*
  * Networking
  */

--- a/src/components/CreateVmWizard/steps/style.css
+++ b/src/components/CreateVmWizard/steps/style.css
@@ -231,3 +231,7 @@ table tbody tr td.kebab-menu-cell {
   border-left: 1px solid #eee;
   padding-left: 10px;
 }
+
+.info-circle-icon {
+  margin-left: 3px;
+}

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -39,6 +39,7 @@ export const messages: { [messageId: string]: MessageType } = {
     message: 'Advanced Options',
     description: 'Label used on forms when there are a set of fields that are initially hidden and require a click to view.',
   },
+  advancedCpuTopologyOptions: 'Advanced CPU Topology Options',
   alias: {
     message: 'Alias',
     description: 'In sense of "human friendly name"',

--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -378,9 +378,9 @@ const Template = {
       cpu: {
         vCPUs: vCpusCount({ cpu: template.cpu }),
         topology: {
-          cores: template.cpu.topology.cores,
-          sockets: template.cpu.topology.sockets,
-          threads: template.cpu.topology.threads,
+          cores: convertInt(template.cpu.topology.cores),
+          sockets: convertInt(template.cpu.topology.sockets),
+          threads: convertInt(template.cpu.topology.threads),
         },
       },
 

--- a/src/sagas/vmChanges.js
+++ b/src/sagas/vmChanges.js
@@ -8,8 +8,6 @@ import * as C from '_/constants'
 import { arrayMatch } from '_/utils'
 import { msg } from '_/intl'
 
-import { getTopology } from '_/components/utils'
-
 import { callExternalAction, delay, delayInMsSteps } from './utils'
 import { startProgress, stopProgress, addVmNic, fetchSingleVm } from './index'
 import { createDiskForVm } from './disks'
@@ -26,22 +24,6 @@ function* createMemoryPolicyFromCluster (clusterId, memorySize) {
   return memoryPolicy
 }
 
-function* createCpuTopology (vcpu) {
-  const maxNumberOfSockets = yield select(state => state.config.get('maxNumberOfSockets'))
-  const maxNumberOfCores = yield select(state => state.config.get('maxNumberOfCores'))
-  const maxNumberOfThreads = yield select(state => state.config.get('maxNumberOfThreads'))
-
-  const topology = getTopology({
-    value: vcpu,
-    max: {
-      sockets: maxNumberOfSockets,
-      cores: maxNumberOfCores,
-      threads: maxNumberOfThreads,
-    },
-  })
-  return topology
-}
-
 /**
  * Compose the VM as JSON consumable directly by the REST API and
  * send it to be created.
@@ -56,7 +38,7 @@ function* composeAndCreateVm ({ payload: { basic, nics, disks }, meta: { correla
   // Common parts
   const vm = {
     cluster: { id: basic.clusterId },
-    cpu: { topology: yield createCpuTopology(basic.cpus) },
+    cpu: { topology: basic.topology },
     description: basic.description,
     memory_policy: memoryPolicy,
     memory,


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/1264

This PR adds support for editing advanced CPU topology (i.e. number of virtual sockets, cores per virtual socket, threads per core) in the _Basic Settings_ of the Create VM Wizard, by adding the "**Advanced CPU Topology Options**" that we can expand/collapse.
The chosen settings are also displayed in a popover next to the number of the virtual CPUs in the _Review_ report step of the Create VM Wizard.

Also the css style of the pf `ExpandCollapse` was slightly edited [to achieve the expected look](https://github.com/oVirt/ovirt-web-ui/pull/1279/commits/1575e874661782a4556d9bcbc1d6377f702083c0#diff-0cdb3888d313c777c2256655e5b4f867R236-R251) (same as before, extra space above the Adv. CPU Topology Options and above their content, proper align of the expand/collapse icon (^ V) with the rest of the component).

---

**After:**
_Basic settings_ step:
![adv1](https://user-images.githubusercontent.com/13417815/94066840-55654c80-fded-11ea-97c3-a110fb5b3a3d.png)
![adv2](https://user-images.githubusercontent.com/13417815/94066850-57c7a680-fded-11ea-9a6e-1f8930faee3a.png)
![adv3](https://user-images.githubusercontent.com/13417815/94066863-5a2a0080-fded-11ea-8a5a-59d046e81346.png)
_See also:_
https://github.com/oVirt/ovirt-web-ui/pull/1279#issuecomment-697999825
_Review_ step:
https://github.com/oVirt/ovirt-web-ui/pull/1279#issuecomment-688354076