### PR TITLE
Prevent VM Portal crash on viewing suspending/shut down vm details

### DIFF
--- a/src/components/VmDetails/cards/UtilizationCard/CpuCharts.js
+++ b/src/components/VmDetails/cards/UtilizationCard/CpuCharts.js
@@ -26,7 +26,7 @@ import NoLiveData from './NoLiveData'
  * right.
  */
 const CpuCharts = ({ cpuStats, isRunning, id, vcpus }) => {
-  const cpuUsed = cpuStats['current.total'].datum / vcpus // the average value considering the number of VM CPUs, same as in Admin Portal
+  const cpuUsed = cpuStats['current.total'].firstDatum / vcpus // the average value considering the number of VM CPUs, same as in Admin Portal
   const cpuAvailable = 100 - cpuUsed
 
   // NOTE: CPU history comes sorted from newest to oldest

--- a/src/components/VmDetails/cards/UtilizationCard/MemoryCharts.js
+++ b/src/components/VmDetails/cards/UtilizationCard/MemoryCharts.js
@@ -31,12 +31,12 @@ import NoLiveData from './NoLiveData'
  *       currently used data should work for VMs with and without the guest agent.
  */
 const MemoryCharts = ({ memoryStats, isRunning, id }) => {
-  const available = isRunning ? memoryStats.free.datum : memoryStats.installed.datum
-  const used = !isRunning ? 0 : memoryStats.installed.datum - memoryStats.free.datum
+  const available = isRunning ? memoryStats.free.firstDatum : memoryStats.installed.firstDatum
+  const used = !isRunning ? 0 : memoryStats.installed.firstDatum - memoryStats.free.firstDatum
 
   const usedFormated = userFormatOfBytes(used, null, 1)
   const availableFormated = userFormatOfBytes(available, null, 1)
-  const totalFormated = userFormatOfBytes(memoryStats.installed.datum, null, 1)
+  const totalFormated = userFormatOfBytes(memoryStats.installed.firstDatum, null, 1)
 
   // NOTE: Memory history comes sorted from newest to oldest
   const history = ((memoryStats['usage.history'] && memoryStats['usage.history'].datum) || []).reverse()

--- a/src/components/VmDetails/cards/UtilizationCard/NetworkingCharts.js
+++ b/src/components/VmDetails/cards/UtilizationCard/NetworkingCharts.js
@@ -31,7 +31,7 @@ import NoLiveData from './NoLiveData'
 const NetworkingCharts = ({ netStats, isRunning, id }) => {
   const haveNetworkStats = !!netStats['current.total']
 
-  const used = (netStats['current.total'] && netStats['current.total'].datum) || 0
+  const used = (netStats['current.total'] && netStats['current.total'].firstDatum) || 0
   const available = 100 - used
 
   // NOTE: Network history comes sorted from newest to oldest

--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -305,7 +305,8 @@ const VmStatistics = {
       cpu: {},
       network: {},
       elapsedUptime: {
-        datum: 0,
+        firstDatum: undefined,
+        datum: [ 0 ],
         unit: 'seconds',
         description: 'Elapsed VM runtime (default to 0)',
       },
@@ -314,22 +315,28 @@ const VmStatistics = {
 
     for (const stat: ApiVmStatisticType of statistics) {
       if (stat.name === 'elapsed.time') {
-        base.elapsedUptime.datum = stat.values.value[0].datum
+        base.elapsedUptime.datum = stat.values.value.map((val: any) => val.datum)
+        base.elapsedUptime.firstDatum = base.elapsedUptime.datum[0]
         base.elapsedUptime.description = stat.description
       }
 
       if (stat.kind !== 'gauge') continue
 
-      // no values -> undefined, 1 value -> value.datum, >1 values -> [...values.datum]
-      // ?disks.usage -> {detail...}
-      let datum: any =
-        stat.values &&
-        stat.values.value &&
-        (stat.name === 'disks.usage'
-          ? stat.values.value[0] && stat.values.value[0].detail
-          : stat.values.value.length === 1
-            ? stat.values.value[0].datum
-            : stat.values.value.map(value => value.datum))
+      // no values -> undefined, >0 value -> [...values.datum]
+      let datum: any
+      if (stat.values && stat.values.value) {
+        if (stat.type === 'decimal' || stat.type === 'integer') {
+          datum = Array.isArray(stat.values.value)
+            ? stat.values.value.map((val: any) => val.datum)
+            : [stat.values.value.datum]
+        }
+
+        if (stat.type === 'string') {
+          datum = Array.isArray(stat.values.value)
+            ? stat.values.value.map((val: any) => val.detail)
+            : [stat.values.value.detail]
+        }
+      }
 
       if (stat.name === 'disks.usage' && !!datum) {
         datum = JSON.parse(datum)
@@ -339,9 +346,16 @@ const VmStatistics = {
           return data
         })
       }
+
+      const firstDatum: any =
+        (datum && datum.length > 0)
+          ? datum[0]
+          : undefined
+
       const nameParts = /^(memory|cpu|network|disks)\.(.*)?$/.exec(stat.name)
       if (nameParts) {
         base[nameParts[1]][nameParts[2]] = {
+          firstDatum,
           datum,
           unit: stat.unit,
           description: stat.description,

--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -986,6 +986,7 @@ export {
   Icon,
   VmConsoles,
   VmSessions,
+  VmStatistics,
   CloudInit,
   Permissions,
   Event,

--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -299,7 +299,7 @@ const VM = {
 //
 //
 const VmStatistics = {
-  toInternal ({ statistics }: { statistics: Array<ApiVmStatisticType> }): VmStatisticsType {
+  toInternal ({ statistics = [] }: { statistics: Array<ApiVmStatisticType> } = {}): VmStatisticsType {
     const base: VmStatisticsType = {
       memory: {},
       cpu: {},

--- a/src/ovirtapi/transform.test.js
+++ b/src/ovirtapi/transform.test.js
@@ -1,0 +1,341 @@
+/* eslint-env jest */
+
+import { VmStatistics } from './transform'
+
+const TESTS_DATA = {
+  title: 'Test transform.js VmStatistics.toInternal ',
+  testCases: [
+    {
+      title: 'test case 0',
+      test: [
+        {
+          id: '0',
+          kind: 'gauge',
+          type: 'integer',
+          unit: 'bytes',
+          values: {
+            value: [
+              { datum: 1073741824 },
+            ],
+          },
+          name: 'memory.installed',
+          description: 'Total memory configured',
+        },
+      ],
+      expect: { memory: { installed: { firstDatum: 1073741824, datum: [1073741824], unit: 'bytes', description: 'Total memory configured' } }, cpu: {}, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
+    },
+    {
+      title: 'test case 1',
+      test: [
+        {
+          id: '1',
+          kind: 'gauge',
+          type: 'decimal',
+          unit: 'percent',
+          values: {
+            value: [
+              { datum: 0.61 },
+            ],
+          },
+          name: 'cpu.current.total',
+          description: 'Total CPU used',
+        },
+      ],
+      expect: { memory: {}, cpu: { 'current.total': { firstDatum: 0.61, datum: [0.61], unit: 'percent', description: 'Total CPU used' } }, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
+    },
+    {
+      title: 'test case 2',
+      test: [
+        {
+          id: '2',
+          kind: 'gauge',
+          type: 'string',
+          unit: 'none',
+          values: {
+            value: [
+              {
+                detail: '[{"path":"/boot","total":"952840192","used":"100130816","fs":"ext4"},{"path":"/run/media/sdickers/Fedora-SB-ostree-x86_64-33","total":"2874408960","used":"2874408960","fs":"iso9660"}]',
+              },
+            ],
+          },
+          name: 'disks.usage',
+          description: 'Disk usage, in bytes, per filesystem as JSON (agent)',
+        },
+      ],
+      expect: {
+        memory: {}, cpu: {}, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: { usage: { firstDatum: { path: '/boot', total: 952840192, used: 100130816, fs: 'ext4' }, datum: [{ path: '/boot', total: 952840192, used: 100130816, fs: 'ext4' }, { path: '/run/media/sdickers/Fedora-SB-ostree-x86_64-33', total: 2874408960, used: 2874408960, fs: 'iso9660' }], unit: 'none', description: 'Disk usage, in bytes, per filesystem as JSON (agent)' } } },
+    },
+    {
+      title: 'test case 3',
+      test: [
+        {
+          id: '3',
+          kind: 'counter',
+          type: 'integer',
+          unit: 'seconds',
+          values: {
+            value: [
+              {
+                datum: 1670253,
+              },
+            ],
+          },
+          name: 'elapsed.time',
+          description: 'Elapsed VM runtime',
+        },
+      ],
+      expect: { memory: {}, cpu: {}, network: {}, elapsedUptime: { firstDatum: 1670253, datum: [1670253], unit: 'seconds', description: 'Elapsed VM runtime' }, disks: {} },
+    },
+    {
+      title: 'test case 4',
+      test: [
+        {
+          id: '4',
+          kind: 'gauge',
+          type: 'decimal',
+          unit: 'percent',
+          values: {
+            value: [
+              {
+                datum: 1,
+              },
+              {
+                datum: 2,
+              },
+              {
+                datum: 3,
+              },
+            ],
+          },
+          name: 'memory.usage.history',
+          description: 'List of memory usage history, sorted by date from newest to oldest, at intervals of 30 seconds',
+        },
+      ],
+      expect: { memory: { 'usage.history': { firstDatum: 1, datum: [1, 2, 3], unit: 'percent', description: 'List of memory usage history, sorted by date from newest to oldest, at intervals of 30 seconds' } }, cpu: {}, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
+    },
+    {
+      title: 'test case 5',
+      test: [
+        {
+          id: '5',
+          kind: 'gauge',
+          type: 'integer',
+          unit: 'bytes',
+          values: {
+            value: [
+              {
+                datum: 268435456,
+              },
+            ],
+          },
+          name: 'memory.used.history',
+          description: 'Memory used (agent)',
+        },
+      ],
+      expect: { memory: { 'used.history': { firstDatum: 268435456, datum: [268435456], unit: 'bytes', description: 'Memory used (agent)' } }, cpu: {}, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
+    },
+    {
+      title: 'test case 6',
+      test: [
+        {
+          id: '6',
+          kind: 'gauge',
+          type: 'decimal',
+          unit: 'percent',
+          values: {
+            value: [
+              {
+                datum: 0.74,
+              },
+            ],
+          },
+          name: 'cpu.current.guest',
+          description: 'CPU used by guest',
+        },
+      ],
+      expect: { memory: {}, cpu: { 'current.guest': { firstDatum: 0.74, datum: [0.74], unit: 'percent', description: 'CPU used by guest' } }, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
+    },
+    {
+      title: 'test case 7',
+      test: [
+        {
+          id: '7',
+          kind: 'gauge',
+          type: 'decimal',
+          unit: 'percent',
+          values: {
+            value: [
+              {
+                datum: 0.74,
+              },
+            ],
+          },
+          name: 'cpu.current.hypervisor',
+          description: 'CPU overhead',
+        },
+      ],
+      expect: { memory: {}, cpu: { 'current.hypervisor': { firstDatum: 0.74, datum: [0.74], unit: 'percent', description: 'CPU overhead' } }, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
+    },
+    {
+      title: 'test case 8',
+      test: [
+        {
+          id: '8',
+          kind: 'gauge',
+          type: 'decimal',
+          unit: 'percent',
+          values: {
+            value: [
+              {
+                datum: 0.74,
+              },
+            ],
+          },
+          name: 'cpu.current.hypervisor',
+          description: 'CPU overhead',
+        },
+      ],
+      expect: { memory: {}, cpu: { 'current.hypervisor': { firstDatum: 0.74, datum: [0.74], unit: 'percent', description: 'CPU overhead' } }, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
+    },
+    {
+      title: 'test case 9',
+      test: [
+        {
+          id: '9',
+          kind: 'gauge',
+          type: 'decimal',
+          unit: 'percent',
+          values: {
+            value: [
+              {
+                datum: 0,
+              },
+            ],
+          },
+          name: 'migration.progress',
+          description: 'Migration Progress',
+        },
+      ],
+      expect: { memory: {}, cpu: {}, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
+    },
+    {
+      title: 'test case 10',
+      test: [
+        {
+          id: '10',
+          kind: 'gauge',
+          type: 'integer',
+          unit: 'bytes',
+          values: {
+            value: [
+              {
+                datum: 2158592,
+              },
+            ],
+          },
+          name: 'memory.buffered',
+          description: 'Memory buffered (agent)',
+        },
+      ],
+      expect: { memory: { buffered: { firstDatum: 2158592, datum: [2158592], unit: 'bytes', description: 'Memory buffered (agent)' } }, cpu: {}, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
+    },
+    {
+      title: 'test case 11',
+      test: [
+        {
+          id: '11',
+          kind: 'gauge',
+          type: 'integer',
+          unit: 'bytes',
+          values: {
+            value: [
+              {
+                datum: 702443520,
+              },
+            ],
+          },
+          name: 'memory.free',
+          description: 'Memory free (agent)',
+        },
+      ],
+      expect: { memory: { free: { firstDatum: 702443520, datum: [702443520], unit: 'bytes', description: 'Memory free (agent)' } }, cpu: {}, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
+    },
+    {
+      title: 'test case 12',
+      test: [
+        {
+          id: '12',
+          kind: 'gauge',
+          type: 'decimal',
+          unit: 'percent',
+          values: {
+            value: [
+              {
+                datum: 0,
+              },
+            ],
+          },
+          name: 'network.current.total',
+          description: 'Total network used',
+        },
+      ],
+      expect: { memory: {}, cpu: {}, network: { 'current.total': { firstDatum: 0, datum: [0], unit: 'percent', description: 'Total network used' } }, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
+    },
+    {
+      title: 'test case 13',
+      test: [
+        {
+          id: '13',
+          kind: 'gauge',
+          type: 'decimal',
+          unit: 'percent',
+          values: {
+            value: [
+              { datum: 0 },
+              { datum: 0 },
+              { datum: 0 },
+              { datum: 2 },
+              { datum: 0 },
+              { datum: 0 },
+            ],
+          },
+          name: 'cpu.usage.history',
+          description: 'List of CPU usage history, sorted by date from newest to oldest, at intervals of 30 seconds',
+        },
+      ],
+      expect: { memory: {}, cpu: { 'usage.history': { firstDatum: 0, datum: [0, 0, 0, 2, 0, 0], unit: 'percent', description: 'List of CPU usage history, sorted by date from newest to oldest, at intervals of 30 seconds' } }, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
+    },
+    {
+      title: 'test case 14',
+      test: [
+        {
+          id: '14',
+          kind: 'gauge',
+          type: 'decimal',
+          unit: 'percent',
+          values: {
+            value: [
+              { datum: 0 },
+              { datum: 0 },
+              { datum: 0 },
+              { datum: 0 },
+              { datum: 0 },
+              { datum: 0 },
+            ],
+          },
+          name: 'network.usage.history',
+          description: 'List of CPU usage history, sorted by date from newest to oldest, at intervals of 30 seconds',
+        },
+      ],
+      expect: { memory: {}, cpu: {}, network: { 'usage.history': { firstDatum: 0, datum: [0, 0, 0, 0, 0, 0], unit: 'percent', description: 'List of CPU usage history, sorted by date from newest to oldest, at intervals of 30 seconds' } }, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
+    },
+  ],
+}
+describe(TESTS_DATA.title, () => {
+  describe.each(TESTS_DATA.testCases)('', (testCase) => {
+    test(`testing: ${testCase.title}`, () => {
+      const result = VmStatistics.toInternal({ statistics: testCase.test })
+      expect(result).toEqual(testCase.expect)
+    })
+  })
+})

--- a/src/ovirtapi/transform.test.js
+++ b/src/ovirtapi/transform.test.js
@@ -2,340 +2,522 @@
 
 import { VmStatistics } from './transform'
 
-const TESTS_DATA = {
-  title: 'Test transform.js VmStatistics.toInternal ',
-  testCases: [
+/*
+ * test.each data table:
+ *  [
+ *    [ 'test title', input ApiVmStatisticType, expected partial VmStatisticsType ],
+ *    [ 'test title', input ApiVmStatisticType, expected partial VmStatisticsType ],
+ *    ...
+ *  ]
+ *
+ * NOTE, The ovirt-engine REST API generates statistics for a VM in this Java code:
+ *       https://github.com/oVirt/ovirt-engine/blob/master/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/VmStatisticalQuery.java
+ */
+const TRANSFORM_TESTS = [
+  [
+    'counter, integer - elapsed.time',
     {
-      title: 'test case 0',
-      test: [
-        {
-          id: '0',
-          kind: 'gauge',
-          type: 'integer',
-          unit: 'bytes',
-          values: {
-            value: [
-              { datum: 1073741824 },
-            ],
-          },
-          name: 'memory.installed',
-          description: 'Total memory configured',
-        },
-      ],
-      expect: { memory: { installed: { firstDatum: 1073741824, datum: [1073741824], unit: 'bytes', description: 'Total memory configured' } }, cpu: {}, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
+      id: '3',
+      kind: 'counter',
+      type: 'integer',
+      unit: 'seconds',
+      values: {
+        value: [
+          { datum: 1670253 },
+        ],
+      },
+      name: 'elapsed.time',
+      description: 'Elapsed VM runtime',
     },
     {
-      title: 'test case 1',
-      test: [
-        {
-          id: '1',
-          kind: 'gauge',
-          type: 'decimal',
-          unit: 'percent',
-          values: {
-            value: [
-              { datum: 0.61 },
-            ],
-          },
-          name: 'cpu.current.total',
-          description: 'Total CPU used',
-        },
-      ],
-      expect: { memory: {}, cpu: { 'current.total': { firstDatum: 0.61, datum: [0.61], unit: 'percent', description: 'Total CPU used' } }, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
-    },
-    {
-      title: 'test case 2',
-      test: [
-        {
-          id: '2',
-          kind: 'gauge',
-          type: 'string',
-          unit: 'none',
-          values: {
-            value: [
-              {
-                detail: '[{"path":"/boot","total":"952840192","used":"100130816","fs":"ext4"},{"path":"/run/media/sdickers/Fedora-SB-ostree-x86_64-33","total":"2874408960","used":"2874408960","fs":"iso9660"}]',
-              },
-            ],
-          },
-          name: 'disks.usage',
-          description: 'Disk usage, in bytes, per filesystem as JSON (agent)',
-        },
-      ],
-      expect: {
-        memory: {}, cpu: {}, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: { usage: { firstDatum: { path: '/boot', total: 952840192, used: 100130816, fs: 'ext4' }, datum: [{ path: '/boot', total: 952840192, used: 100130816, fs: 'ext4' }, { path: '/run/media/sdickers/Fedora-SB-ostree-x86_64-33', total: 2874408960, used: 2874408960, fs: 'iso9660' }], unit: 'none', description: 'Disk usage, in bytes, per filesystem as JSON (agent)' } } },
-    },
-    {
-      title: 'test case 3',
-      test: [
-        {
-          id: '3',
-          kind: 'counter',
-          type: 'integer',
-          unit: 'seconds',
-          values: {
-            value: [
-              {
-                datum: 1670253,
-              },
-            ],
-          },
-          name: 'elapsed.time',
-          description: 'Elapsed VM runtime',
-        },
-      ],
-      expect: { memory: {}, cpu: {}, network: {}, elapsedUptime: { firstDatum: 1670253, datum: [1670253], unit: 'seconds', description: 'Elapsed VM runtime' }, disks: {} },
-    },
-    {
-      title: 'test case 4',
-      test: [
-        {
-          id: '4',
-          kind: 'gauge',
-          type: 'decimal',
-          unit: 'percent',
-          values: {
-            value: [
-              {
-                datum: 1,
-              },
-              {
-                datum: 2,
-              },
-              {
-                datum: 3,
-              },
-            ],
-          },
-          name: 'memory.usage.history',
-          description: 'List of memory usage history, sorted by date from newest to oldest, at intervals of 30 seconds',
-        },
-      ],
-      expect: { memory: { 'usage.history': { firstDatum: 1, datum: [1, 2, 3], unit: 'percent', description: 'List of memory usage history, sorted by date from newest to oldest, at intervals of 30 seconds' } }, cpu: {}, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
-    },
-    {
-      title: 'test case 5',
-      test: [
-        {
-          id: '5',
-          kind: 'gauge',
-          type: 'integer',
-          unit: 'bytes',
-          values: {
-            value: [
-              {
-                datum: 268435456,
-              },
-            ],
-          },
-          name: 'memory.used.history',
-          description: 'Memory used (agent)',
-        },
-      ],
-      expect: { memory: { 'used.history': { firstDatum: 268435456, datum: [268435456], unit: 'bytes', description: 'Memory used (agent)' } }, cpu: {}, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
-    },
-    {
-      title: 'test case 6',
-      test: [
-        {
-          id: '6',
-          kind: 'gauge',
-          type: 'decimal',
-          unit: 'percent',
-          values: {
-            value: [
-              {
-                datum: 0.74,
-              },
-            ],
-          },
-          name: 'cpu.current.guest',
-          description: 'CPU used by guest',
-        },
-      ],
-      expect: { memory: {}, cpu: { 'current.guest': { firstDatum: 0.74, datum: [0.74], unit: 'percent', description: 'CPU used by guest' } }, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
-    },
-    {
-      title: 'test case 7',
-      test: [
-        {
-          id: '7',
-          kind: 'gauge',
-          type: 'decimal',
-          unit: 'percent',
-          values: {
-            value: [
-              {
-                datum: 0.74,
-              },
-            ],
-          },
-          name: 'cpu.current.hypervisor',
-          description: 'CPU overhead',
-        },
-      ],
-      expect: { memory: {}, cpu: { 'current.hypervisor': { firstDatum: 0.74, datum: [0.74], unit: 'percent', description: 'CPU overhead' } }, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
-    },
-    {
-      title: 'test case 8',
-      test: [
-        {
-          id: '8',
-          kind: 'gauge',
-          type: 'decimal',
-          unit: 'percent',
-          values: {
-            value: [
-              {
-                datum: 0.74,
-              },
-            ],
-          },
-          name: 'cpu.current.hypervisor',
-          description: 'CPU overhead',
-        },
-      ],
-      expect: { memory: {}, cpu: { 'current.hypervisor': { firstDatum: 0.74, datum: [0.74], unit: 'percent', description: 'CPU overhead' } }, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
-    },
-    {
-      title: 'test case 9',
-      test: [
-        {
-          id: '9',
-          kind: 'gauge',
-          type: 'decimal',
-          unit: 'percent',
-          values: {
-            value: [
-              {
-                datum: 0,
-              },
-            ],
-          },
-          name: 'migration.progress',
-          description: 'Migration Progress',
-        },
-      ],
-      expect: { memory: {}, cpu: {}, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
-    },
-    {
-      title: 'test case 10',
-      test: [
-        {
-          id: '10',
-          kind: 'gauge',
-          type: 'integer',
-          unit: 'bytes',
-          values: {
-            value: [
-              {
-                datum: 2158592,
-              },
-            ],
-          },
-          name: 'memory.buffered',
-          description: 'Memory buffered (agent)',
-        },
-      ],
-      expect: { memory: { buffered: { firstDatum: 2158592, datum: [2158592], unit: 'bytes', description: 'Memory buffered (agent)' } }, cpu: {}, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
-    },
-    {
-      title: 'test case 11',
-      test: [
-        {
-          id: '11',
-          kind: 'gauge',
-          type: 'integer',
-          unit: 'bytes',
-          values: {
-            value: [
-              {
-                datum: 702443520,
-              },
-            ],
-          },
-          name: 'memory.free',
-          description: 'Memory free (agent)',
-        },
-      ],
-      expect: { memory: { free: { firstDatum: 702443520, datum: [702443520], unit: 'bytes', description: 'Memory free (agent)' } }, cpu: {}, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
-    },
-    {
-      title: 'test case 12',
-      test: [
-        {
-          id: '12',
-          kind: 'gauge',
-          type: 'decimal',
-          unit: 'percent',
-          values: {
-            value: [
-              {
-                datum: 0,
-              },
-            ],
-          },
-          name: 'network.current.total',
-          description: 'Total network used',
-        },
-      ],
-      expect: { memory: {}, cpu: {}, network: { 'current.total': { firstDatum: 0, datum: [0], unit: 'percent', description: 'Total network used' } }, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
-    },
-    {
-      title: 'test case 13',
-      test: [
-        {
-          id: '13',
-          kind: 'gauge',
-          type: 'decimal',
-          unit: 'percent',
-          values: {
-            value: [
-              { datum: 0 },
-              { datum: 0 },
-              { datum: 0 },
-              { datum: 2 },
-              { datum: 0 },
-              { datum: 0 },
-            ],
-          },
-          name: 'cpu.usage.history',
-          description: 'List of CPU usage history, sorted by date from newest to oldest, at intervals of 30 seconds',
-        },
-      ],
-      expect: { memory: {}, cpu: { 'usage.history': { firstDatum: 0, datum: [0, 0, 0, 2, 0, 0], unit: 'percent', description: 'List of CPU usage history, sorted by date from newest to oldest, at intervals of 30 seconds' } }, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
-    },
-    {
-      title: 'test case 14',
-      test: [
-        {
-          id: '14',
-          kind: 'gauge',
-          type: 'decimal',
-          unit: 'percent',
-          values: {
-            value: [
-              { datum: 0 },
-              { datum: 0 },
-              { datum: 0 },
-              { datum: 0 },
-              { datum: 0 },
-              { datum: 0 },
-            ],
-          },
-          name: 'network.usage.history',
-          description: 'List of CPU usage history, sorted by date from newest to oldest, at intervals of 30 seconds',
-        },
-      ],
-      expect: { memory: {}, cpu: {}, network: { 'usage.history': { firstDatum: 0, datum: [0, 0, 0, 0, 0, 0], unit: 'percent', description: 'List of CPU usage history, sorted by date from newest to oldest, at intervals of 30 seconds' } }, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
+      elapsedUptime: { firstDatum: 1670253, datum: [1670253], unit: 'seconds', description: 'Elapsed VM runtime' },
     },
   ],
-}
-describe(TESTS_DATA.title, () => {
-  describe.each(TESTS_DATA.testCases)('', (testCase) => {
-    test(`testing: ${testCase.title}`, () => {
-      const result = VmStatistics.toInternal({ statistics: testCase.test })
-      expect(result).toEqual(testCase.expect)
-    })
+
+  [
+    'gauge, string - disks.usage for a stopped VM (or without a guest agent) ',
+    {
+      id: '2',
+      kind: 'gauge',
+      type: 'string',
+      unit: 'none',
+      values: {},
+      name: 'disks.usage',
+      description: 'Disk usage, in bytes, per filesystem as JSON (agent)',
+    },
+    {
+      disks: {
+        usage: {
+          firstDatum: undefined,
+          datum: undefined,
+          unit: 'none',
+          description: 'Disk usage, in bytes, per filesystem as JSON (agent)',
+        },
+      },
+    },
+  ],
+
+  [
+    'gauge, string - disks.usage parsed for a running VM with a guest agent',
+    {
+      id: '2',
+      kind: 'gauge',
+      type: 'string',
+      unit: 'none',
+      values: {
+        value: [
+          {
+            detail: '[{"path":"/boot","total":"952840192","used":"100130816","fs":"ext4"},{"path":"/run/media/sdickers/Fedora-SB-ostree-x86_64-33","total":"2874408960","used":"2874408960","fs":"iso9660"}]',
+          },
+        ],
+      },
+      name: 'disks.usage',
+      description: 'Disk usage, in bytes, per filesystem as JSON (agent)',
+    },
+    {
+      disks: {
+        usage: {
+          firstDatum: { path: '/boot', total: 952840192, used: 100130816, fs: 'ext4' },
+          datum: [
+            { path: '/boot', total: 952840192, used: 100130816, fs: 'ext4' },
+            { path: '/run/media/sdickers/Fedora-SB-ostree-x86_64-33', total: 2874408960, used: 2874408960, fs: 'iso9660' },
+          ],
+          unit: 'none',
+          description: 'Disk usage, in bytes, per filesystem as JSON (agent)',
+        },
+      },
+    },
+  ],
+
+  [
+    'gauge, integer, bytes, single datum - memory.installed',
+    {
+      id: '0',
+      kind: 'gauge',
+      type: 'integer',
+      unit: 'bytes',
+      values: {
+        value: [
+          { datum: 1073741824 },
+        ],
+      },
+      name: 'memory.installed',
+      description: 'Total memory configured',
+    },
+    {
+      memory: {
+        installed: {
+          firstDatum: 1073741824,
+          datum: [1073741824],
+          unit: 'bytes',
+          description: 'Total memory configured',
+        },
+      },
+    },
+  ],
+
+  [
+    'gauge, integer, bytes, single datum - memory.used',
+    {
+      id: '0',
+      kind: 'gauge',
+      type: 'integer',
+      unit: 'bytes',
+      values: {
+        value: [
+          { datum: 1073741824 },
+        ],
+      },
+      name: 'memory.used',
+      description: 'Memory used (agent)',
+    },
+    {
+      memory: {
+        used: {
+          firstDatum: 1073741824,
+          datum: [1073741824],
+          unit: 'bytes',
+          description: 'Memory used (agent)',
+        },
+      },
+    },
+  ],
+
+  [
+    'gauge, integer, bytes, single datum - memory.free',
+    {
+      id: '11',
+      kind: 'gauge',
+      type: 'integer',
+      unit: 'bytes',
+      values: {
+        value: [
+          {
+            datum: 702443520,
+          },
+        ],
+      },
+      name: 'memory.free',
+      description: 'Memory free (agent)',
+    },
+    {
+      memory: {
+        free: {
+          firstDatum: 702443520,
+          datum: [702443520],
+          unit: 'bytes',
+          description: 'Memory free (agent)',
+        },
+      },
+    },
+  ],
+
+  [
+    'gauge, integer, bytes, single datum - memory.buffered',
+    {
+      id: '10',
+      kind: 'gauge',
+      type: 'integer',
+      unit: 'bytes',
+      values: {
+        value: [
+          { datum: 2158592 },
+        ],
+      },
+      name: 'memory.buffered',
+      description: 'Memory buffered (agent)',
+    },
+    {
+      memory: {
+        buffered: {
+          firstDatum: 2158592,
+          datum: [2158592],
+          unit: 'bytes',
+          description: 'Memory buffered (agent)',
+        },
+      },
+    },
+  ],
+
+  [
+    'gauge, decimal, percent, multiple datum - memory.usage.history for a stopped VM',
+    {
+      id: '4',
+      kind: 'gauge',
+      type: 'decimal',
+      unit: 'percent',
+      values: {},
+      name: 'memory.usage.history',
+      description: 'List of memory usage history, sorted by date from newest to oldest, at intervals of 30 seconds',
+    },
+    {
+      memory: {
+        'usage.history': {
+          firstDatum: undefined,
+          datum: undefined,
+          unit: 'percent',
+          description: 'List of memory usage history, sorted by date from newest to oldest, at intervals of 30 seconds',
+        },
+      },
+    },
+  ],
+
+  [
+    'gauge, decimal, percent, multiple datum - memory.usage.history for a running VM',
+    {
+      id: '4',
+      kind: 'gauge',
+      type: 'decimal',
+      unit: 'percent',
+      values: {
+        value: [
+          { datum: 1 },
+          { datum: 2 },
+          { datum: 3 },
+        ],
+      },
+      name: 'memory.usage.history',
+      description: 'List of memory usage history, sorted by date from newest to oldest, at intervals of 30 seconds',
+    },
+    {
+      memory: {
+        'usage.history': {
+          firstDatum: 1,
+          datum: [1, 2, 3],
+          unit: 'percent',
+          description: 'List of memory usage history, sorted by date from newest to oldest, at intervals of 30 seconds',
+        },
+      },
+    },
+  ],
+
+  [
+    'gauge, decimal, percent, single datum - cpu.current.total',
+    {
+      id: '1',
+      kind: 'gauge',
+      type: 'decimal',
+      unit: 'percent',
+      values: {
+        value: [
+          { datum: 0.61 },
+        ],
+      },
+      name: 'cpu.current.total',
+      description: 'Total CPU used',
+    },
+    {
+      cpu: {
+        'current.total': {
+          firstDatum: 0.61,
+          datum: [0.61],
+          unit: 'percent',
+          description: 'Total CPU used',
+        },
+      },
+    },
+  ],
+
+  [
+    'gauge, decimal, percent, single datum - cpu.current.guest',
+    {
+      id: '6',
+      kind: 'gauge',
+      type: 'decimal',
+      unit: 'percent',
+      values: {
+        value: [
+          {
+            datum: 0.74,
+          },
+        ],
+      },
+      name: 'cpu.current.guest',
+      description: 'CPU used by guest',
+    },
+    {
+      cpu: {
+        'current.guest': {
+          firstDatum: 0.74,
+          datum: [0.74],
+          unit: 'percent',
+          description: 'CPU used by guest',
+        },
+      },
+    },
+  ],
+
+  [
+    'gauge, decimal, percent, single datum - cpu.current.hypervisor',
+    {
+      id: '7',
+      kind: 'gauge',
+      type: 'decimal',
+      unit: 'percent',
+      values: {
+        value: [
+          {
+            datum: 0.74,
+          },
+        ],
+      },
+      name: 'cpu.current.hypervisor',
+      description: 'CPU overhead',
+    },
+    {
+      cpu: {
+        'current.hypervisor': {
+          firstDatum: 0.74,
+          datum: [0.74],
+          unit: 'percent',
+          description: 'CPU overhead',
+        },
+      },
+    },
+  ],
+
+  [
+    'gauge, decimal, percent, multiple datum - cpu.usage.history for a stopped VM',
+    {
+      id: '13',
+      kind: 'gauge',
+      type: 'decimal',
+      unit: 'percent',
+      values: {},
+      name: 'cpu.usage.history',
+      description: 'List of CPU usage history, sorted by date from newest to oldest, at intervals of 30 seconds',
+    },
+    {
+      cpu: {
+        'usage.history': {
+          firstDatum: undefined,
+          datum: undefined,
+          unit: 'percent',
+          description: 'List of CPU usage history, sorted by date from newest to oldest, at intervals of 30 seconds',
+        },
+      },
+    },
+  ],
+
+  [
+    'gauge, decimal, percent, multiple datum - cpu.usage.history for a running VM',
+    {
+      id: '13',
+      kind: 'gauge',
+      type: 'decimal',
+      unit: 'percent',
+      values: {
+        value: [
+          { datum: 99 },
+          { datum: 99 },
+          { datum: 5 },
+          { datum: 5 },
+          { datum: 12 },
+          { datum: 2 },
+        ],
+      },
+      name: 'cpu.usage.history',
+      description: 'List of CPU usage history, sorted by date from newest to oldest, at intervals of 30 seconds',
+    },
+    {
+      cpu: {
+        'usage.history': {
+          firstDatum: 99,
+          datum: [99, 99, 5, 5, 12, 2],
+          unit: 'percent',
+          description: 'List of CPU usage history, sorted by date from newest to oldest, at intervals of 30 seconds',
+        },
+      },
+    },
+  ],
+
+  [
+    'gauge, decimal, percent, single datum - migration.progress (not captured, so expect stats base)',
+    {
+      id: '9',
+      kind: 'gauge',
+      type: 'decimal',
+      unit: 'percent',
+      values: {
+        value: [
+          { datum: 0 },
+        ],
+      },
+      name: 'migration.progress',
+      description: 'Migration Progress',
+    },
+    { memory: {}, cpu: {}, network: {}, elapsedUptime: { datum: [0], unit: 'seconds', description: 'Elapsed VM runtime (default to 0)' }, disks: {} },
+  ],
+
+  [
+    'gauge, decimal, percent, single datum - network.current.total',
+    {
+      id: '12',
+      kind: 'gauge',
+      type: 'decimal',
+      unit: 'percent',
+      values: {
+        value: [
+          { datum: 0 },
+        ],
+      },
+      name: 'network.current.total',
+      description: 'Total network used',
+    },
+    {
+      network: {
+        'current.total': {
+          firstDatum: 0,
+          datum: [0],
+          unit: 'percent',
+          description: 'Total network used',
+        },
+      },
+    },
+  ],
+
+  [
+    'gauge, decimal, percent, multiple datum - network.usage.history for a stopped VM',
+    {
+      id: '14',
+      kind: 'gauge',
+      type: 'decimal',
+      unit: 'percent',
+      values: {},
+      name: 'network.usage.history',
+      description: 'List of CPU usage history, sorted by date from newest to oldest, at intervals of 30 seconds',
+    },
+    {
+      network: {
+        'usage.history': {
+          firstDatum: undefined,
+          datum: undefined,
+          unit: 'percent',
+          description: 'List of CPU usage history, sorted by date from newest to oldest, at intervals of 30 seconds',
+        },
+      },
+    },
+  ],
+
+  [
+    'gauge, decimal, percent, multiple datum - network.usage.history for a running VM',
+    {
+      id: '14',
+      kind: 'gauge',
+      type: 'decimal',
+      unit: 'percent',
+      values: {
+        value: [
+          { datum: 0 },
+          { datum: 1 },
+          { datum: 2 },
+          { datum: 3 },
+          { datum: 4 },
+          { datum: 5 },
+        ],
+      },
+      name: 'network.usage.history',
+      description: 'List of CPU usage history, sorted by date from newest to oldest, at intervals of 30 seconds',
+    },
+    {
+      network: {
+        'usage.history': {
+          firstDatum: 0,
+          datum: [0, 1, 2, 3, 4, 5],
+          unit: 'percent',
+          description: 'List of CPU usage history, sorted by date from newest to oldest, at intervals of 30 seconds',
+        },
+      },
+    },
+  ],
+]
+
+describe('Test transform.js VmStatistics.toInternal()', () => {
+  const base = {
+    cpu: {},
+    disks: {},
+    elapsedUptime: { 'datum': [0], 'description': 'Elapsed VM runtime (default to 0)', 'firstDatum': undefined, 'unit': 'seconds' },
+    memory: {},
+    network: {},
+  }
+
+  test('no input gives the base/empty stats', () => {
+    expect(VmStatistics.toInternal()).toEqual(base)
   })
+
+  test('empty input gives the base/empty stats', () => {
+    expect(VmStatistics.toInternal({})).toEqual(base)
+  })
+
+  test('empty statistics gives the base/empty stats', () => {
+    expect(VmStatistics.toInternal({ statistics: [] })).toEqual(base)
+  })
+
+  test.each(TRANSFORM_TESTS)(
+    'transform test [%s]',
+    (title, apiInput, expectedTransformPart) => {
+      const result = VmStatistics.toInternal({ statistics: [ apiInput ] })
+      expect(result).toMatchObject(expectedTransformPart)
+    }
+  )
 })

--- a/src/ovirtapi/types.js
+++ b/src/ovirtapi/types.js
@@ -24,7 +24,8 @@ export type ApiVmStatisticType = {
 }
 
 export type StatisticValueType = {
-  datum: number | Array<number>,
+  firstDatum: number | string | Object | void,
+  datum: Array<number | string | Object>,
   unit: ApiStatisticUnitType,
   description: string
 }

--- a/src/ovirtapi/types.js
+++ b/src/ovirtapi/types.js
@@ -16,10 +16,7 @@ export type ApiVmStatisticType = {
   type: ApiStatisticTypeType,
   unit: ApiStatisticUnitType,
   values: {
-    value: Array<{
-      datum: number,
-      detail?: string
-    }>
+    value: Array<{ datum: number} | { detail: string }>
   }
 }
 


### PR DESCRIPTION
Fixes: #1339 .
The issue described in #1339 caused when the vm is starts and the entry `cpuStats['usage.history'].datum` has only one element, its value represented as a number and not as array with one element...
When this is occur we call `reverse()` on number but the function is undefined and that is the issue that caused web UI crash.

To fix it I changed the transform function `VmStatistics.toInternal` to set array in case of single element instead of set the element.
I'm not sure if it's necessary, but I added validation to check the value of `cpuStats['usage.history'].datum` to prevent future failures.
