### PR TITLE
Change refresh interval via Account Settings

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -60,7 +60,7 @@ export function manualRefresh () {
 
 export function startSchedulerFixedDelay ({
   delayInSeconds = AppConfiguration.schedulerFixedDelayInSeconds,
-  startDelayInSeconds = AppConfiguration.schedulerFixedDelayInSeconds,
+  startDelayInSeconds,
   targetPage,
   pageRouterRefresh = false,
   manualRefresh = false,

--- a/src/actions/options.js
+++ b/src/actions/options.js
@@ -84,7 +84,7 @@ export function loadingUserOptionsFinished (): Object {
   }
 }
 
-export function saveGlobalOptions ({ values: { sshKey, language, showNotifications, notificationSnoozeDuration, updateRate } = {} }: Object, { transactionId }: Object): SaveGlobalOptionsActionType {
+export function saveGlobalOptions ({ values: { sshKey, language, showNotifications, notificationSnoozeDuration, refreshInterval } = {} }: Object, { transactionId }: Object): SaveGlobalOptionsActionType {
   return {
     type: C.SAVE_GLOBAL_OPTIONS,
     payload: {
@@ -92,7 +92,7 @@ export function saveGlobalOptions ({ values: { sshKey, language, showNotificatio
       language,
       showNotifications,
       notificationSnoozeDuration,
-      updateRate,
+      refreshInterval,
     },
     meta: {
       transactionId,

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -12,7 +12,7 @@ export type LoadUserOptionsActionType = {
 export type SaveGlobalOptionsActionType = {
   type: C.SAVE_GLOBAL_OPTIONS,
   payload: {|
-    updateRate?: number,
+    refreshInterval?: number,
     language?: string,
     showNotifications?: boolean,
     notificationSnoozeDuration?: number,

--- a/src/components/UserSettings/GlobalSettings.js
+++ b/src/components/UserSettings/GlobalSettings.js
@@ -33,7 +33,7 @@ class GlobalSettings extends Component {
     },
   ]
 
-  updateRateList = [
+  refreshIntervalList = [
     {
       id: 30,
       value: msg.every30Seconds(),
@@ -92,7 +92,7 @@ class GlobalSettings extends Component {
         language: msg.language(),
         showNotifications: msg.dontDisturb(),
         notificationSnoozeDuration: msg.dontDisturbFor(),
-        updateRate: msg.uiRefresh(),
+        refreshInterval: msg.uiRefresh(),
       },
     }
     this.handleCancel = this.handleCancel.bind(this)
@@ -178,6 +178,25 @@ class GlobalSettings extends Component {
           },
         ],
       },
+      refreshInterval: {
+        title: msg.refreshInterval(),
+        tooltip: msg.refreshIntervalTooltip(),
+        fields: [
+          {
+            title: translatedLabels.refreshInterval,
+            body: (
+              <div className={style['half-width']}>
+                <SelectBox
+                  id={`${idPrefix}-update-rate`}
+                  items={this.refreshIntervalList}
+                  selected={draftValues.refreshInterval}
+                  onChange={onChange('refreshInterval')}
+                />
+              </div>
+            ),
+          },
+        ],
+      },
       notifications: {
         title: msg.notifications(),
         tooltip: msg.notificationSettingsAffectAllNotifications(),
@@ -257,7 +276,7 @@ export default connect(
       language: options.getIn(['remoteOptions', 'locale', 'content']),
       showNotifications: options.getIn(['localOptions', 'showNotifications']),
       notificationSnoozeDuration: options.getIn(['localOptions', 'notificationSnoozeDuration']),
-      updateRate: options.getIn(['remoteOptions', 'updateRate', 'content']),
+      refreshInterval: options.getIn(['remoteOptions', 'refreshInterval', 'content']),
     },
     lastTransactionId: options.getIn(['lastTransactions', 'global', 'transactionId'], ''),
   }),

--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -980,10 +980,14 @@ const RemoteUserOptions = {
     vmPortalOptions.forEach(([name, option]) => { fromEntries[name] = option })
 
     // pick only options supported by this version of the UI
-    const { locale } = fromEntries
+    const {
+      locale,
+      refreshInterval,
+    } = fromEntries
 
     return {
       locale,
+      refreshInterval,
     }
   },
 }

--- a/src/ovirtapi/types.js
+++ b/src/ovirtapi/types.js
@@ -164,7 +164,7 @@ export type VmSessionsType = Object
 export type ApiUserType = Object
 
 export type GlobalUserSettingsType = {|
-  updateRate: number,
+  refreshInterval: number,
   language: string,
   showNotifications?: boolean,
   notificationSnoozeDuration?: number
@@ -172,7 +172,7 @@ export type GlobalUserSettingsType = {|
 
 export type RemoteUserOptionsType = {|
   locale: UserOptionType<string>,
-  updateRate?: UserOptionType<number>
+  refreshInterval?: UserOptionType<number>
 |}
 
 export type UserOptionsType = {|

--- a/src/reducers/config.js
+++ b/src/reducers/config.js
@@ -18,6 +18,7 @@ import {
   SET_USER_SESSION_TIMEOUT_INTERVAL,
   SET_WEBSOCKET,
   SHOW_TOKEN_EXPIRED_MSG,
+  REFRESH_DATA,
   SET_GLOBAL_DEFAULT_CONSOLE,
   SET_GLOBAL_DEFAULT_VNC_MODE,
 } from '_/constants'
@@ -54,6 +55,7 @@ const initialState = Immutable.fromJS({
   defaultWindowsTimezone: 'GMT Standard Time',
   websocket: null,
   blankTemplateId: '00000000-0000-0000-0000-000000000000', // "engine/api/" -> special_objects.blank_template.id
+  lastRefresh: 0,
 })
 
 const config = actionReducer(initialState, {
@@ -136,6 +138,9 @@ const config = actionReducer(initialState, {
       defaultGeneralTimezone,
       defaultWindowsTimezone,
     })
+  },
+  [REFRESH_DATA] (state) {
+    return state.set('lastRefresh', Date.now())
   },
   [APP_CONFIGURED] (state) {
     return state.set('appConfigured', true)

--- a/src/reducers/options.js
+++ b/src/reducers/options.js
@@ -20,7 +20,7 @@ const defaultOptions: UserOptionsType = {
       id: undefined,
       content: locale,
     },
-    updateRate: {
+    refreshInterval: {
       id: undefined,
       content: AppConfiguration.schedulerFixedDelayInSeconds,
     },

--- a/src/sagas/options.js
+++ b/src/sagas/options.js
@@ -164,11 +164,17 @@ function withLoadingUserOptions (delegateGenerator: (any) => Generator<any, any,
   }
 }
 
-function* saveGlobalOptions ({ payload: { sshKey, showNotifications, notificationSnoozeDuration, language, updateRate }, meta: { transactionId } }: SaveGlobalOptionsActionType): Generator<any, any, any> {
-  const { ssh, locale } = yield all({
+function* saveGlobalOptions ({ payload: { sshKey, showNotifications, notificationSnoozeDuration, language, refreshInterval }, meta: { transactionId } }: SaveGlobalOptionsActionType): Generator<any, any, any> {
+  const { ssh, locale, refresh } = yield all({
     ssh: call(saveSSHKey, ...Object.entries({ sshKey })),
     locale: call(saveRemoteOption, ...Object.entries({ locale: language })),
+    refresh: call(saveRemoteOption, ...Object.entries({ refreshInterval })),
   })
+
+  if (!refresh.error && refresh.change && !refresh.sameAsCurrent) {
+    const { name, value } = refresh.data
+    yield put(A.setOption({ key: [ 'remoteOptions', name ], value }))
+  }
 
   if (!locale.error && locale.change && !locale.sameAsCurrent) {
     const { name, value } = locale.data


### PR DESCRIPTION
Fixes: #1387
Note that this  PR depends on #1372 

This PR adds possibility to change the global refresh interval used to refresh data in the UI.

Change summary:
1. configured value is persisted as `vmPortal.refreshInterval` on the server
2. each time the refreshInterval setting is changed the refresh scheduler  is restarted (similar as during manual refresh or page change).
3.  already elapsed time is subtracted from the first new period. This is possible by tracking `lastRefresh` time.