### PR TITLE
Set enable-usb-autoshare in console.vv file according to SpiceUsbAutoShare engine config value

### DIFF
--- a/src/sagas/console/vvFileUtils.js
+++ b/src/sagas/console/vvFileUtils.js
@@ -33,7 +33,7 @@ export function adjustVVFile ({ data, options, usbAutoshare, usbFilter }) {
   }
 
   // make USB Auto-Share to be enabled/disabled in VM Portal according to the SpiceUsbAutoShare config value
-  data = data.replace(/^enable-usb-autoshare=.*$/mg, `enable-usb-autoshare=${usbAutoshare ? 1 : 0}`)
+  data = data.replace(/^enable-usb-autoshare=.*$/mg, `enable-usb-autoshare=${usbAutoshare.toString() === 'true' ? 1 : 0}`)
 
   console.log('adjustVVFile data after adjustment:', data)
   return data


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1811466

This PR sets `enable-usb-autoshare` according to the `SpiceUsbAutoShare` engine config default value properly. This wasn't 100% properly set in the previous PR https://github.com/oVirt/ovirt-web-ui/pull/1235.

The core of the problem was string vs. boolean type of the `usbAutoshare` variable in the `adjustVVFile` function, especially with the `false` vs. `'false'`. Now with this fix, whatever appears in the `usbAutoshare` variable (boolean or string), it will be converted to string and compared with `'true'`so the `enable-usb-autoshare` value will always be set as expected.

**Before**: (with the `SpiceUsbAutoShare` value set to `false`)
```
$ egrep 'share' *.vv
enable-usb-autoshare=1
```

**After**:
```
$ egrep 'share' *.vv
enable-usb-autoshare=0
```

---

How to test this PR:
1. Set the `SpiceUsbAutoShare` engine value to `true`:
  `engine-config -s SpiceUsbAutoShare=true && systemctl restart ovirt-engine`
 - or you can check the actual value by `engine-config -a | grep SpiceUsbAutoShare`
2. In the VM Portal, open the SPICE console.vv file in a text editor and check if there's `enable-usb-autoshare=1` or save the .vv file and `egrep 'share' *.vv`.

Similarly for the `SpiceUsbAutoShare` set to `false` together with `enable-usb-autoshare` set to `0` in the .vv file.

