### PR TITLE
AutoFocus on the VM Name field on Create VM, Basic Settings

### DIFF
--- a/src/components/CreateVmWizard/steps/BasicSettings.js
+++ b/src/components/CreateVmWizard/steps/BasicSettings.js
@@ -441,6 +441,7 @@ class BasicSettings extends React.Component {
         <FieldRow label={msg.name()} id={`${idPrefix}-name`} required validationState={indicators.name}>
           <FormControl
             id={`${idPrefix}-name-edit`}
+            autoFocus
             autoComplete='off'
             type='text'
             defaultValue={data.name}


### PR DESCRIPTION
Before, on Create VM, when Basic Settings is displayed, no input fields are focused.

Now, the VM Name input field is auto focused.  With the guided fields functionality, it is less jarring to see a focused empty invalid name.   It also lets a user start typing a name immediately after clicking create without needing another click.

Before:
![screenshot-ghost local dickerson-web com_3000-2020 10 27-11_07_30 (1)](https://user-images.githubusercontent.com/3985964/97320900-aa5d0e00-1844-11eb-8c6b-48017f060134.png)

After:
![screenshot-ghost local dickerson-web com_3000-2020 10 27-11_07_30 (3)](https://user-images.githubusercontent.com/3985964/97321007-cc569080-1844-11eb-91e1-b995e10aa47e.png)



