### PR TITLE
Prevent duplicate refresh on page change

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -6,6 +6,7 @@ import {
   GET_BY_PAGE,
   GET_OPTION,
   GET_USER_GROUPS,
+  MANUAL_REFRESH,
   SET_ADMINISTRATOR,
   SET_CPU_TOPOLOGY_OPTIONS,
   SET_CURRENT_PAGE,
@@ -45,10 +46,20 @@ export function appConfigured () {
   return { type: APP_CONFIGURED }
 }
 
-export function startSchedulerFixedDelay (delayInSeconds = AppConfiguration.schedulerFixedDelayInSeconds) {
+export function manualRefresh () {
+  return { type: MANUAL_REFRESH }
+}
+
+export function startSchedulerFixedDelay ({
+  delayInSeconds = AppConfiguration.schedulerFixedDelayInSeconds,
+  startDelayInSeconds = AppConfiguration.schedulerFixedDelayInSeconds,
+  targetPage,
+  pageRouterRefresh = false,
+  manualRefresh = false,
+}) {
   return {
     type: START_SCHEDULER_FIXED_DELAY,
-    payload: { delayInSeconds },
+    payload: { delayInSeconds, startDelayInSeconds, targetPage, pageRouterRefresh, manualRefresh },
   }
 }
 

--- a/src/actions/vm.js
+++ b/src/actions/vm.js
@@ -15,6 +15,7 @@ import {
   LOGIN,
   LOGOUT,
   NAVIGATE_TO_VM_DETAILS,
+  NO_REFRESH_TYPE,
   REFRESH_DATA,
   REMOVE_MISSING_VMS,
   REMOVE_VM,
@@ -55,13 +56,20 @@ export function login ({ username, domain, token, userId }) {
 /**
  * I.e. the Refresh button is clicked or scheduler event occurred (polling)
  */
-export function refresh ({ shallowFetch = false, onNavigation = false, onSchedule = false }) {
+export function refresh ({
+  shallowFetch = false,
+  pageRouterRefresh = false,
+  schedulerRefresh = false,
+  manualRefresh = false,
+  targetPage = { type: NO_REFRESH_TYPE } }) {
   return {
     type: REFRESH_DATA,
     payload: {
       shallowFetch,
-      onNavigation,
-      onSchedule,
+      pageRouterRefresh,
+      schedulerRefresh,
+      manualRefresh,
+      targetPage,
     },
   }
 }

--- a/src/components/VmsPageHeader/index.js
+++ b/src/components/VmsPageHeader/index.js
@@ -9,7 +9,7 @@ import UserMenu from './UserMenu'
 import Header from '../Header'
 import { hrefWithoutHistory } from '_/helpers'
 
-import { refresh } from '_/actions'
+import { manualRefresh } from '_/actions'
 import { msg } from '_/intl'
 import { Tooltip } from '../tooltips'
 
@@ -44,8 +44,8 @@ VmsPageHeader.propTypes = {
 }
 
 export default connect(
-  (state) => ({ }),
+  null,
   (dispatch) => ({
-    onRefresh: (page) => dispatch(refresh({ shallowFetch: false })),
+    onRefresh: () => dispatch(manualRefresh()),
   })
 )(VmsPageHeader)

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -49,6 +49,7 @@ export const LOGIN = 'LOGIN'
 export const LOGIN_FAILED = 'LOGIN_FAILED'
 export const LOGIN_SUCCESSFUL = 'LOGIN_SUCCESSFUL'
 export const LOGOUT = 'LOGOUT'
+export const MANUAL_REFRESH = 'MANUAL_REFRESH'
 export const MAX_VM_MEMORY_FACTOR = 4 // see Edit VM flow; magic constant to stay aligned with Web Admin
 export const OPEN_CONSOLE_VM = 'OPEN_CONSOLE_VM'
 export const POOL_ACTION_IN_PROGRESS = 'POOL_ACTION_IN_PROGRESS'


### PR DESCRIPTION
Add following safeguards:
    1. merge 3 possible paths to refresh() into one: via scheduler.
       Both page change and manual refresh will restart the scheduler.
    2. refresh only the page that was used to start the scheduler.
       Subsequent page changes will have no effect on a running scheduler.
    3. check the scheduler ID against the current scheduler count and do a
       self-shutdown if a newer scheduler has been detected
