### PR TITLE
Add 'yarn intl:check-use' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,8 @@
     "intl:pull": "scripts/intl/intl-zanata-pull.sh",
     "intl:apply": "scripts/intl/intl-apply.sh",
     "intl:report": "babel-node scripts/intl/report.js --presets env,flow",
-    "intl:sync": "babel-node scripts/intl/sync-messages.js --presets env,flow"
+    "intl:sync": "babel-node scripts/intl/sync-messages.js --presets env,flow",
+    "intl:check-use": "scripts/intl/check-message-use.sh"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/scripts/intl/check-message-use.sh
+++ b/scripts/intl/check-message-use.sh
@@ -1,0 +1,32 @@
+#! /usr/bin/env bash
+[[ -e package.json ]] || cd ../..
+
+yarn intl:extract
+
+keys_used=0
+keys_enum=0
+keys_unused=0
+
+while read -ra intlKey; do
+  grep -rq "msg.${intlKey}(" src/*
+  if [[ $? -eq 0 ]]; then
+    echo "Key \"${intlKey}\" is used!"
+    (( keys_used++ ))
+
+  elif [[ "${intlKey}" =~ ^enum_.*_.*$ ]]; then
+    # account for enum_.* keys that are defined like "enum_enumId_enumType" and
+    # used in code like "enumMsg('enumId', 'enumType')"
+    echo "enum key -> \"${intlKey}\""
+    (( keys_enum++ ))
+
+  else
+    echo "UNUSED KEY -> \"${intlKey}\""
+    (( keys_unused++ ))
+
+  fi
+done < <( jq -r '.[] | .id' extra/to-zanata/messages.json )
+
+echo ""
+echo "Keys in use           : $keys_used"
+echo "Keys part of 'enumMsg': $keys_enum"
+echo "Keys NOT in use       : ${keys_unused}"


### PR DESCRIPTION
This script will use `jq` and `grep` to do a simple source search
to check if each message, defined in `src/intl/messages.js`, is
actually used in a source file.  It is helpful to be able to remove
intl message keys that are not being used anymore.