### PR TITLE
Select The Right "Other OS" operatingSystemId in CreateVmWizard -> BasicSettings according to cluster's cpu architecture.

### DIFF
--- a/src/components/utils/build-select-box-lists.js
+++ b/src/components/utils/build-select-box-lists.js
@@ -1,5 +1,6 @@
 import {
   filterOsByArchitecture,
+  getClusterArchitecture,
   localeCompare,
   templateNameRenderer,
 } from '_/helpers'
@@ -79,10 +80,8 @@ function createOsList (clusterId, clusters, operatingSystems) {
     return []
   }
 
-  const cluster = clusters && clusters.get(clusterId)
-  const architecture = cluster && cluster.get('architecture')
   const osList =
-    filterOsByArchitecture(operatingSystems, architecture)
+    filterOsByArchitecture(operatingSystems, getClusterArchitecture(clusterId, clusters))
       .toList()
       .map(os => ({
         id: os.get('id'),

--- a/src/constants/operatingSystems.js
+++ b/src/constants/operatingSystems.js
@@ -1,0 +1,6 @@
+// default OS for each cluster arch type, usually displayed on ui as "Other OS"
+export const defaultOperatingSystemIds = [
+  '0', // X86
+  '1001', // PPC
+  '2001', // S390
+]

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -246,7 +246,6 @@ export function formatDateFromNow (d) {
 export function filterOsByArchitecture (operatingSystems, architecture) {
   return operatingSystems.filter(os => os.get('architecture') === architecture)
 }
-
 export function getClusterArchitecture (clusterId, clusters) {
   const cluster = clusters && clusters.get(clusterId)
   return cluster && cluster.get('architecture')

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,6 @@
 import { locale as appLocale, msg } from '_/intl'
 import AppConfiguration from '_/config'
+import { defaultOperatingSystemIds } from '_/constants/operatingSystems'
 
 // "payload":{"message":"Not Found","shortMessage":"LOGIN failed","type":404,"action":{"type":"LOGIN","payload":{"credentials":{"username":"admin@internal","password":"admi"}}}}}
 export function hidePassword ({ action, param }) {
@@ -244,6 +245,16 @@ export function formatDateFromNow (d) {
 
 export function filterOsByArchitecture (operatingSystems, architecture) {
   return operatingSystems.filter(os => os.get('architecture') === architecture)
+}
+
+export function getClusterArchitecture (clusterId, clusters) {
+  const cluster = clusters && clusters.get(clusterId)
+  return cluster && cluster.get('architecture')
+}
+
+export function getDefaultOSByArchitecture (operatingSystems, architecture) {
+  const clustersOs = filterOsByArchitecture(operatingSystems, architecture)
+  return clustersOs.find(os => defaultOperatingSystemIds.includes(os.get('id')))
 }
 
 export function findOsByName (operatingSystems, name) {


### PR DESCRIPTION
Fixes: #1307 .
In CreateVmWizrd -> BasicSettings The operating system drop down includes another options according to selected cluster's CPU architecture (even if it's not visible to users, the IDs are different between architectures), But our default value for "Other OS" is not compatible with all the architectures.

To solve this issue I added new helper function that verifies that every time we sets OperatingSystemId property (not by the user) we check if we selected "Other OS" value that is in the list.
If the selected value is Other OS default values or undefined The function will verify the OperatingSystemId if not it will return the original value.

![image](https://user-images.githubusercontent.com/64131213/102099002-7d82ab80-3e30-11eb-9928-21fe6c4483d5.png)
