### PR TITLE
VM filter - Makes the filter be case insensitive

### DIFF
--- a/src/utils/vms-filters.js
+++ b/src/utils/vms-filters.js
@@ -2,7 +2,7 @@ import { getOsHumanName } from '../components/utils'
 import { enumMsg } from '_/intl'
 
 const compareMap = {
-  name: (item, filter) => !!filter.find(n => item.get('name').includes(n)),
+  name: (item, filter) => !!filter.find(n => item.get('name').toUpperCase().includes(n.toUpperCase())),
   os: (item, filter) => getOsHumanName(item.getIn(['os', 'type'])) === filter,
   status: (item, filter) => enumMsg('VmStatus', item.get('status')) === filter,
 }


### PR DESCRIPTION
Fixes: [BZ1879655](https://bugzilla.redhat.com/show_bug.cgi?id=1879655)
> Description of problem:
At present, it is not possible to search VM names using case sensitive keys or using partial VM name in VM Portal.
>
>For example, in VM portal, if VM name is,
>
>rhel-python-affinity-1, then it is not possible to search for the VM using simply affinity or Rhel(R is capital, testing for case sensitive)

In this PR I fixed the issues described above.
The issue is divided into 2 sub issues:
1. The filter is not includes vms which the filter string is not in the beginning of their names.
This sub issue is already resolved by #1193 .

2. The filter is case sensitive.
To fix this sub issue we need to make the filter be case insensitive.

To achieve the case insensitivity I tests the filter string and the vm name as upper case strings.
Few screenshots:
**The tested VMs:**
![VMs](https://user-images.githubusercontent.com/64131213/95991315-4ba39780-0e35-11eb-9e19-438cf7e17f44.png)

**Before:**
Lower case search:
![beforeLower](https://user-images.githubusercontent.com/64131213/95991343-53633c00-0e35-11eb-8440-fe7a59baf8e5.png)
Middle sub string search:
![beforeMiddle](https://user-images.githubusercontent.com/64131213/95991347-54946900-0e35-11eb-9393-3c5d3632268b.png)
Case sensitive search:
![beforeUpper](https://user-images.githubusercontent.com/64131213/95991348-54946900-0e35-11eb-9083-02ad140061e5.png)

**After:**
Middle sub string case sensitive search: 
![afterPython](https://user-images.githubusercontent.com/64131213/95991662-b8b72d00-0e35-11eb-8344-43b80025071f.png)
Case sensitive:
![afterRhel](https://user-images.githubusercontent.com/64131213/95991665-b94fc380-0e35-11eb-866e-ff8e8c763b62.png)
