### PR TITLE
Sort Disks and NICs in the Review step of CreateVmWizard

### DIFF
--- a/src/components/CreateVmWizard/steps/Networking.js
+++ b/src/components/CreateVmWizard/steps/Networking.js
@@ -2,12 +2,13 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { msg, enumMsg } from '_/intl'
-import { localeCompare, generateUnique } from '_/helpers'
+import { generateUnique } from '_/helpers'
 import { NIC_SHAPE } from '../dataPropTypes'
 
 import {
   createNicInterfacesList,
   createVNicProfileList,
+  sortNicsDisks,
   suggestNicName,
 } from '_/components/utils'
 
@@ -384,12 +385,7 @@ class Networking extends React.Component {
     const vnicList = createVNicProfileList(vnicProfiles, { dataCenterId, cluster })
     const enableCreate = vnicList.length > 0 && Object.keys(this.state.editing).length === 0
 
-    const nicList = [...nics]
-      .sort((a, b) => // template based then by name.
-        a.isFromTemplate && !b.isFromTemplate ? -1
-          : !a.isFromTemplate && b.isFromTemplate ? 1
-            : localeCompare(a.name, b.name)
-      )
+    const nicList = sortNicsDisks([...nics])
       .concat(this.state.creating ? [ this.state.editing[this.state.creating] ] : [])
       .map(nic => ({
         ...(this.state.editing[nic.id] ? this.state.editing[nic.id] : nic),

--- a/src/components/CreateVmWizard/steps/Storage.js
+++ b/src/components/CreateVmWizard/steps/Storage.js
@@ -2,13 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { msg } from '_/intl'
-import { localeCompare, generateUnique } from '_/helpers'
+import { generateUnique } from '_/helpers'
 import { isNumber, convertValue } from '_/utils'
 import { BASIC_DATA_SHAPE, STORAGE_SHAPE } from '../dataPropTypes'
 
 import {
   createDiskTypeList,
   createStorageDomainList,
+  sortNicsDisks,
   suggestDiskName,
 } from '_/components/utils'
 
@@ -559,12 +560,7 @@ class Storage extends React.Component {
     const filteredStorageDomainList = createStorageDomainList(storageDomains, dataCenterId)
     const enableCreate = storageDomainList.length > 0 && !this.isEditingMode()
 
-    const diskList = [...disks]
-      .sort((a, b) => // template based then by name.
-        a.isFromTemplate && !b.isFromTemplate ? -1
-          : !a.isFromTemplate && b.isFromTemplate ? 1
-            : localeCompare(a.name, b.name)
-      )
+    const diskList = sortNicsDisks([...disks])
       .concat(this.state.creating ? [ this.state.editing[this.state.creating] ] : [])
       .map(disk => {
         disk = this.state.editing[disk.id] ? this.state.editing[disk.id] : disk // update editing changes from state after sorting

--- a/src/components/CreateVmWizard/steps/SummaryReview.js
+++ b/src/components/CreateVmWizard/steps/SummaryReview.js
@@ -6,6 +6,7 @@ import { Alert, Icon, Spinner, Label } from 'patternfly-react'
 import { msg, enumMsg } from '_/intl'
 import { templateNameRenderer, userFormatOfBytes } from '_/helpers'
 import { Grid, Row, Col } from '_/components/Grid'
+import { sortNicsDisks } from '_/components/utils'
 
 import { BASIC_DATA_SHAPE, NIC_SHAPE, STORAGE_SHAPE } from '../dataPropTypes'
 import { optimizedForMap } from './BasicSettings'
@@ -205,8 +206,13 @@ class SummaryReview extends React.Component {
   render () {
     const id = this.props.id ? `${this.props.id}-review` : 'create-vm-wizard-review'
     const {
+      network,
+      storage,
       progress = { inProgress: false },
     } = this.props
+
+    const disksList = sortNicsDisks([...storage]) // Sort the template based ones first, then by name
+    const nicsList = sortNicsDisks([...network])
 
     return <div className={style['review-content']}>
       { (!progress.inProgress && !progress.result) &&
@@ -283,12 +289,12 @@ class SummaryReview extends React.Component {
             <ReviewNetworking
               id={`${id}-network`}
               vnicProfiles={this.props.vnicProfiles}
-              network={this.props.network}
+              network={nicsList}
             />
             <ReviewStorage
               id={`${id}-storage`}
               storageDomains={this.props.storageDomains}
-              storage={this.props.storage}
+              storage={disksList}
             />
             <ReviewAdvanced
               id={`${id}-advanced`}

--- a/src/components/utils/disks.js
+++ b/src/components/utils/disks.js
@@ -9,3 +9,14 @@ import { localeCompare } from '_/helpers'
 export function sortDisksForDisplay (disks, locale = appLocale) {
   return disks.sort((a, b) => { return localeCompare(a.get('name'), b.get('name'), locale) })
 }
+
+// Sort the Disks and NICs for display in the CreateVmWizard
+// Sort the template based ones first, then by name
+export function sortNicsDisks (objs, locale = appLocale) {
+  return objs
+    .sort((a, b) =>
+      a.isFromTemplate && !b.isFromTemplate ? -1
+        : !a.isFromTemplate && b.isFromTemplate ? 1
+          : localeCompare(a.name, b.name)
+    )
+}


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/1281

Sort Disks and NICs in the _Storage_ and _Networking_ sections of the _Review_ report step ~~alphabetically~~ by template, then by name - the same as in _Storage_ and _Networking_ steps of the wizard, to achieve the consistency.

---

**Before:**
![review_before](https://user-images.githubusercontent.com/13417815/91155610-5e1a1400-e6c3-11ea-8a2d-5db29101d6f1.png)

**After:**
![review_after](https://user-images.githubusercontent.com/13417815/91155623-62463180-e6c3-11ea-8410-6d4b70923779.png)
If template based Disks and NICs are present: https://github.com/oVirt/ovirt-web-ui/pull/1283#issuecomment-680081711
