### PR TITLE
Filter the clusters with no architecture and cpu-type attached - CreateVmWizard and Details card

### DIFF
--- a/src/components/CreateVmWizard/steps/BasicSettings.js
+++ b/src/components/CreateVmWizard/steps/BasicSettings.js
@@ -367,7 +367,7 @@ class BasicSettings extends React.Component {
           value: `${cluster.value} (${this.props.dataCenters.find(dc => dc.id === cluster.datacenter).name})`,
         }))
     if (!isValidUid(data.clusterId)) {
-      clusterList.unshift({ id: '_', value: `-- ${msg.createVmWizardSelectCluster()} --` })
+      clusterList.unshift({ id: '_', value: clusterList.length === 0 ? `-- ${msg.noClustersAvailable()} --` : `-- ${msg.createVmWizardSelectCluster()} --` })
       indicators.cluster = !indicators.name && 'error'
     } else {
       delete indicators.cluster
@@ -400,7 +400,7 @@ class BasicSettings extends React.Component {
         .sort((a, b) => localeCompare(a.value, b.value))
       : [ { id: '_', value: `-- ${msg.createVmWizardSelectClusterBeforeISO()} --` } ]
     if (enableIsoSelect && !isValidUid(data.isoImage)) {
-      isoList.unshift({ id: '_', value: `-- ${msg.createVmWizardSelectISO()} --` })
+      isoList.unshift({ id: '_', value: isoList.length === 0 ? `-- ${msg.noCdsAvailable()} --` : `-- ${msg.createVmWizardSelectISO()} --` })
       indicators.isoList = !indicators.provisionSource && !indicators.name && 'error'
     } else {
       delete indicators.isoList

--- a/src/components/VmDetails/cards/DetailsCard/index.js
+++ b/src/components/VmDetails/cards/DetailsCard/index.js
@@ -113,7 +113,7 @@ class DetailsCard extends React.Component {
       promptNextRunChanges: false,
 
       isoList: createIsoList(props.storageDomains, vmDataCenterId),
-      clusterList: createClusterList(props.clusters),
+      clusterList: createClusterList(props.clusters, vmDataCenterId),
       osList: createOsList(vmClusterId, props.clusters, props.operatingSystems),
     }
     this.trackUpdates = {}
@@ -170,13 +170,14 @@ class DetailsCard extends React.Component {
     //       __storageDomains__, and __operatingSystems__ don't need to be kept in state for
     //       change comparison
     const vmClusterId = this.props.vm.getIn(['cluster', 'id'])
+    const vmDataCenterId = this.props.clusters.getIn([vmClusterId, 'dataCenterId'])
 
     if (prevProps.clusters !== this.props.clusters) {
-      this.setState({ clusterList: createClusterList(this.props.clusters) }) // eslint-disable-line react/no-did-update-set-state
+      const { clusters } = this.props
+      this.setState({ clusterList: createClusterList(clusters, vmDataCenterId) }) // eslint-disable-line react/no-did-update-set-state
     }
 
     if (prevProps.storageDomains !== this.props.storageDomains) {
-      const vmDataCenterId = this.props.clusters.getIn([vmClusterId, 'dataCenterId'])
       this.setState({ isoList: createIsoList(this.props.storageDomains, vmDataCenterId) }) // eslint-disable-line react/no-did-update-set-state
     }
 
@@ -734,7 +735,7 @@ class DetailsCard extends React.Component {
                       { isFullEdit && canChangeCluster &&
                         <SelectBox
                           id={`${idPrefix}-cluster-edit`}
-                          items={clusterList.filter(cluster => cluster.datacenter === dataCenterId)}
+                          items={clusterList}
                           selected={clusterId}
                           onChange={(selectedId) => { this.handleChange('cluster', selectedId) }}
                         />

--- a/src/components/utils/build-select-box-lists.js
+++ b/src/components/utils/build-select-box-lists.js
@@ -17,6 +17,9 @@ function createClusterList (clusters, dataCenterId = null) {
       .toList()
       .filter(cluster =>
         cluster.get('canUserUseCluster') &&
+        !!cluster.get('architecture') &&
+        cluster.get('architecture') !== 'undefined' &&
+        !!cluster.get('cpuType') &&
         (dataCenterId === null
           ? true
           : cluster.get('dataCenterId') === dataCenterId)

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -446,6 +446,8 @@ export const messages: { [messageId: string]: MessageType } = {
   nicNoVnicAssigned: 'N/A',
   nicsTooltip: 'Connected VM network interfaces.',
   noActiveStorageDomainInDataCenter: 'There is no active data storage domain in data center "{dataCenterName}"',
+  noCdsAvailable: 'No CDs available',
+  noClustersAvailable: 'No Clusters available',
   noDisks: 'no disks',
   noError: 'No error',
   noMessages: 'There are no notifications to display.',

--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -658,6 +658,7 @@ const Cluster = {
       name: cluster.name,
       dataCenterId: cluster.data_center && cluster.data_center.id,
       architecture: cluster.cpu && cluster.cpu.architecture,
+      cpuType: cluster.cpu && cluster.cpu.type,
 
       memoryPolicy: {
         overCommitPercent:


### PR DESCRIPTION
Fixes: #1313 .

Before, in CreateVMWizard on basic settings step, Cluster's selectBox options included clusters which are not includes any host:

> When creating a new VM on basic settings step, the options for the Cluster menu field are only those clusters that include at least one host (host status is not relevant). The VM can't run on a cluster without any host assigned, so those clusters should be blocked for vms creation..

The issue mentioned only for CreateVmWizard but I found that the same issue can be occurred in edit existing VM dialog.
Now, The Cluster's list includes clusters that include at least one host, I made a little improvement as well, in the Details card the call to `createClusterList` function includes the dataCenterId parameters so it won't filter it in any `render()`.

Before:
![CreateVm](https://user-images.githubusercontent.com/64131213/97440452-27b17d00-1930-11eb-8fa5-06d8a913c6f1.png)

After:
![CreateVm](https://user-images.githubusercontent.com/64131213/97440498-3304a880-1930-11eb-8af9-8e2f5f2be203.png)
