### PR TITLE
TableInlineEditRow -  set button position using row position and fixed row height

### DIFF
--- a/src/components/CreateVmWizard/steps/_TableInlineEditRow.js
+++ b/src/components/CreateVmWizard/steps/_TableInlineEditRow.js
@@ -1,25 +1,30 @@
-import React from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import TableConfirmButtonsRow from 'patternfly-react/dist/js/components/Table/TableConfirmButtonsRow'
-
-const TableInlineEditRow = props => {
-  const buttonsPosition = (window, rowDimensions) => {
+class TableInlineEditRow extends Component {
+  constructor (props) {
+    super(props)
+    this.buttonsPosition = this.buttonsPosition.bind(this)
+    this.rowHeight = undefined
+  }
+  buttonsPosition (window, rowDimensions) {
     const position = {}
+    const modalDomElement = document.querySelectorAll('div.fade.in.modal')
+    const scrolledInPx = modalDomElement.length === 1 ? modalDomElement[0].scrollTop : 0
 
-    if (props.last) {
-      position.bottom = window.height - rowDimensions.top - 1
-    } else {
-      position.top = rowDimensions.bottom
+    if (!this.rowHeight || Math.abs(this.rowHeight - rowDimensions.height) < 10) {
+      this.rowHeight = rowDimensions.height
     }
+
+    position.top = rowDimensions.y + this.rowHeight + scrolledInPx
     position.right = 75 // window.width - rowDimensions.right + 10
 
     console.info('button position', position)
     return position
   }
-
-  const buttonsClassName = props.last ? 'top' : 'bottom'
-
-  return <TableConfirmButtonsRow {...props} buttonsPosition={buttonsPosition} buttonsClassName={buttonsClassName} />
+  render () {
+    return <TableConfirmButtonsRow {...this.props} buttonsPosition={this.buttonsPosition} buttonsClassName={'bottom'} />
+  }
 }
 
 TableInlineEditRow.shouldComponentUpdate = true


### PR DESCRIPTION
**Related issue:** #1258
**Depends on**: https://github.com/oVirt/ovirt-web-ui/pull/1300 (MERGED)

>"Save" (blue-white tick) and "Cancel" buttons "jump" in the Networking step when clicking on them repeatedly while the name remains invalid.

few aliases for the explanation:
Origin: position (x = 0, y = 0)


Before the change we used `rowDimensions.bottom` as the height position (which is the distance from the origin to the Table's row bottom, in Y axis) that value might change in case of error message appeared or in cases we need to include more components in Table's  row.
In this PR we are using the `rowDimensions.y + rowHeight`.
`rowDimensions.y ` is the distance from the origin to the top of the Table's row, in Y axis that probably won't change, `rowHeight` is a fixed value which represents the edited row's height, in case there are no errors etc.. .

I Also changed the "interface" of the TableInlineEditRow component to create a way to set `rowHeight` value dynamically, if you think that is unnecessary tell me and I'll remove it.

Before:
![Before](https://user-images.githubusercontent.com/13417815/87937542-38329b80-ca95-11ea-82f5-7c1068b610dd.png)

After:
![After](https://user-images.githubusercontent.com/64131213/94702049-0156ec80-0346-11eb-93f9-81aac7358c53.gif)



please ignore the fact that we can't save vnics it will be fixed in #1300 .