### PR TITLE
Increase spacing between Boot Order and VCPU Topology sections in VM Details card

### DIFF
--- a/src/components/VmDetails/cards/DetailsCard/index.js
+++ b/src/components/VmDetails/cards/DetailsCard/index.js
@@ -911,7 +911,7 @@ class DetailsCard extends React.Component {
                         />
                       </FieldRow>
                       {/* VCPU Topology */}
-                      <Row className={style['field-row']}>
+                      <Row className={style['field-row-divide']}>
                         <Col cols={12} className={style['col-label']}>
                           <div>
                             <span>{msg.vcpuTopology()}</span>

--- a/src/components/VmDetails/cards/DetailsCard/style.css
+++ b/src/components/VmDetails/cards/DetailsCard/style.css
@@ -17,6 +17,11 @@
   margin-top: 5px;
 }
 
+.field-row-divide {
+  margin-top: 20px;
+  margin-bottom: 5px;
+}
+
 .col-label {
   font-weight: bold;
   padding-left: 15px; /* 20px + -15px + this = px from edge */


### PR DESCRIPTION
Related comment: https://github.com/oVirt/ovirt-web-ui/issues/1264#issuecomment-676308058

In this PR, I've increased the space between the two sections which are part of the _Advanced Options_ of a VM _Details_ card. I've chosen a simple solution by using `margin-top` and `margin-bottom` css properties, applied on the element with the name of the second section of the second column in Advanced Options (_VCPU Topology_).

This change improves the visual feeling, separates the two sections, so the user can easily distinguish which options belong to which section.

**Before:**
![space_before](https://user-images.githubusercontent.com/13417815/92959391-0114b100-f46c-11ea-8cef-c8c220600e8d.png)

**After:**
![space_after](https://user-images.githubusercontent.com/13417815/92959394-03770b00-f46c-11ea-9b3c-16f568127514.png)
