### PR TITLE
Remove fc30 from STDCI

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -1,5 +1,4 @@
 distros:
-  - fc30
   - el8
 release_branches:
   master: ovirt-master


### PR DESCRIPTION
See: https://gerrit.ovirt.org/c/jenkins/+/111994

CI is only testing/building in el8 now.