### PR TITLE
Create VM Wizard - Add support in creating high performance template based VM

### DIFF
--- a/src/components/VmDetails/cards/DetailsCard/index.js
+++ b/src/components/VmDetails/cards/DetailsCard/index.js
@@ -61,7 +61,7 @@ function rephraseVmType (vmType) {
   const types = {
     'desktop': msg.vmType_desktop(),
     'server': msg.vmType_server(),
-    'highperformance': msg.vmType_highPerformance(),
+    'high_performance': msg.vmType_highPerformance(),
   }
 
   const type = vmType.toLowerCase()


### PR DESCRIPTION
Before this PR users couldn't create HP (high performance) template based VM via the web UI even if they had the permissions to do so.

This PR adds the ability to create HP template based VM via web UI.

The VM created by using template is not perfect HP VM (for both, web ui and web admin) because there are few parameters that are not included in the template, but VMs created via web ui and web admin by using the same template are identical so we don't want to block it.

Fixes: #1326 

Before:
![image](https://user-images.githubusercontent.com/64131213/105687206-d7cb5d80-5f00-11eb-9619-acf70b2f38db.png)


After:
![image](https://user-images.githubusercontent.com/64131213/105686714-3ba15680-5f00-11eb-99b7-3ad6a6aa290a.png)
