### PR TITLE
Enable DUMMY_LOCALE via "?locale=aa" on URL

### DIFF
--- a/src/intl/initialize.js
+++ b/src/intl/initialize.js
@@ -69,7 +69,7 @@ function coerceToSupportedLocale (locale: string): ?string {
     return 'en'
   }
 
-  if (BASE_LOCALE_SET.has(locale)) {
+  if (BASE_LOCALE_SET.has(locale) || DUMMY_LOCALE === locale) {
     return locale
   }
 


### PR DESCRIPTION
The locale coercion function needs to be aware of the dummy locale
("aa") to allow testing using the dummy locale.  So now the following
should work for testing with the dummy locale:

    > yarn intl:dummy
    > ENGINE_URL=https://localhost:8443/ovit-engine yarn start

 Open VM Portal URL with the dummy locale:
 * http://localhost:3000?locale=aa