### PR TITLE
Refactor i18n normalize script to explicitly sort

### DIFF
--- a/scripts/intl/normalize-messages.js
+++ b/scripts/intl/normalize-messages.js
@@ -16,8 +16,12 @@ function main() {
   const stringContent = fs.readFileSync(SOURCE, { encoding: 'utf8' })
   const parsedContent = JSON.parse(stringContent)
   removeEmptyMessages(parsedContent)
-  const serializedContent = stableStringify(parsedContent, { space: 2 }) + '\n'
-  fs.writeFileSync(DESTINATION, serializedContent)
+
+  const pretty = stableStringify(parsedContent, {
+    space: '  ',
+    cmp: (a, b) => { return a.key > b.key ? 1 : -1 }
+  }) + '\n'
+  fs.writeFileSync(DESTINATION, pretty)
   console.log(chalk.green(`[normalize-messages.js] ${DESTINATION} written ✔`))
 }
 


### PR DESCRIPTION
To reduce any confusion about how translated keys are sorted,
add an explicit key sorting function in the stringify call.

Follows up on https://github.com/oVirt/ovirt-web-ui/pull/1287#issuecomment-689677277