### PR TITLE
Fix OS error after changing the cluster when editing DetailsCard component

### DIFF
--- a/src/components/VmDetails/cards/DetailsCard/index.js
+++ b/src/components/VmDetails/cards/DetailsCard/index.js
@@ -106,8 +106,10 @@ const DEFAULT_GMT_TIMEZONE = timezones.find(timezone => timezone.value.startsWit
 class DetailsCard extends React.Component {
   constructor (props) {
     super(props)
-    const vmClusterId = props.vm.getIn(['cluster', 'id'])
-    const vmDataCenterId = props.clusters.getIn([vmClusterId, 'dataCenterId'])
+    const { vm, clusters } = props
+    const vmClusterId = vm.getIn(['cluster', 'id'])
+    const vmDataCenterId = clusters.getIn([vmClusterId, 'dataCenterId'])
+    const clusterArchitecture = getClusterArchitecture(vmClusterId, clusters)
 
     this.state = {
       vm: props.vm, // ImmutableJS Map
@@ -121,7 +123,7 @@ class DetailsCard extends React.Component {
       promptNextRunChanges: false,
 
       isoList: createIsoList(props.storageDomains, vmDataCenterId),
-      clusterList: createClusterList(props.clusters, vmDataCenterId),
+      clusterList: createClusterList(props.clusters, vmDataCenterId, clusterArchitecture),
       osList: createOsList(vmClusterId, props.clusters, props.operatingSystems),
 
       enableInitTimezone: !!props.vm.getIn(['cloudInit', 'timezone']), // true if sysprep timezone set or Configure Timezone checkbox checked
@@ -180,12 +182,14 @@ class DetailsCard extends React.Component {
     // NOTE: Doing the following here instead of getDerivedStateFromProps so __clusters__,
     //       __storageDomains__, and __operatingSystems__ don't need to be kept in state for
     //       change comparison
-    const vmClusterId = this.props.vm.getIn(['cluster', 'id'])
-    const vmDataCenterId = this.props.clusters.getIn([vmClusterId, 'dataCenterId'])
+    const { clusters, vm } = this.props
+    const vmClusterId = vm.getIn(['cluster', 'id'])
+    const vmDataCenterId = clusters.getIn([vmClusterId, 'dataCenterId'])
+    const clusterArchitecture = getClusterArchitecture(vmClusterId, clusters)
 
     if (prevProps.clusters !== this.props.clusters) {
       const { clusters } = this.props
-      this.setState({ clusterList: createClusterList(clusters, vmDataCenterId) }) // eslint-disable-line react/no-did-update-set-state
+      this.setState({ clusterList: createClusterList(clusters, vmDataCenterId, clusterArchitecture) }) // eslint-disable-line react/no-did-update-set-state
     }
 
     if (prevProps.storageDomains !== this.props.storageDomains) {

--- a/src/components/VmDetails/cards/DetailsCard/index.js
+++ b/src/components/VmDetails/cards/DetailsCard/index.js
@@ -255,7 +255,6 @@ class DetailsCard extends React.Component {
       maxNumberOfCores,
       maxNumberOfThreads,
       operatingSystems,
-      blankTemplateId,
       clusters,
       templates,
     } = this.props
@@ -269,14 +268,6 @@ class DetailsCard extends React.Component {
         case 'cluster':
           updates = updates.set('cluster', clusters.get(value))
           fieldUpdated = 'cluster'
-
-          // Change the template to 'Blank' if the VM's template isn't in the new cluster
-          {
-            const template = templates.get(updates.getIn(['template', 'id']))
-            if (template && template.get('clusterId') && template.get('clusterId') !== value) {
-              changeQueue.push({ fieldName: 'template', value: blankTemplateId })
-            }
-          }
           break
 
         case 'template':
@@ -1018,7 +1009,6 @@ DetailsCard.propTypes = {
   vms: PropTypes.object.isRequired,
   onEditChange: PropTypes.func,
 
-  blankTemplateId: PropTypes.string.isRequired,
   hosts: PropTypes.object.isRequired,
   clusters: PropTypes.object.isRequired,
   dataCenters: PropTypes.object.isRequired,
@@ -1039,7 +1029,6 @@ DetailsCard.propTypes = {
 
 const DetailsCardConnected = connect(
   (state) => ({
-    blankTemplateId: state.config.get('blankTemplateId'),
     vms: state.vms,
     hosts: state.hosts,
     clusters: state.clusters,

--- a/src/components/utils/build-select-box-lists.js
+++ b/src/components/utils/build-select-box-lists.js
@@ -11,7 +11,7 @@ import { EMPTY_VNIC_PROFILE_ID } from '_/constants'
  * Return a normalized and sorted list of clusters ready for use in a __SelectBox__ from
  * the Map of provided clusters, optionally limiting to clusters in a given data center.
  */
-function createClusterList (clusters, dataCenterId = null) {
+function createClusterList (clusters, dataCenterId = null, architecture = null) {
   const clusterList =
     clusters
       .toList()
@@ -20,9 +20,8 @@ function createClusterList (clusters, dataCenterId = null) {
         !!cluster.get('architecture') &&
         cluster.get('architecture') !== 'undefined' &&
         !!cluster.get('cpuType') &&
-        (dataCenterId === null
-          ? true
-          : cluster.get('dataCenterId') === dataCenterId)
+        (architecture === null || cluster.get('architecture') === architecture) &&
+        (dataCenterId === null || cluster.get('dataCenterId') === dataCenterId)
       )
       .map(cluster => ({
         id: cluster.get('id'),

--- a/src/constants/operatingSystems.js
+++ b/src/constants/operatingSystems.js
@@ -1,0 +1,6 @@
+// default OS for each cluster arch type, usually displayed on ui as "Other OS"
+export const defaultOperatingSystemIds = [
+  '0', // X86
+  '1001', // PPC
+  '2001', // S390
+]

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,6 @@
 import { locale as appLocale, msg } from '_/intl'
 import AppConfiguration from '_/config'
+import { defaultOperatingSystemIds } from '_/constants/operatingSystems'
 
 // "payload":{"message":"Not Found","shortMessage":"LOGIN failed","type":404,"action":{"type":"LOGIN","payload":{"credentials":{"username":"admin@internal","password":"admi"}}}}}
 export function hidePassword ({ action, param }) {
@@ -244,6 +245,16 @@ export function formatDateFromNow (d) {
 
 export function filterOsByArchitecture (operatingSystems, architecture) {
   return operatingSystems.filter(os => os.get('architecture') === architecture)
+}
+
+export function getClusterArchitecture (clusterId, clusters) {
+  const cluster = clusters && clusters.get(clusterId)
+  return cluster && cluster.get('architecture')
+}
+
+export function getDefaultOSByArchitecture (operatingSystems, architecture) {
+  const clustersOs = filterOsByArchitecture(operatingSystems, architecture)
+  return clustersOs.find(os => defaultOperatingSystemIds.includes(os.get('id')))
 }
 
 export function findOsByName (operatingSystems, name) {


### PR DESCRIPTION
This change should fix the issue that mentioned in this [comment](https://github.com/oVirt/ovirt-web-ui/issues/1320#issue-732507158).

The cause of the issue:
In `operatingSystems` there is no entry `'type'`:
![image](https://user-images.githubusercontent.com/64131213/102238182-2519df80-3efe-11eb-81b8-7740bd36414a.png)
As a result `templateOs` will always be `undefined`,
So the requested fix should be, to change it to `'name'`, but it won't work for ppc 64 architecture because any OS has its own id and name and it might cause errors,
for example Other OS for ppc64 has different id from x86_64.
So I used the `'description'` attribute (like I did in #1349 ).

Fixes: #1320 