### PR TITLE
Fix create VM from template bootable disk flag check

### DIFF
--- a/src/components/CreateVmWizard/steps/Storage.js
+++ b/src/components/CreateVmWizard/steps/Storage.js
@@ -424,12 +424,12 @@ class Storage extends React.Component {
     return Object.keys(this.state.editing).length > 0
   }
 
-  // return true if there's any disk set as bootable and if it's a template disk
+  // return true if the VM has any template disks that are set bootable
   isBootableDiskTemplate () {
-    const bootableDisk = this.props.disks.find(disk => disk.bootable)
-    const templateDisk = this.props.disks.find(disk => disk.isFromTemplate)
+    const bootableTemplateDisks = this.props.disks
+      .filter(disk => disk.isFromTemplate && disk.bootable)
 
-    return bootableDisk && templateDisk && bootableDisk === templateDisk
+    return bootableTemplateDisks.length > 0
   }
 
   // set appropriate tooltip message regarding setting bootable flag


### PR DESCRIPTION
In the Create VM Storage step, if any of a VM's template defined disks is marked bootable, then the bootable flag cannot be changed when adding or editing a new disk.

Previously, the `isBootableDiskTemplate` check in the `Storage` component worked for a template provisioned new VM with a single template defined disk, but not for templates that have multiple defined disks.  The check has been updated to handle multiple template defined disks, any of which may be bootable.

Fixes: #1347

Example of how it looks now when adding a disk to a single template defined disk:
![VM Portal - Google Chrome_051](https://user-images.githubusercontent.com/3985964/101947646-d0edc300-3bbe-11eb-981d-9b4479e61ed2.png)

Example of how it looks now when adding a disk to multiple template defined disks:
![VM Portal - Google Chrome_052](https://user-images.githubusercontent.com/3985964/101947666-d945fe00-3bbe-11eb-98ce-7b72eeb50e40.png)

