### PR TITLE
Remove disk size inconsistent tooltip

### DIFF
--- a/src/components/CreateVmWizard/steps/Storage.js
+++ b/src/components/CreateVmWizard/steps/Storage.js
@@ -18,7 +18,6 @@ import {
   Checkbox,
   DropdownKebab,
   EmptyState,
-  FormGroup,
   FormControl,
   MenuItem,
   Table,
@@ -220,24 +219,18 @@ class Storage extends React.Component {
         editView: (value, { rowData }) => {
           const row = this.state.editing[rowData.id]
           const sizeGiB = row.size / (1024 ** 3)
-          const { invalidSizeValue } = row
 
           return <div className={style['disk-size-edit']}>
-            <FormGroup
-              validationState={invalidSizeValue && 'error'}
-              className={style['form-group-edit']}
-            >
+            <div>
               <FormControl
                 id={`${idPrefix}-${value}-size-edit`}
                 type='number'
-                min={this.props.minDiskSizeInGiB}
-                max={this.props.maxDiskSizeInGiB}
                 step={1}
                 value={sizeGiB}
                 className={style['disk-size-form-control-edit']}
                 onChange={e => this.handleCellChange(rowData, 'size', e.target.value)}
               />
-            </FormGroup>
+            </div>
             <span className={style['disk-size-edit-label']}>GiB</span>
             <div>
               <InfoTooltip id={`${idPrefix}-${value}-size-edit-info-tooltip`} tooltip={msg.diskEditorSizeCreateInfoTooltip()} />
@@ -531,14 +524,9 @@ class Storage extends React.Component {
   handleCellChange (rowData, field, value) {
     const editingRow = this.state.editing[rowData.id]
     if (field === 'size') {
-      if (!isNumber(value)) return
-
       const { minDiskSizeInGiB, maxDiskSizeInGiB } = this.props
-      if (value >= minDiskSizeInGiB && value <= maxDiskSizeInGiB) {
-        delete editingRow.invalidSizeValue
-      } else {
-        editingRow.invalidSizeValue = true
-      }
+      if (!isNumber(value) || value < minDiskSizeInGiB || value > maxDiskSizeInGiB) return
+
       value = +value * (1024 ** 3) // GiB to B
     }
 
@@ -566,7 +554,7 @@ class Storage extends React.Component {
     const actionCreate = !!this.state.creating && this.state.creating === rowData.id
     const editedRow = this.state.editing[rowData.id]
 
-    if (editedRow.invalidSizeValue || editedRow.storageDomainId === '_') return
+    if (editedRow.storageDomainId === '_') return
 
     // if the edited disk is set bootable, make sure to remove bootable from the other disks
     if (editedRow.bootable) {

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -210,7 +210,7 @@ export const messages: { [messageId: string]: MessageType } = {
   },
   diskEditorResizeLabel: 'Increase Size By (GiB)',
   diskEditorSizeCantChangeHelp: 'Disk size cannot be extended for this type of disk.',
-  diskEditorSizeCreateInfoTooltip: 'After creating a disk, you can only extends its size. It is not possible to decrease disk size.',
+  diskEditorSizeCreateInfoTooltip: 'After creating a disk, you can only extend its size. It is not possible to decrease disk size.',
   diskEditorSizeLabel: 'Size (GiB)',
   diskEditorSizeEditLabel: 'Current Size (GiB)',
   diskEditorResizeNote: `After resizing the disk, you must also increase the size of the guest's filesystem`,


### PR DESCRIPTION
The tooltip discussed on #1360 is a side effect of HTML min max validations (the tooltip is part of the input that appears on error).

Like we talked in the meeting I removed the min max values and as well I implemented  the validation in the JS level.
As a result of implementing the validations in the JS level the field’s value can be no value out of range so the notifiers became unnecessary and were removed too.
 the tooltip:
![image](https://user-images.githubusercontent.com/18169498/104946957-9815ea80-59c3-11eb-9dfb-83ad8a80f88b.png)

P.S: It creates the same behavior as edit existing VM disk

Fixes: #1360 .