### PR TITLE
Make the PF delete icon in the VM details red

### DIFF
--- a/src/index-nomodules.css
+++ b/src/index-nomodules.css
@@ -234,6 +234,10 @@ textarea {
   resize: vertical;
 }
 
+.pficon-delete {
+  color: #C9190B;
+}
+
 /*
  * For Advanced Options/ExpandCollapse pf3 component
  */


### PR DESCRIPTION
**Related comments:**
https://github.com/oVirt/ovirt-web-ui/issues/1199#issuecomment-638970474 (4th suggestion)
https://github.com/oVirt/ovirt-web-ui/issues/1199#issuecomment-640279790

Some time ago, I had an idea to have the bin icon for deletion in a red color: the color would help to distinguish between for example the Edit and Delete icons in the VM Details cards more easily, also it would be more consistent with the red _Remove_ button for deleting an existing VM. I often used to make a mistake and clicked on Edit icon instead of Delete, or the opposite.

We agreed on this suggestion so in this PR, I make all the deletion icons red. A particular patternfly red color, was used of course.

PF colors: https://www.patternfly.org/v4/guidelines/colors

**Before:**
![red_before](https://user-images.githubusercontent.com/13417815/96935820-2feb6180-14c5-11eb-9063-231531dc3d23.png)

**After:**
![red_after](https://user-images.githubusercontent.com/13417815/96935828-337ee880-14c5-11eb-8287-b649a8bac030.png)
