### PR TITLE
Use DELETE method to remove SSH Public key

### DIFF
--- a/src/ovirtapi/index.js
+++ b/src/ovirtapi/index.js
@@ -481,12 +481,20 @@ const OvirtApi = {
   saveSSHKey ({ key, userId, sshId }: { key: string, userId: string, sshId: ?string }): Promise<Object> {
     assertLogin({ methodName: 'saveSSHKey' })
     const input = JSON.stringify({ content: key })
-    if (sshId !== undefined && sshId !== null) {
+    if (sshId && key) {
+      // update existing key
       return httpPut({
         url: `${AppConfiguration.applicationContext}/api/users/${userId}/sshpublickeys/${sshId}`,
         input,
       })
+    } else if (sshId && !key) {
+      // delete existing key
+      return httpDelete({
+        url: `${AppConfiguration.applicationContext}/api/users/${userId}/sshpublickeys/${sshId}`,
+        input: '',
+      })
     } else {
+      // create new key
       return httpPost({
         url: `${AppConfiguration.applicationContext}/api/users/${userId}/sshpublickeys`,
         input,


### PR DESCRIPTION
Removing the key using PUT(with empty content) is an undocumented
[REST API](http://ovirt.github.io/ovirt-engine-api-model/4.4/#services/ssh_public_key) feature and will be dropped in the future versions of the API.

