### PR TITLE
Add linting rules for React hooks

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -24,7 +24,8 @@ module.exports = {
 
   plugins: [
     'flowtype',
-    'import'
+    'import',
+    'react-hooks',
   ],
 
   parserOptions: {
@@ -58,6 +59,8 @@ module.exports = {
     'comma-dangle': [2, 'always-multiline'],
     'object-curly-spacing': [2, 'always'],
     'import/no-duplicates': 2,
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
     'flowtype/boolean-style': [
       2,
       'boolean'

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-node": "6.0.1",
     "eslint-plugin-promise": "3.8.0",
     "eslint-plugin-react": "7.8.2",
+    "eslint-plugin-react-hooks": "4.1.2",
     "eslint-plugin-standard": "3.1.0",
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.9.0",

--- a/src/components/VmsList/VmCardList.js
+++ b/src/components/VmsList/VmCardList.js
@@ -71,7 +71,7 @@ const VmCardList = ({ vms, alwaysShowPoolCard, fetchMoreVmsAndPools }) => {
     if (sentinelStillInView) {
       fetchMoreVmsAndPools()
     }
-  }, [ vms ])
+  }, [ vms, scrollerRef, sentinelRef ])
 
   return (
     <div className={style['scroll-container-wrapper']}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4731,6 +4731,11 @@ eslint-plugin-promise@3.8.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz#65ebf27a845e3c1e9d6f6a5622ddd3801694b621"
   integrity sha512-JiFL9UFR15NKpHyGii1ZcvmtIqa3UTwiDAGb8atSffe43qJ3+1czVGN6UtkklpcJ2DVnqvTMzEKRaJdBkAL2aQ==
 
+eslint-plugin-react-hooks@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.1.2.tgz#2eb53731d11c95826ef7a7272303eabb5c9a271e"
+  integrity sha512-ykUeqkGyUGgwTtk78C0o8UG2fzwmgJ0qxBGPp2WqRKsTwcLuVf01kTDRAtOsd4u6whX2XOC8749n2vPydP82fg==
+
 eslint-plugin-react@7.8.2:
   version "7.8.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.8.2.tgz#e95c9c47fece55d2303d1a67c9d01b930b88a51d"


### PR DESCRIPTION
  - Add react-hooks to eslint (same version being used in ovirt-engine-ui-extensions)

  - Enable rules-of-hooks as errors

  - Enable exhaustive-deps as a warning