### PR TITLE
Update minimum ovirt version to 4.4

### DIFF
--- a/src/version.js.in
+++ b/src/version.js.in
@@ -5,7 +5,7 @@ const Product = {
 
   ovirtApiVersionRequired: {
     major: 4,
-    minor: 2,
+    minor: 4,
   },
 }
 


### PR DESCRIPTION
With adding user settings, the minimum rest api level required to
run all of web-ui will be 4.4.  There have been a few other rest
api bugs since 4.2 that solved a few web-ui bugs as well.

See: #1088