### PR TITLE
CreateVmWizard Networking step - Fix saving new nic error

### DIFF
--- a/src/components/CreateVmWizard/steps/Networking.js
+++ b/src/components/CreateVmWizard/steps/Networking.js
@@ -376,7 +376,7 @@ class Networking extends React.Component {
     const editedRow = this.state.editing[rowData.id]
 
     let editingErrors = false
-    for (const errorKey of this.state.editingErrors) {
+    for (const errorKey in this.state.editingErrors) {
       editingErrors = editingErrors || this.state.editingErrors[errorKey]
     }
 


### PR DESCRIPTION
Fixes: #1299 .
The previous syntax includes bug.
I changed Iterator's syntax, now vnic saved successfully