### PR TITLE
Fix tooltip propType errors

### DIFF
--- a/src/components/VmDetails/BaseCard.js
+++ b/src/components/VmDetails/BaseCard.js
@@ -164,8 +164,8 @@ BaseCard.propTypes = {
   editMode: PropTypes.bool,
   editable: PropTypes.bool,
   disableSaveButton: PropTypes.bool,
-  editTooltip: PropTypes.oneOfType(Tooltip.propTypes.tooltip),
-  disableTooltip: PropTypes.oneOfType(Tooltip.propTypes.tooltip),
+  editTooltip: PropTypes.oneOfType([ Tooltip.propTypes.tooltip ]),
+  disableTooltip: PropTypes.oneOfType([ Tooltip.propTypes.tooltip ]),
   editTooltipPlacement: Tooltip.propTypes.placement,
 
   onStartEdit: PropTypes.func,

--- a/src/components/VmDetails/CardEditButton.js
+++ b/src/components/VmDetails/CardEditButton.js
@@ -69,10 +69,10 @@ class CardEditButton extends React.Component {
   }
 }
 CardEditButton.propTypes = {
-  tooltip: PropTypes.oneOfType(Tooltip.propTypes.tooltip),
+  tooltip: Tooltip.propTypes.tooltip,
   editEnabled: PropTypes.bool,
   editable: PropTypes.bool,
-  disableTooltip: PropTypes.oneOfType(Tooltip.propTypes.tooltip),
+  disableTooltip: PropTypes.oneOfType([ Tooltip.propTypes.tooltip ]),
   id: PropTypes.string.isRequired,
   onClick: PropTypes.func,
   placement: Tooltip.propTypes.placement,

--- a/src/components/VmDetails/cards/DetailsCard/FieldRow.js
+++ b/src/components/VmDetails/cards/DetailsCard/FieldRow.js
@@ -25,7 +25,7 @@ const FieldRow = ({ label, children, id, tooltip, tooltipPosition }) => (
 FieldRow.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
-  tooltip: PropTypes.oneOfType(Tooltip.propTypes.tooltip),
+  tooltip: PropTypes.oneOfType([ Tooltip.propTypes.tooltip ]),
   children: PropTypes.node.isRequired,
   tooltipPosition: Tooltip.propTypes.placement,
 }


### PR DESCRIPTION
Fixed the use of `PropTypes.oneOfType` to wrap the tooltip
type in an array.  Since the base tooltip propType is required,
this form allows the tooltip to be optional on other components.