### PR TITLE
Create VM - Force template disk storage domain selection and change default diskType for Template and ISO provisioned VMs

### DIFF
--- a/src/components/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/CreateVmWizard/CreateVmWizard.js
@@ -356,7 +356,7 @@ class CreateVmWizard extends React.Component {
               : template.get('disks', List())
                 .map(disk => {
                   const canUserUseStorageDomain =
-                    storageDomains.getIn([ disk.get('storageDomainId'), 'canUserUseDomain' ], false)
+                    !!filteredStorageDomainList.find(sd => sd.id === disk.get('storageDomainId'))
 
                   const diskType = // constrain to values from createDiskTypeList()
                     template.get('type') === 'desktop' // optimizedFor

--- a/src/components/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/CreateVmWizard/CreateVmWizard.js
@@ -348,7 +348,10 @@ class CreateVmWizard extends React.Component {
         }
 
         if (resetDisks) {
-          const { storageDomains } = this.props
+          const dataCenterStorageDomainsList = createStorageDomainList(
+            this.props.storageDomains,
+            this.state.steps.basic.dataCenterId)
+
           draft.steps.storage = {
             updated: (draft.steps.storage.updated + 1),
             disks: !template
@@ -356,7 +359,7 @@ class CreateVmWizard extends React.Component {
               : template.get('disks', List())
                 .map(disk => {
                   const canUserUseStorageDomain =
-                    !!filteredStorageDomainList.find(sd => sd.id === disk.get('storageDomainId'))
+                    !!dataCenterStorageDomainsList.find(sd => sd.id === disk.get('storageDomainId'))
 
                   const diskType = // constrain to values from createDiskTypeList()
                     template.get('type') === 'desktop' // optimizedFor

--- a/src/components/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/CreateVmWizard/CreateVmWizard.js
@@ -348,28 +348,39 @@ class CreateVmWizard extends React.Component {
         }
 
         if (resetDisks) {
-          const filteredStorageDomainList = createStorageDomainList(this.props.storageDomains, this.state.steps.basic.dataCenterId)
+          const { storageDomains } = this.props
           draft.steps.storage = {
             updated: (draft.steps.storage.updated + 1),
             disks: !template
               ? []
               : template.get('disks', List())
-                .map(disk => ({
-                  id: disk.get('attachmentId'),
-                  name: disk.get('name'),
+                .map(disk => {
+                  const canUserUseStorageDomain =
+                    storageDomains.getIn([ disk.get('storageDomainId'), 'canUserUseDomain' ], false)
 
-                  diskId: disk.get('id'),
-                  storageDomainId: disk.get('storageDomainId'),
-                  canUserUseStorageDomain: this.props.storageDomains.getIn([ disk.get('storageDomainId'), 'canUserUseDomain' ], false),
-                  createdFromInvalidTemplate: !filteredStorageDomainList.find(sd => sd.id === disk.get('storageDomainId')),
+                  const diskType = // constrain to values from createDiskTypeList()
+                    template.get('type') === 'desktop' // optimizedFor
+                      ? canUserUseStorageDomain
+                        ? disk.get('sparse') ? 'thin' : 'pre'
+                        : 'pre'
+                      : 'pre'
 
-                  bootable: disk.get('bootable'),
-                  iface: disk.get('iface'),
-                  type: disk.get('type'), // [ image | lun | cinder ]
-                  diskType: disk.get('sparse') ? 'thin' : 'pre', // constrain to values from createDiskTypeList()
-                  size: disk.get('provisionedSize'), // bytes
-                  isFromTemplate: true,
-                }))
+                  return {
+                    id: disk.get('attachmentId'),
+                    name: disk.get('name'),
+
+                    diskId: disk.get('id'),
+                    storageDomainId: disk.get('storageDomainId'),
+                    canUserUseStorageDomain,
+
+                    bootable: disk.get('bootable'),
+                    iface: disk.get('iface'),
+                    type: disk.get('type'), // [ image | lun | cinder ]
+                    diskType,
+                    size: disk.get('provisionedSize'), // bytes
+                    isFromTemplate: true,
+                  }
+                })
                 .toJS(),
           }
         }

--- a/src/components/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/CreateVmWizard/CreateVmWizard.js
@@ -9,6 +9,7 @@ import * as Actions from '_/actions'
 import { generateUnique } from '_/helpers'
 import { msg } from '_/intl'
 import { handleClusterIdChange } from './helpers'
+import { createStorageDomainList } from '_/components/utils'
 
 import NavigationConfirmationModal from '../NavigationConfirmationModal'
 import BasicSettings from './steps/BasicSettings'
@@ -347,6 +348,7 @@ class CreateVmWizard extends React.Component {
         }
 
         if (resetDisks) {
+          const filteredStorageDomainList = createStorageDomainList(this.props.storageDomains, this.state.steps.basic.dataCenterId)
           draft.steps.storage = {
             updated: (draft.steps.storage.updated + 1),
             disks: !template
@@ -359,6 +361,7 @@ class CreateVmWizard extends React.Component {
                   diskId: disk.get('id'),
                   storageDomainId: disk.get('storageDomainId'),
                   canUserUseStorageDomain: this.props.storageDomains.getIn([ disk.get('storageDomainId'), 'canUserUseDomain' ], false),
+                  createdFromInvalidTemplate: !filteredStorageDomainList.find(sd => sd.id === disk.get('storageDomainId')),
 
                   bootable: disk.get('bootable'),
                   iface: disk.get('iface'),

--- a/src/components/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/CreateVmWizard/CreateVmWizard.js
@@ -362,10 +362,8 @@ class CreateVmWizard extends React.Component {
                     !!dataCenterStorageDomainsList.find(sd => sd.id === disk.get('storageDomainId'))
 
                   const diskType = // constrain to values from createDiskTypeList()
-                    template.get('type') === 'desktop' // optimizedFor
-                      ? canUserUseStorageDomain
-                        ? disk.get('sparse') ? 'thin' : 'pre'
-                        : 'pre'
+                    this.state.steps.basic.optimizedFor === 'desktop'
+                      ? disk.get('sparse') ? 'thin' : 'pre'
                       : 'pre'
 
                   return {

--- a/src/components/CreateVmWizard/steps/Storage.js
+++ b/src/components/CreateVmWizard/steps/Storage.js
@@ -579,9 +579,11 @@ class Storage extends React.Component {
       id: idPrefix = 'create-vm-wizard-disks',
       storageDomains,
       disks,
+      dataCenterId,
     } = this.props
 
     const storageDomainList = createStorageDomainList(storageDomains)
+    const dataCenterStorageDomainsList = createStorageDomainList(storageDomains, dataCenterId)
     const enableCreate = storageDomainList.length > 0 && !this.isEditingMode()
 
     const diskList = sortNicsDisks([...disks])
@@ -589,7 +591,10 @@ class Storage extends React.Component {
       .map(disk => {
         disk = this.state.editing[disk.id] || disk
         const sd = storageDomainList.find(sd => sd.id === disk.storageDomainId)
-        const isSdOk = sd && disk.canUserUseStorageDomain
+        const isSdOk = !!sd && (
+          disk.canUserUseStorageDomain ||
+          dataCenterStorageDomainsList.find(sd => sd.id === disk.storageDomainId)
+        )
 
         return {
           ...disk,

--- a/src/components/CreateVmWizard/steps/Storage.js
+++ b/src/components/CreateVmWizard/steps/Storage.js
@@ -30,15 +30,6 @@ import SelectBox from '_/components/SelectBox'
 import style from './style.css'
 import { Tooltip, InfoTooltip } from '_/components/tooltips'
 
-function getDefaultDiskType (vmOptimizedFor) {
-  const diskType =
-    vmOptimizedFor === 'highperformance' ? 'pre'
-      : vmOptimizedFor === 'server' ? 'pre'
-        : 'thin'
-
-  return diskType
-}
-
 const TooltipLabel = ({ id, className, bsStyle = 'default', children }) =>
   <Label
     id={id}
@@ -478,7 +469,6 @@ class Storage extends React.Component {
       dataCenterId,
       vmName,
       disks,
-      optimizedFor,
     } = this.props
 
     // If only 1 storage domain is available, select it automatically
@@ -500,7 +490,7 @@ class Storage extends React.Component {
           bootable: false,
           iface: 'virtio_scsi',
           type: 'image',
-          diskType: getDefaultDiskType(optimizedFor),
+          diskType: 'thin',
 
           size: (diskInitialSizeInGib * 1024 ** 3),
         },

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -134,6 +134,8 @@ export const messages: { [messageId: string]: MessageType } = {
   createVmStorageEmptyTitle: 'No Disks Defined',
   createVmStorageNoEditBootableMessage: 'Disk "{diskName}", defined by the selected template, is set as bootable. This can only be changed after the VM has been created.',
   createVmStorageNoEditHelpMessage: 'This Disk is defined by your selected template and cannot be edited or deleted at creation.',
+  createVmStorageNoStorageDomainAvailable: 'No Storage Domain is available',
+  createVmStorageNoStorageDomainAvailableTooltip: 'This Disk is defined by the selected template, is not currently available to you, and there are no target storage domains available. Please contact your administrator to resolve this problem.',
   createVmStorageSelectDiskType: 'Select a Disk Type',
   createVmStorageSelectStorageDomain: 'Select a Storage Domain',
   createVmStorageTableHeaderBootable: 'Bootable',

--- a/src/sagas/vmChanges.js
+++ b/src/sagas/vmChanges.js
@@ -146,7 +146,6 @@ function* composeAndCreateVm ({ payload: { basic, nics, disks }, meta: { correla
 }
 
 function* composeProvisionSourceIso ({ vm, basic }) {
-  // TODO: Verify that we absolutely need to create VM then change CD.
   const cdrom = {
     fileId: basic.isoImage,
   }
@@ -202,6 +201,7 @@ function* composeProvisionSourceTemplate ({ vm, basic, disks }) {
       // did the storage domain change?
       if (disk.storageDomainId !== templateDisk.get('storageDomainId')) {
         changesToTemplateDisk.sparse = false
+        changesToTemplateDisk.format = 'raw'
         changesToTemplateDisk.storage_domains = {
           storage_domain: [{ id: disk.storageDomainId }],
         }
@@ -212,7 +212,7 @@ function* composeProvisionSourceTemplate ({ vm, basic, disks }) {
         changesToTemplateDisk.sparse = disk.diskType === 'thin'
       }
 
-      if (Object.keys(changesToTemplateDisk) > 1) {
+      if (Object.keys(changesToTemplateDisk).length > 1) {
         vmRequiresClone = true
         merge(vmUpdates, {
           disk_attachments: {

--- a/src/sagas/vmChanges.js
+++ b/src/sagas/vmChanges.js
@@ -60,53 +60,38 @@ function* composeAndCreateVm ({ payload: { basic, nics, disks }, meta: { correla
       }
       : {},
   }
+  let vmRequiresClone = false
 
   // Provision = ISO (setup boot to CD and "insert" the CD after the VM is created)
   let cdrom
   if (basic.provisionSource === 'iso') {
-    // TODO: Verify that we absolutely need to create VM then change CD.
-    cdrom = {
-      fileId: basic.isoImage,
-    }
+    const [ vmUpdates, cdrom_ ] = yield composeProvisionSourceIso({ vm, basic })
 
-    merge(vm, {
-      template: { id: yield select(state => state.config.get('blankTemplateId')) },
-
-      os: {
-        boot: {
-          devices: {
-            device: [ 'cdrom' ],
-          },
-        },
-      },
-    })
+    cdrom = cdrom_
+    merge(vm, vmUpdates)
   }
 
   // Provision = TEMPLATE
   if (basic.provisionSource === 'template') {
-    const template = yield select(state => state.templates.get(basic.templateId))
-    merge(vm, {
-      template: { id: template.get('id') },
+    const [ vmUpdates, vmRequiresClone_ ] = yield composeProvisionSourceTemplate({ vm, basic, disks })
 
-      cpu: {
-        topology: (basic.cpus === template.getIn(['cpu', 'vCPUs']))
-          ? template.getIn(['cpu', 'topology']).toJS()
-          : vm.cpu.topology,
-      },
-    })
+    vmRequiresClone = vmRequiresClone_
+    merge(vm, vmUpdates)
   }
 
   // TODO: TimeZone handling (https://github.com/oVirt/ovirt-web-ui/pull/1118)
+
+  const clone = (
+    (basic.provisionSource === 'template' && basic.optimizedFor !== 'desktop') ||
+    vmRequiresClone
+  )
+  const clonePermissions = basic.provisionSource === 'template'
 
   /*
    * NOTE: The VM create REST service does not handle adding NICs or Disks. Until
    *       the create service supports this, we will add Nics and Disks individually
    *       after the VM has been created and is no longer image locked.
    */
-
-  const clone = false // TODO: Clone from template based on criteria
-  const clonePermissions = basic.provisionSource === 'template'
-
   const newVmId = yield createVm(
     A.createVm({ vm, cdrom, clone, clonePermissions, transformInput: false }, { correlationId })
   )
@@ -116,7 +101,7 @@ function* composeAndCreateVm ({ payload: { basic, nics, disks }, meta: { correla
   }
 
   // Wait for the VM image to be unlocked before adding NICs and Disks
-  yield waitForVmToBeUnlocked(newVmId)
+  yield waitForVmToBeUnlocked(newVmId, clone)
 
   // Assuming NICs cannot be added along with the VM create request, add them now
   yield all(nics.filter(nic => !nic.isFromTemplate).map(nic =>
@@ -131,6 +116,7 @@ function* composeAndCreateVm ({ payload: { basic, nics, disks }, meta: { correla
       },
     }))
   ))
+  // TODO? If cloning, toast notify that NICs have been added.
 
   // Assuming Disks cannot be added along with the VM create request, add them now
   yield all(disks.filter(disk => !disk.isFromTemplate).map(disk =>
@@ -151,11 +137,94 @@ function* composeAndCreateVm ({ payload: { basic, nics, disks }, meta: { correla
       },
     }))
   ))
+  // TODO? If cloning, toast notify that Disks have been added.
 
   // start on create, but after everything else is done...
   if (newVmId !== -1 && basic.startOnCreation) {
     yield put(A.startVm({ vmId: newVmId }))
   }
+}
+
+function* composeProvisionSourceIso ({ vm, basic }) {
+  // TODO: Verify that we absolutely need to create VM then change CD.
+  const cdrom = {
+    fileId: basic.isoImage,
+  }
+
+  const vmUpdates = {
+    template: { id: yield select(state => state.config.get('blankTemplateId')) },
+
+    os: {
+      boot: {
+        devices: {
+          device: [ 'cdrom' ],
+        },
+      },
+    },
+  }
+
+  return [ vmUpdates, cdrom ]
+}
+
+function* composeProvisionSourceTemplate ({ vm, basic, disks }) {
+  const template = yield select(state => state.templates.get(basic.templateId))
+  let vmRequiresClone = false
+
+  const vmUpdates = {
+    template: { id: template.get('id') },
+
+    cpu: {
+      topology: (basic.cpus === template.getIn(['cpu', 'vCPUs']))
+        ? template.getIn(['cpu', 'topology']).toJS()
+        : vm.cpu.topology,
+    },
+  }
+
+  /*
+   * If a template defined disk needs to be created in a storage domain different than
+   * the one defined in the template, of if the disk's sparse value is changed, the
+   * changes need to passed along in the VM create call.
+   *
+   * See: http://ovirt.github.io/ovirt-engine-api-model/master/#services/vms/methods/add
+   */
+  disks
+    .filter(disk => disk.isFromTemplate)
+    .forEach(disk => {
+      const templateDisk = template.get('disks').find(tdisk => tdisk.get('id') === disk.id)
+      if (!templateDisk) {
+        return
+      }
+
+      const changesToTemplateDisk = {
+        id: disk.id,
+      }
+
+      // did the storage domain change?
+      if (disk.storageDomainId !== templateDisk.get('storageDomainId')) {
+        changesToTemplateDisk.sparse = false
+        changesToTemplateDisk.storage_domains = {
+          storage_domain: [{ id: disk.storageDomainId }],
+        }
+      }
+
+      // did the diskType (disk's sparse ) change?  'thin' === sparse, 'pre' === !sparse
+      if ((disk.diskType === 'thin') !== templateDisk.get('sparse')) {
+        changesToTemplateDisk.sparse = disk.diskType === 'thin'
+      }
+
+      if (Object.keys(changesToTemplateDisk) > 1) {
+        vmRequiresClone = true
+        merge(vmUpdates, {
+          disk_attachments: {
+            disk_attachment: [{
+              disk: changesToTemplateDisk,
+            }],
+          },
+        })
+      }
+    })
+
+  return [ vmUpdates, vmRequiresClone ]
 }
 
 /*
@@ -205,10 +274,16 @@ function* createVm (action) {
   return -1
 }
 
-function* waitForVmToBeUnlocked (vmId) {
+/*
+ * Poll at intervals and return when either the number of polling steps has completed,
+ * or when the VM's image is no longer locked.  If the VM is being cloned, use 200 steps.
+ * If not, use 20 steps.  Cloning requires a full copy of the Template disks, so the
+ * process may take a long time.
+ */
+function* waitForVmToBeUnlocked (vmId, isCloning = false) {
   const vm = yield select(state => state.vms.getIn(['vms', vmId]))
   if (vm.get('status') === 'image_locked') {
-    for (let delayMs of delayInMsSteps()) {
+    for (let delayMs of delayInMsSteps(isCloning ? 20 : 200)) {
       yield delay(delayMs)
 
       const check = yield callExternalAction('getVm', Api.getVm, { payload: { vmId } }, true)

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -2,8 +2,17 @@
 import Selectors from '_/selectors'
 import type { ClusterType, PermissionType, VnicProfileType } from '_/ovirtapi/types'
 
-function checkUserPermit (permit: string, permits: Set<string>): boolean {
-  return permits.has(permit)
+function checkUserPermit (permit: string | Array<string>, permits: Set<string>): boolean {
+  if (Array.isArray(permit)) {
+    for (const p of permit) {
+      if (!permits.has(p)) {
+        return false
+      }
+    }
+    return true
+  } else {
+    return permits.has(permit)
+  }
 }
 
 export function canUserChangeCd (permits: Set<string>): boolean {
@@ -31,7 +40,7 @@ export function canUserManipulateSnapshots (permits: Set<string>): boolean {
 }
 
 export function canUserUseStorageDomain (permits: Set<string>): boolean {
-  return checkUserPermit('create_disk', permits)
+  return checkUserPermit([ 'create_disk', 'attach_disk_profile' ], permits)
 }
 
 export function canUserEditVmStorage (permits: Set<string>): boolean {
@@ -64,15 +73,16 @@ export function getUserPermits (permissions: Array<PermissionType>): Set<string>
   const userFilter = Selectors.getFilter()
   const userGroups = Selectors.getUserGroups()
   const userId = Selectors.getUserId()
-  let permits = []
+
+  const permits = new Set()
   permissions.forEach((role) => {
     if (userFilter ||
       (
         (role.groupId && userGroups.includes(role.groupId)) ||
         (role.userId && role.userId === userId)
       )) {
-      role.permits.map((permit) => permit.name).forEach((permit) => permits.push(permit))
+      role.permits.map((permit) => permit.name).forEach((permit) => permits.add(permit))
     }
   })
-  return new Set(permits)
+  return permits
 }


### PR DESCRIPTION
### Overview
Merge diskType PR #1316 and create vm template disk storage domain selection PR #1233 and fix the the VM creation saga.

Now a new VM can be created where a user has access to a template but not to the storage domain of the template's disks.  The saga modifications for diskType handles this scenario properly.

### Disk Type changes
Fixes: #1237

Following the description in issue #1237, change the diskType as per the template VM type and where disks will be created.

Summary of changes:

  - **Storage**: When creating a new disk, default `diskType` to 'thin'.  This matches behavior in VM Details Disk card.

  - **CreateVmWizard**: 
    - **diskType**: When preparing Template Disks for the Storage card, default the disk's `diskType` to the template disk's sparse flag when the template is `optimizedFor` (VM type of) "desktop" ~~and the user can use the disk's storage domain~~.  When `optimizedFor` is not "desktop", ~~or if a "desktop" disk resides in a storage domain the user does not have access to use,~~ set disk type to preallocated.
    - **clone disks**: When `optimizedFor` is Server or if a disk needs to change storage domains, the VM's creation is set to clone the disks.

  - **composeAndCreateVm()** saga: To be able to have a template disk created in a different target storage domain, or to change its `diskType`/sparsity on creation, disks need to specified on the VM's creation JSON object.  The compose sagas and supporting functions now support this kind of creation.

### Storage domain selection for template disks in a storage domain that the creating user does not have disk create permits
Fixes: #1230 

Added validation to storage domain for template defined disks.

Previously, in the case the template's disk is in a storage domain for which the user is not permitted to create a disk the Create Vm Wizard will be displayed with 'UNKNOWN' storage domain.  The user can create this vm with no validation or Error handling.  For example:
![image](https://user-images.githubusercontent.com/64131213/84657556-72cb7600-aee2-11ea-8f4e-d83dd96f19cf.png)

The new feature will force the user to choose new a storage domain for which they can create a disk.  The Storage step will disable the next button as long as the user has not selected a valid storage domain for the template disk.

Initially opening the Storage step, this is the new storage domain dropdown with the disabled "Next" button:
![image](https://user-images.githubusercontent.com/64131213/84658479-f6d22d80-aee3-11ea-9f13-f57358cdeb58.png)

Storage domain dropdown expanded:
![image](https://user-images.githubusercontent.com/64131213/84658697-4284d700-aee4-11ea-9dda-f7aaca5ff8e2.png)

After choosing a storage domain, the "Next" button is enabled:
![image](https://user-images.githubusercontent.com/64131213/84658732-54667a00-aee4-11ea-8228-c282708c2d7c.png)
