### PR TITLE
Prevents VM portal crashes on vms/pools filtering

### DIFF
--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -369,7 +369,6 @@ export function* startProgress ({ vmId, poolId, name }) {
 }
 
 export function* stopProgress ({ vmId, poolId, name, result }) {
-  const actionInProgress = vmId ? vmActionInProgress : poolActionInProgress
   if (result && result.status === 'complete') {
     vmId = vmId || result.vm.id
     // do not call 'end of in progress' if successful,
@@ -381,6 +380,7 @@ export function* stopProgress ({ vmId, poolId, name, result }) {
     yield getSingleInstance({ vmId, poolId })
   }
 
+  const actionInProgress = vmId ? vmActionInProgress : poolActionInProgress
   yield put(actionInProgress(Object.assign(vmId ? { vmId } : { poolId }, { name, started: false })))
 }
 


### PR DESCRIPTION
This PR includes changes that should fix the web ui crashes on vms filtering.
The cause:
For the specific scenario of the bug Let’s assume that `vmId == undefined` and `poolId` is a string. 

In this [function]( https://github.com/bamsalem/ovirt-web-ui/blob/5142499b73de6924b30fe573cb7ad9823961aa4e/src/sagas/index.js#L371-L386)
 in [line 372](https://github.com/bamsalem/ovirt-web-ui/blob/5142499b73de6924b30fe573cb7ad9823961aa4e/src/sagas/index.js#L372) the assigned function is `poolActionInProgress` because vmId is undefined but in [line 375](https://github.com/bamsalem/ovirt-web-ui/blob/5142499b73de6924b30fe573cb7ad9823961aa4e/src/sagas/index.js#L375) we define `vmId`.

When we are calling put in [line 385](https://github.com/bamsalem/ovirt-web-ui/blob/5142499b73de6924b30fe573cb7ad9823961aa4e/src/sagas/index.js#L385) we always send `vmId` to `poolActionInProgress` but `poolActionInProgress` expects to get `poolId` as parameter and that’s why ‘poolId = undefined` in https://github.com/bamsalem/ovirt-web-ui/blob/5142499b73de6924b30fe573cb7ad9823961aa4e/src/actions/pool.js#L98-L107 and that how the state's pools looks like:
![undefinedPool](https://user-images.githubusercontent.com/64131213/102778904-0c954380-439c-11eb-8a1c-4dfef292ba72.png)

So when VMS-filter gets the pools list that includes pool that does not contain a `'name'` property, and cannot call toUppercase on undefined.
That was the cause of the crashes, but the root of the crashes is in:
https://github.com/bamsalem/ovirt-web-ui/blob/5142499b73de6924b30fe573cb7ad9823961aa4e/src/sagas/index.js#L371-L386

Fixes: #1352
