### PR TITLE
Add validation messages for VM name and Cloud-init/Sysprep's hostname in CreateVMWizard > BasicSettings

### DIFF
--- a/src/components/CreateVmWizard/steps/BasicSettings.js
+++ b/src/components/CreateVmWizard/steps/BasicSettings.js
@@ -29,6 +29,7 @@ import {
   ExpandCollapse,
   Form,
   FormControl,
+  HelpBlock,
   Checkbox,
 } from 'patternfly-react'
 import { Grid, Row, Col } from '_/components/Grid'
@@ -53,6 +54,7 @@ const FieldRow = ({
   fieldCols = 7,
   children,
   tooltip,
+  errorMessage,
 }) => (
   <Row className={`
       form-group
@@ -69,6 +71,9 @@ const FieldRow = ({
             {label}
           </div>
           <div>{children}</div>
+          {(validationState && errorMessage) &&
+            <HelpBlock>{errorMessage}</HelpBlock>
+          }
         </Col>
       </React.Fragment>
     }
@@ -83,7 +88,12 @@ const FieldRow = ({
             />
           }
         </Col>
-        <Col cols={fieldCols} className={style['col-data']} id={id}>{children}</Col>
+        <Col cols={fieldCols} className={style['col-data']} id={id}>
+          {children}
+          {(validationState && errorMessage) &&
+            <HelpBlock>{errorMessage}</HelpBlock>
+          }
+        </Col>
       </React.Fragment>
     }
   </Row>
@@ -99,6 +109,7 @@ FieldRow.propTypes = {
   fieldCols: PropTypes.number,
   children: PropTypes.node.isRequired,
   tooltip: PropTypes.string,
+  errorMessage: PropTypes.string,
 }
 
 const SubHeading = ({ children }) => (
@@ -302,6 +313,7 @@ class BasicSettings extends React.Component {
     const { data, clusters, maxNumOfSockets, maxNumOfCores, maxNumOfThreads, operatingSystems } = this.props
     const indicators = {
       name: this.validateVmName(),
+      hostName: !isHostNameValid(data.initHostname || ''),
     }
 
     const clusterList =
@@ -382,7 +394,7 @@ class BasicSettings extends React.Component {
     return <Form horizontal id={idPrefix}>
       <Grid className={style['settings-container']}>
         {/* -- VM name and where it will live -- */}
-        <FieldRow label={msg.name()} id={`${idPrefix}-name`} required validationState={indicators.name}>
+        <FieldRow label={msg.name()} id={`${idPrefix}-name`} required validationState={indicators.name} errorMessage={data.name ? msg.pleaseEnterValidVmName() : ''}>
           <FormControl
             id={`${idPrefix}-name-edit`}
             autoFocus
@@ -512,8 +524,13 @@ class BasicSettings extends React.Component {
           <React.Fragment>
             <SubHeading>{msg.cloudInitOptions()}</SubHeading>
 
-            {/* TODO: cloud-init/linux hostname field level validation? */}
-            <FieldRow label={msg.hostName()} id={`${idPrefix}-cloudInitHostname`} vertical>
+            <FieldRow
+              label={msg.hostName()}
+              id={`${idPrefix}-cloudInitHostname`}
+              vertical
+              validationState={data.initHostname && indicators.hostName ? 'error' : undefined}
+              errorMessage={msg.pleaseEnterValidHostName()}
+            >
               <FormControl
                 id={`${idPrefix}-cloudInitHostname-edit`}
                 type='text'
@@ -538,8 +555,13 @@ class BasicSettings extends React.Component {
           <React.Fragment>
             <SubHeading>{msg.sysPrepOptions()}</SubHeading>
 
-            {/* TODO: sysprep/windows hostname field level validation? */}
-            <FieldRow label={msg.hostName()} id={`${idPrefix}-sysPrepHostname`} vertical>
+            <FieldRow
+              label={msg.hostName()}
+              id={`${idPrefix}-sysPrepHostname`}
+              vertical
+              validationState={data.initHostname && indicators.hostName ? 'error' : undefined}
+              errorMessage={msg.pleaseEnterValidHostName()}
+            >
               <FormControl
                 id={`${idPrefix}-sysPrepHostname-edit`}
                 type='text'

--- a/src/components/utils/validation.js
+++ b/src/components/utils/validation.js
@@ -1,12 +1,7 @@
 // @flow
 
 export function isHostNameValid (nameCandidate: string): boolean {
-  if (nameCandidate.length > 64) {
-    return false
-  }
-  const regexpString = '^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$'
-  const regexp = new RegExp(regexpString)
-  return regexp.test(nameCandidate)
+  return /^[a-zA-Z0-9_\-\\.]{1,255}$/.test(nameCandidate)
 }
 
 const UNICODE_NON_ASCII_LETTERS =

--- a/src/components/utils/validation.test.js
+++ b/src/components/utils/validation.test.js
@@ -6,15 +6,17 @@ describe('check host names', function () {
     expect(isHostNameValid('a')).toEqual(true)
     expect(isHostNameValid('a1')).toEqual(true)
     expect(isHostNameValid('abcd-1')).toEqual(true)
+    expect(isHostNameValid('abc_.d-1')).toEqual(true)
+    expect(isHostNameValid('AC.DC')).toEqual(true)
+    expect(isHostNameValid('veryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongname')).toEqual(true)
   })
 
   it('invalid host names', function () {
-    expect(isHostNameValid('..0_0..')).toEqual(false)
-    expect(isHostNameValid('A_b')).toEqual(false)
-    expect(isHostNameValid('AC.DC')).toEqual(false)
-    expect(isHostNameValid('-abc')).toEqual(false)
+    expect(isHostNameValid('..0_ 0..')).toEqual(false)
+    expect(isHostNameValid('!A_b')).toEqual(false)
+    expect(isHostNameValid('#-abc')).toEqual(false)
     expect(isHostNameValid('Кирилиця')).toEqual(false)
-    expect(isHostNameValid('veryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongname')).toEqual(false)
+    expect(isHostNameValid('veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongname')).toEqual(false)
   })
 })
 

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -505,7 +505,8 @@ export const messages: { [messageId: string]: MessageType } = {
   permissionsNoEditThisVm: 'You do not have permissions to edit VM {name} / {vmId}',
   pendingChanges: 'Pending Changes',
   pleaseEnterValidDiskName: 'Please enter a valid disk name. Only lower-case and upper-case letters, numbers, and \'_\',\'-\',\'.\' are allowed.',
-  pleaseEnterValidVmName: 'Please enter a valid virtual machine name. Only lower-case and upper-case letters, numbers, and \'_\',\'-\',\'.\' are allowed.',
+  pleaseEnterValidHostName: "Please enter a valid host name. Only lower-case and upper-case letters, numbers, and '_','-','.' are allowed.",
+  pleaseEnterValidVmName: "Please enter a valid virtual machine name. Only lower-case and upper-case letters, numbers, and '_','-','.' are allowed.",
   preserveDisks: 'Preserve disks',
   pressF11ExitFullScreen: 'Press F11 to exit full screen mode',
   provisionSource: {


### PR DESCRIPTION
This PR adds an error message to VM name in CreateVmWizard > BasicSettings.
The error message doesn't show If the field is empty, the only indication will be a red frame, But when the field isn't Empty and there is an error with the typed name. the error message will appear.
Screenshots:

![Empty](https://user-images.githubusercontent.com/64131213/103273014-eb99a780-49c6-11eb-9b5f-ebdca7aa3af4.png)

![Error](https://user-images.githubusercontent.com/64131213/103273072-14ba3800-49c7-11eb-97b3-e18518368f12.png)

![Valid](https://user-images.githubusercontent.com/64131213/103273036-fe13e100-49c6-11eb-8d41-319316894ed6.png)

Fixes: #1321 .

