### PR TITLE
Update parsing of VM statistics (fetched with VM details)

### DIFF
--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -326,12 +326,12 @@ const VmStatistics = {
         stat.values &&
         stat.values.value &&
         (stat.name === 'disks.usage'
-          ? stat.values.value[0].detail || null
+          ? stat.values.value[0] && stat.values.value[0].detail
           : stat.values.value.length === 1
             ? stat.values.value[0].datum
             : stat.values.value.map(value => value.datum))
 
-      if (stat.name === 'disks.usage' && datum !== null) {
+      if (stat.name === 'disks.usage' && !!datum) {
         datum = JSON.parse(datum)
         datum = datum.map(data => {
           data.total = convertInt(data.total)


### PR DESCRIPTION
This commit changes the check for the `disks.usage` statistic
to exclude any falsey datum value from further parsing when
processing a VM's statistics.

With changes on the master branch ovirt-engine from at least 4.4.4.2,
VM statistics for file system usage is responding slightly different.
As a result, the VmStatistics transform code was returning an
`undefined` for the `disks.usage` named statistic instead of the
anticipated `null`. Since the code was explicitly checking for a `null`
value, the `undefined` datum was not excluded from further attempted
parsing.  `undefined` can't be further parsed and the errors happen.

Fixes: #1336