### PR TITLE
Display proper sysprep timezone default value in CreateVmWizard and VM Details card

### DIFF
--- a/src/components/CreateVmWizard/steps/BasicSettings.js
+++ b/src/components/CreateVmWizard/steps/BasicSettings.js
@@ -309,11 +309,28 @@ class BasicSettings extends React.Component {
         changes.initSshKeys = template.getIn(['cloudInit', 'sshAuthorizedKeys'])
         changes.initTimezone = template.getIn(['cloudInit', 'timezone'])
         changes.initCustomScript = template.getIn(['cloudInit', 'customScript'])
+
+        if (changes.initTimezone && isOsWindows(changes.operatingSystemId, this.props.operatingSystems)) {
+          // Configure Timezone checkbox should be checked if template's timezone set
+          changes.enableInitTimezone = true
+          changes.lastInitTimezone = changes.initTimezone // select template's timezone in the Timezone drop down
+        } else {
+          changes.enableInitTimezone = false
+          changes.initTimezone = ''
+          // select the same default GMT sysprep timezone as in Admin Portal
+          changes.lastInitTimezone = timezones.find(timezone => timezone.value.startsWith('(GMT) Greenwich')).id
+        }
+
         break
 
       case 'operatingSystemId':
         changes[field] = value
         changes.timeZone = this.checkTimeZone(value, this.props.data.templateId)
+
+        // only when changing the OS from one Windows to other Windows
+        changes.initTimezone = this.props.data.cloudInitEnabled && this.props.data.enableInitTimezone && isOsWindows(value, this.props.operatingSystems)
+          ? this.props.data.lastInitTimezone // set the sysprep timezone as the last selected sysprep timezone
+          : ''
         break
 
       case 'memory':
@@ -332,6 +349,24 @@ class BasicSettings extends React.Component {
 
       case 'topology': // number of sockets, cores or threads changed by the user in Advanced Options section
         changes[field] = this.getTopologySettings(this.props.data.cpus, { [extra.vcpu]: +value })
+        break
+
+      case 'enableInitTimezone': // Configure Timezone checkbox change
+        changes[field] = value
+        // if the Configure Timezone checkbox checked, set the sysprep timezone
+        changes.initTimezone = value ? this.props.data.initTimezone || this.props.data.lastInitTimezone : ''
+        break
+
+      case 'initTimezone': // sysprep timezone change
+        changes[field] = value
+        changes.lastInitTimezone = value // save the actual selected sysprep timezone
+        break
+
+      case 'cloudInitEnabled': // Cloud-init/Sysprep checkbox change
+        changes[field] = value
+        changes.initTimezone = value && this.props.data.enableInitTimezone && isOsWindows(this.props.data.operatingSystemId, this.props.operatingSystems)
+          ? this.props.data.lastInitTimezone
+          : ''
         break
 
       default:
@@ -355,7 +390,7 @@ class BasicSettings extends React.Component {
 
   render () {
     const idPrefix = this.props.id || 'create-vm-wizard-basic'
-    const { data, clusters, maxNumOfSockets, maxNumOfCores, maxNumOfThreads } = this.props
+    const { data, clusters, maxNumOfSockets, maxNumOfCores, maxNumOfThreads, operatingSystems } = this.props
     const indicators = {
       name: this.validateVmName(),
     }
@@ -387,7 +422,7 @@ class BasicSettings extends React.Component {
 
     const enableOsSelect = isValidUid(data.clusterId) && [ 'iso', 'template' ].includes(data.provisionSource)
     const operatingSystemList = enableOsSelect
-      ? createOsList(data.clusterId, clusters, this.props.operatingSystems)
+      ? createOsList(data.clusterId, clusters, operatingSystems)
       : [ { id: '_', value: `-- ${msg.createVmWizardSelectClusterBeforeOS()} --` } ]
 
     const enableIsoSelect = data.provisionSource === 'iso' && isValidUid(data.dataCenterId)
@@ -417,8 +452,8 @@ class BasicSettings extends React.Component {
       delete indicators.template
     }
 
-    const enableCloudInit = data.cloudInitEnabled && isOsLinux(data.operatingSystemId, this.props.operatingSystems)
-    const enableSysPrep = data.cloudInitEnabled && isOsWindows(data.operatingSystemId, this.props.operatingSystems)
+    const enableCloudInit = data.cloudInitEnabled && isOsLinux(data.operatingSystemId, operatingSystems)
+    const enableSysPrep = data.cloudInitEnabled && isOsWindows(data.operatingSystemId, operatingSystems)
 
     // for Advanced CPU Topology Options expand/collapse section
     const vCpuTopologyDividers = getTopologyPossibleValues({
@@ -604,12 +639,24 @@ class BasicSettings extends React.Component {
               />
             </FieldRow>
 
+            {/*  Configure Timezone checkbox */}
+            <FieldRow id={`${idPrefix}-sysPrepTimezone-configure`} vertical>
+              <Checkbox
+                id={`${idPrefix}-sysprep-timezone-config`}
+                checked={data.enableInitTimezone}
+                onChange={e => this.handleChange('enableInitTimezone', e.target.checked)}
+              >
+                {msg.sysPrepTimezoneConfigure()}
+              </Checkbox>
+            </FieldRow>
+
             <FieldRow label={msg.sysPrepTimezone()} id={`${idPrefix}-sysPrepTimezone`} vertical>
               <SelectBox
                 id={`${idPrefix}-sysprep-timezone-select`}
                 items={timezones}
-                selected={data.initTimezone}
+                selected={data.lastInitTimezone}
                 onChange={selectedId => this.handleChange('initTimezone', selectedId)}
+                disabled={!data.enableInitTimezone}
               />
             </FieldRow>
 

--- a/src/components/SelectBox.js
+++ b/src/components/SelectBox.js
@@ -56,7 +56,7 @@ class SelectBox extends React.Component {
   }
 
   render () {
-    const { id } = this.props
+    const { id, disabled } = this.props
 
     const selectedItem = this.state.items.find(item => item.id === this.state.selected)
     const validationClass = this.getValidationClass()
@@ -64,7 +64,13 @@ class SelectBox extends React.Component {
     return (
       <div style={{ width: '100%' }} id={id}>
         <div className='dropdown'>
-          <button className={`btn btn-default dropdown-toggle ${style['dropdown-button']} ${validationClass}`} type='button' data-toggle='dropdown' id={`${id}-button-toggle`}>
+          <button
+            className={`btn btn-default dropdown-toggle ${style['dropdown-button']} ${validationClass}`}
+            type='button'
+            data-toggle='dropdown'
+            id={`${id}-button-toggle`}
+            disabled={disabled}
+          >
             <span className={style['dropdown-button-text']} id={`${id}-button-text`} title={selectedItem && selectedItem.value}>
               {selectedItem ? selectedItem.value : NOBREAK_SPACE}
             </span>
@@ -96,6 +102,7 @@ SelectBox.propTypes = {
   onChange: PropTypes.func.isRequired, // (selectedId: string) => any
   id: PropTypes.string,
   validationState: PropTypes.oneOf([ false, 'default', 'error' ]),
+  disabled: PropTypes.bool,
 }
 
 export default SelectBox

--- a/src/components/VmDetails/cards/DetailsCard/CloudInit/SysprepForm.js
+++ b/src/components/VmDetails/cards/DetailsCard/CloudInit/SysprepForm.js
@@ -1,19 +1,21 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {
-  FormControl,
+  Checkbox,
   ControlLabel,
+  FormControl,
   FormGroup,
 } from 'patternfly-react'
 import { msg } from '_/intl'
 import SelectBox from '../../../../SelectBox'
 import timezones from '_/components/utils/timezones.json'
 
-const SysprepForm = ({ idPrefix, vm, onChange }) => {
+const SysprepForm = ({ idPrefix, vm, onChange, lastInitTimezone }) => {
   const cloudInitHostName = vm.getIn(['cloudInit', 'hostName'])
   const cloudInitPassword = vm.getIn(['cloudInit', 'password'])
-  const cloudInitTimezone = vm.getIn(['cloudInit', 'timezone']) || timezones[0].id
   const cloudInitCustomScript = vm.getIn(['cloudInit', 'customScript'])
+  const enableInitTimezone = !!vm.getIn(['cloudInit', 'timezone']) // true if sysprep timezone set or Configure Timezone checked
+
   return (
     <React.Fragment>
       <FormGroup controlId={`${idPrefix}-cloud-init-hostname`}>
@@ -36,6 +38,16 @@ const SysprepForm = ({ idPrefix, vm, onChange }) => {
           onChange={e => onChange('cloudInitPassword', e.target.value)}
         />
       </FormGroup>
+
+      {/*  Configure Timezone checkbox */}
+      <Checkbox
+        id={`${idPrefix}-sysprep-timezone-config`}
+        checked={enableInitTimezone}
+        onChange={e => onChange('enableInitTimezone', e.target.checked)}
+      >
+        {msg.sysPrepTimezoneConfigure()}
+      </Checkbox>
+
       <FormGroup controlId={`${idPrefix}-cloud-init-timezone`}>
         <ControlLabel>
           {msg.timezone()}
@@ -43,8 +55,9 @@ const SysprepForm = ({ idPrefix, vm, onChange }) => {
         <SelectBox
           id={`${idPrefix}-sysprep-timezone-select`}
           items={timezones}
-          selected={cloudInitTimezone}
+          selected={lastInitTimezone}
           onChange={(selectedId) => onChange('cloudInitTimezone', selectedId)}
+          disabled={!enableInitTimezone}
         />
       </FormGroup>
       <FormGroup controlId={`${idPrefix}-sysprep-custom-script`}>
@@ -65,6 +78,7 @@ SysprepForm.propTypes = {
   idPrefix: PropTypes.string.isRequired,
   vm: PropTypes.object.isRequired,
   onChange: PropTypes.func.isRequired,
+  lastInitTimezone: PropTypes.string.isRequired,
 }
 
 export default SysprepForm

--- a/src/components/VmDetails/cards/DetailsCard/CloudInit/index.js
+++ b/src/components/VmDetails/cards/DetailsCard/CloudInit/index.js
@@ -6,7 +6,7 @@ import FieldRow from '../FieldRow'
 import CloudInitForm from './CloudInitForm'
 import SysprepForm from './SysprepForm'
 
-const CloudInit = ({ idPrefix, vm, isWindows, onChange }) => {
+const CloudInit = ({ idPrefix, vm, isWindows, onChange, lastInitTimezone }) => {
   const cloudInitEnabled = vm.getIn(['cloudInit', 'enabled'])
   return (
     <React.Fragment>
@@ -22,7 +22,7 @@ const CloudInit = ({ idPrefix, vm, isWindows, onChange }) => {
       { cloudInitEnabled && <div style={{ marginTop: '15px' }}>
         {
           isWindows
-            ? <SysprepForm idPrefix={idPrefix} vm={vm} onChange={onChange} />
+            ? <SysprepForm idPrefix={idPrefix} vm={vm} onChange={onChange} lastInitTimezone={lastInitTimezone} />
             : <CloudInitForm idPrefix={idPrefix} vm={vm} onChange={onChange} />
         }
       </div> }
@@ -35,6 +35,7 @@ CloudInit.propTypes = {
   vm: PropTypes.object.isRequired,
   isWindows: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
+  lastInitTimezone: PropTypes.string.isRequired,
 }
 
 export default CloudInit

--- a/src/components/VmDetails/cards/DetailsCard/index.js
+++ b/src/components/VmDetails/cards/DetailsCard/index.js
@@ -89,6 +89,7 @@ NotAvailable.propTypes = {
 }
 
 const DEFAULT_BOOT_DEVICES = List(['hd', null])
+const DEFAULT_GMT_TIMEZONE = timezones.find(timezone => timezone.value.startsWith('(GMT) Greenwich')).id
 
 /*
  * Specific information and details of the VM (status/up-time, data center, cluster,
@@ -115,6 +116,9 @@ class DetailsCard extends React.Component {
       isoList: createIsoList(props.storageDomains, vmDataCenterId),
       clusterList: createClusterList(props.clusters),
       osList: createOsList(vmClusterId, props.clusters, props.operatingSystems),
+
+      enableInitTimezone: !!props.vm.getIn(['cloudInit', 'timezone']), // true if sysprep timezone set or Configure Timezone checkbox checked
+      lastInitTimezone: props.vm.getIn(['cloudInit', 'timezone']) || DEFAULT_GMT_TIMEZONE,
     }
     this.trackUpdates = {}
     this.hotPlugUpdates = {}
@@ -233,6 +237,10 @@ class DetailsCard extends React.Component {
     }
 
     let updates = this.state.vm
+
+    const { enableInitTimezone, lastInitTimezone } = this.state
+    let initTimezoneUpdates = { enableInitTimezone, lastInitTimezone }
+
     const changeQueue = [{ fieldName, value }]
     const { maxNumberOfSockets, maxNumberOfCores, maxNumberOfThreads } = this.props
 
@@ -298,6 +306,8 @@ class DetailsCard extends React.Component {
 
         case 'cloudInitEnabled':
           updates = updates.setIn(['cloudInit', 'enabled'], value)
+          // when sysprep enabled and Configure Timezone checkbox checked, set the sysprep timezone to the last selected one
+          updates = updates.setIn(['cloudInit', 'timezone'], value && enableInitTimezone ? lastInitTimezone : '')
           fieldUpdated = 'cloudInit'
           break
 
@@ -313,6 +323,7 @@ class DetailsCard extends React.Component {
 
         case 'cloudInitTimezone':
           updates = updates.setIn(['cloudInit', 'timezone'], value)
+          initTimezoneUpdates.lastInitTimezone = value // remember the actual change of the sysprep timezone
           fieldUpdated = 'cloudInit'
           break
 
@@ -323,6 +334,12 @@ class DetailsCard extends React.Component {
 
         case 'cloudInitPassword':
           updates = updates.setIn(['cloudInit', 'password'], value)
+          fieldUpdated = 'cloudInit'
+          break
+
+        case 'enableInitTimezone': // Configure Timezone checkbox change
+          updates = updates.setIn(['cloudInit', 'timezone'], value ? lastInitTimezone : '')
+          initTimezoneUpdates.enableInitTimezone = value
           fieldUpdated = 'cloudInit'
           break
 
@@ -422,13 +439,21 @@ class DetailsCard extends React.Component {
 
       if (updates !== this.state.vm) {
         this.trackUpdates[fieldUpdated] = true
-        this.setState({ vm: updates, isDirty: true })
+        this.setState({ vm: updates, isDirty: true, ...initTimezoneUpdates })
       }
     } // for
   }
 
   handleCardOnCancel () {
-    this.setState({ isEditing: false, isDirty: false, correlationId: null, correlatedMessages: null })
+    const cloudInitTimezone = this.props.vm.getIn(['cloudInit', 'timezone'])
+    this.setState({
+      isEditing: false,
+      isDirty: false,
+      correlationId: null,
+      correlatedMessages: null,
+      lastInitTimezone: cloudInitTimezone || DEFAULT_GMT_TIMEZONE,
+      enableInitTimezone: !!cloudInitTimezone,
+    })
     this.props.onEditChange(false)
   }
 
@@ -487,6 +512,10 @@ class DetailsCard extends React.Component {
 
     if (this.trackUpdates['cloudInit']) {
       vmUpdates['cloudInit'] = stateVm.get('cloudInit').toJS()
+      this.setState({
+        enableInitTimezone: vmUpdates['cloudInit'].enabled,
+        lastInitTimezone: vmUpdates['cloudInit'].timezone || DEFAULT_GMT_TIMEZONE,
+      })
     }
 
     if (this.trackUpdates['timeZone']) {
@@ -862,7 +891,7 @@ class DetailsCard extends React.Component {
                           onChange={(e, state) => { this.handleChange('bootMenuEnabled', state) }}
                         />
                       </FieldRow>
-                      <CloudInit idPrefix={idPrefix} vm={vm} onChange={this.handleChange} isWindows={isOsWindows} />
+                      <CloudInit idPrefix={idPrefix} vm={vm} onChange={this.handleChange} isWindows={isOsWindows} lastInitTimezone={this.state.lastInitTimezone} />
                     </Grid>
                   </Col>
                   {/* Second column */}

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -578,6 +578,7 @@ export const messages: { [messageId: string]: MessageType } = {
   },
   sysPrepCustomScript: 'Custom Script',
   sysPrepTimezone: 'Timezone',
+  sysPrepTimezoneConfigure: 'Configure Timezone',
   sysPrepOptions: 'SysPrep Options',
   takeVm: 'Take a Virtual Machine',
   template: 'Template',


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/1276
**Depends on:** https://github.com/oVirt/ovirt-web-ui/pull/1253 (MERGED)

In this PR, we achieve displaying _(GMT) Greenwich Standard Time_ default value in the sysprep timezone dropdown in case of no sysprep timezone value set in the CreateVmWizard. Also the new _Configure Timezone_ checkbox is added to achieve consistency with the Admin Portal's VM Sysprep settings. The same is added in the VM's _Details_ card.

We use different variable to store selected and on-change values. This is intentional, it allows us to achieve the expected behavior - same as in Admin Portal - to see the _(GMT) Greenwich Standard Time_ selected in the drop down in case of no sysprep timezone set (specifically `undefined` or `''`) => these are two different values that we need at the same time. So the selected/displayed sysprep timezone and the one which is actually set cannot be always the same.

This approach also allows us to remember the last selected sysprep timezone in cases when, for example, user disables sysprep completely or decides not to configure the sysprep timezone (and then they can change their mind before creating a VM). In this PR, I followed the behavior in Admin Portal where we remember the last selected value, too, after disabling sysprep or only the sysprep timezone drop down (by _Configure Time Zone_ checkbox):
![tz](https://user-images.githubusercontent.com/13417815/93082314-0272f300-f691-11ea-9cb8-96b9fbe8e41c.png)

---

**Before:**
_Basic settings_ of the CreateVmWizard (together with the https://github.com/oVirt/ovirt-web-ui/pull/1253):
![create_before](https://user-images.githubusercontent.com/13417815/92278285-3281ff80-eef5-11ea-80b8-f92e1d8b7e8d.png)
VM _Details_ card:
![before](https://user-images.githubusercontent.com/13417815/92277272-dfa74880-eef2-11ea-877a-4ce3483b6bee.png)

**After:**
_Basic settings_ of the CreateVmWizard:
![create_after](https://user-images.githubusercontent.com/13417815/92278311-43327580-eef5-11ea-970e-92b5a153aa8d.png)
VM _Details_ card:
![after](https://user-images.githubusercontent.com/13417815/92277280-e33acf80-eef2-11ea-8690-19ad47710956.png)
