### PR TITLE
Filter clusters in CreateVmWizard getInitialState to avoid wrong selection of cluster

### DIFF
--- a/src/components/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/CreateVmWizard/CreateVmWizard.js
@@ -16,6 +16,7 @@ import Networking from './steps/Networking'
 import Storage from './steps/Storage'
 import SummaryReview from './steps/SummaryReview'
 import { EMPTY_VNIC_PROFILE_ID } from '_/constants'
+import { createClusterList } from '_/components/utils'
 
 const DEFAULT_STATE = {
   activeStepIndex: 0,
@@ -76,8 +77,9 @@ const DEFAULT_STATE = {
 function getInitialState ({ clusters, templates, blankTemplateId, operatingSystems, storageDomains, defaultGeneralTimezone, defaultWindowsTimezone }) {
   // 1 cluster available? select it by default
   let changes = {}
-  if (clusters.size === 1) {
-    changes.clusterId = clusters.first().get('id')
+  const clustersList = createClusterList(clusters)
+  if (clustersList.length === 1) {
+    changes.clusterId = clustersList[0].id
   }
 
   // 1 template available (Blank only) on the default cluster? set the source to 'iso'


### PR DESCRIPTION
This PR fixes the issue described by @sandrobonazzola in #1353 .
The issue caused by the feature of auto selection which wasn't considers the filters of the clusters in createVmWizard so it selects the single cluster even if it won't be part of the list.

![image](https://user-images.githubusercontent.com/64131213/104173313-3e834e00-540e-11eb-90cf-7b110f2b358e.png)

Fixes: #1353 .