### PR TITLE
Display only VMs that user is supposed to see after manual refresh

### DIFF
--- a/src/actions/vm.js
+++ b/src/actions/vm.js
@@ -101,6 +101,7 @@ export function getVmsByCount ({ count, shallowFetch = true }) {
     type: GET_VMS,
     payload: {
       shallowFetch,
+      page: 1,
       count,
     },
   }


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/1330

For the regular fetch (which works correctly and is managed through the infinite scroller), `fetchVms` is called in `fetchByPage`, with the `page` set to `1`, at least. For the refresh fetch which doesn't work as expected (manual refresh, clicking on the _Refresh button_), `fetchVms` is called in `refreshListPage` and the `vmsPage` variable is set to `1` there, but although it is set, `page` [is missing](https://github.com/oVirt/ovirt-web-ui/blob/master/src/sagas/background-refresh.js#L88) when calling `fetchVms`, because of the `getVmsByCount` [VM action](https://github.com/oVirt/ovirt-web-ui/blob/master/src/actions/vm.js#L99). So I made a change in this action, set the page to `1` to fix the query which wasn't set correctly and caused displaying the disallowed VMs. Setting the `page` to `1` is ok because we get VMs by count and not by page (`getVmsByPage`) in this case.

**Before:**
![pool_before](https://user-images.githubusercontent.com/13417815/100643044-dc78f880-3339-11eb-817b-671a43838e44.png)

**After:**
![pool_after](https://user-images.githubusercontent.com/13417815/100643051-dedb5280-3339-11eb-94ce-15cb41d13c16.png)

