### PR TITLE
Update Zanata tools to use the maven plugin

### DIFF
--- a/scripts/intl/intl-zanata-pull.sh
+++ b/scripts/intl/intl-zanata-pull.sh
@@ -1,9 +1,10 @@
 #! /usr/bin/env bash
 [[ -e package.json ]] || cd ../..
 
-JAVA_HOME=$(alternatives --list | grep 'jre_1.8.0[[:space:]]' | cut -f 3)
+JAVA_HOME=$(alternatives --list | grep 'jre_1.8.0' | head -1 | cut -f 3)
+ZANATA_LOCALES=de,es,fr,it,ja,ko,pt-BR,zh-CN,cs
 
-zanata-cli pull \
-    --errors \
-    --pull-type trans \
-    --locales de,es,fr,it,ja,ko,pt-BR,zh-CN,cs
+mvn \
+    org.zanata:zanata-maven-plugin:4.6.2:pull \
+    -Dzanata.pullType="trans" \
+    -Dzanata.locales="$ZANATA_LOCALES"

--- a/scripts/intl/intl-zanata-push.sh
+++ b/scripts/intl/intl-zanata-push.sh
@@ -1,9 +1,10 @@
 #! /usr/bin/env bash
 [[ -e package.json ]] || cd ../..
 
-JAVA_HOME=$(alternatives --list | grep 'jre_1.8.0[[:space:]]' | cut -f 3)
+JAVA_HOME=$(alternatives --list | grep 'jre_1.8.0' | head -1 | cut -f 3)
+ZANATA_LOCALES=de,es,fr,it,ja,ko,pt-BR,zh-CN,cs
 
-zanata-cli push \
-    --errors \
-    --push-type source \
-    --locales de,es,fr,it,ja,ko,pt-BR,zh-CN,cs
+mvn \
+    org.zanata:zanata-maven-plugin:4.6.2:push \
+    -Dzanata.pushType="source" \
+    -Dzanata.locales="$ZANATA_LOCALES"


### PR DESCRIPTION
Since the zanata-cli rpm is old on F30 and may not exist in more
recent Fedora or CentOS releases, the Zanata client used has been
updated.  Now, the Zanata maven plugin is being used.  Java 1.8 is
still a requirement to run the plugin, just like the zanata-cli.