### PR TITLE
CreateVmWizard: Fix error in Review step and set timezone in the Basic settings correctly

### DIFF
--- a/src/components/CreateVmWizard/steps/BasicSettings.js
+++ b/src/components/CreateVmWizard/steps/BasicSettings.js
@@ -276,24 +276,15 @@ class BasicSettings extends React.Component {
     let changes = {}
     switch (field) {
       case 'clusterId':
-        if (value === undefined) {
-          changes.dataCenterId = undefined
-          changes.clusterId = undefined
-          changes.provisionSource = 'template'
-          changes.isoImage = undefined
-          changes.templateId = undefined
-        } else {
-          const templateList = createTemplateList(this.props.templates, value)
-
-          changes.dataCenterId = this.props.clusters.getIn([value, 'dataCenterId'])
-          changes.clusterId = value
-          changes.provisionSource =
+        const templateList = value ? createTemplateList(this.props.templates, value) : []
+        changes.dataCenterId = value ? this.props.clusters.getIn([value, 'dataCenterId']) : undefined
+        changes.clusterId = value
+        changes.provisionSource =
             (templateList.length === 1 && templateList[0].id === this.props.blankTemplateId)
               ? 'iso'
               : 'template'
-          changes.isoImage = undefined
-          changes.templateId = templateList.length === 1 ? this.props.blankTemplateId : undefined
-        }
+        changes.templateId = templateList.length === 1 ? this.props.blankTemplateId : undefined
+        changes.isoImage = undefined
         break
 
       case 'provisionSource':

--- a/src/components/CreateVmWizard/steps/BasicSettings.js
+++ b/src/components/CreateVmWizard/steps/BasicSettings.js
@@ -284,7 +284,7 @@ class BasicSettings extends React.Component {
               ? 'iso'
               : 'template'
         changes.templateId = templateList.length === 1 ? this.props.blankTemplateId : undefined
-        changes.isoImage = undefined
+        changes = { ...changes, ...this.handleProvisionSourceChange(changes.provisionSource) }
         break
 
       case 'provisionSource':

--- a/src/components/CreateVmWizard/steps/BasicSettings.js
+++ b/src/components/CreateVmWizard/steps/BasicSettings.js
@@ -141,6 +141,7 @@ class BasicSettings extends React.Component {
     this.validateForm = this.validateForm.bind(this)
     this.validateVmName = this.validateVmName.bind(this)
     this.mapVCpuTopologyItems = this.mapVCpuTopologyItems.bind(this)
+    this.handleProvisionSourceChange = this.handleProvisionSourceChange.bind(this)
 
     this.fields = {
       select: [
@@ -238,6 +239,29 @@ class BasicSettings extends React.Component {
     })
   }
 
+  handleProvisionSourceChange (provisionSource) {
+    const changes = {}
+    const { defaultValues } = this.props
+
+    changes.provisionSource = provisionSource
+    changes.isoImage = undefined
+    changes.templateId = undefined
+    changes.operatingSystemId = defaultValues.operatingSystemId
+    changes.memory = defaultValues.memory
+    changes.cpus = defaultValues.cpus
+    changes.topology = defaultValues.topology
+    changes.optimizedFor = defaultValues.optimizedFor
+    changes.cloudInitEnabled = defaultValues.initEnabled
+
+    // when changing Provision type to ISO, set the default time zone according to the OS
+    if (changes.provisionSource === 'iso') {
+      changes.timeZone = this.checkTimeZone(changes.operatingSystemId, changes.templateId)
+      changes.initTimezone = '' // reset the sysprep timezone value, we don't support cloud-init TZ yet
+    }
+
+    return changes
+  }
+
   handleChange (field, value, extra) {
     // normalize the value for drop downs with a "-- Select --" option
     if (this.fields.select.includes(field) && value === '_') {
@@ -249,7 +273,7 @@ class BasicSettings extends React.Component {
       value = !!value || value === 'on'
     }
 
-    const changes = {}
+    let changes = {}
     switch (field) {
       case 'clusterId':
         if (value === undefined) {
@@ -273,20 +297,7 @@ class BasicSettings extends React.Component {
         break
 
       case 'provisionSource':
-        changes.provisionSource = value
-        changes.isoImage = undefined
-        changes.templateId = undefined
-        changes.operatingSystemId = this.props.defaultValues.operatingSystemId
-        changes.memory = this.props.defaultValues.memory
-        changes.cpus = this.props.defaultValues.cpus
-        changes.topology = this.props.defaultValues.topology
-        changes.optimizedFor = this.props.defaultValues.optimizedFor
-        changes.cloudInitEnabled = this.props.defaultValues.initEnabled
-
-        // when changing Provision type to ISO, set the default time zone according to the OS
-        if (changes.provisionSource === 'iso') {
-          changes.timeZone = this.checkTimeZone(changes.operatingSystemId, changes.templateId)
-        }
+        changes = this.handleProvisionSourceChange(value)
         break
 
       case 'templateId':


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/1308

Error has occurred after trying to move to the _Review_ step of the Create VM Wizard in a specific scenario when _Provision source_ was set to _ISO_ (see the exact steps to reproduce [here](https://github.com/oVirt/ovirt-web-ui/issues/1308#issue-720876530)). This PR fixes it.

The core of the problem was displaying the [timezone name here](https://github.com/oVirt/ovirt-web-ui/blob/master/src/components/CreateVmWizard/steps/SummaryReview.js#L61) in the _Review_ step, but the `timeZone` was `undefined`. Why? Well, actually the only possible places, where the timezone is set, are in some of the cases of the `handleChange` function of the `BasicSettings` component ([for example here](https://github.com/oVirt/ovirt-web-ui/blob/master/src/components/CreateVmWizard/steps/BasicSettings.js#L304)). But if those cases are not reached in the scenario we perform (according to the fields we change in the Basic settings), then the timezone is simply not defined.

This could be fixed by more ways, for example by handling the timezone undefined value in the `ReviewBasic` component for displaying the Review step of the wizard. But I've better chosen to add the missing logic into the `handleChange` function. Before that, I've refactored some cases as there's some code which repeats unnecessary. We wanted to refactor/move this logic anyway, as it's getting too complicated and confused.

First, I've extracted the provision source changes related code in `handleChange` to `handleProvisionSourceChange` function. Added [missing change](https://github.com/oVirt/ovirt-web-ui/pull/1310/files#diff-ecc9f96259bb1bc0ee42cc7ff4de2121caf4ac2bfecc640b2cc798f976565489R259) to reset the sysprep timezone value when changing the provision source to ISO in that function. Simplified the cluster id changes related code and added the `handleProvisionSourceChange`, because it was missing there and causing the error. The provision source is (re)set together with the cluster id change so we need to handle the provision source changes in that situation, too. This will cause setting proper value of the `timeZone` and others.

**Before:** Not possible to reach the Review step, error after clicking on _Next_ in the Storage step:
![before](https://user-images.githubusercontent.com/13417815/96194690-3b7ddc00-0f4b-11eb-88a1-06b66c5f36e6.png)

**After:** The Review step is properly displayed together with the timezone properly set:
![after](https://user-images.githubusercontent.com/13417815/96194696-3f116300-0f4b-11eb-9471-d3fdbed1e604.png)
