### PR TITLE
A temp fix for reading new format of config val MaxNumOfVmCpus

### DIFF
--- a/src/components/CreateVmWizard/steps/BasicSettings.js
+++ b/src/components/CreateVmWizard/steps/BasicSettings.js
@@ -713,7 +713,7 @@ export default connect(
     templates: state.templates,
     blankTemplateId: state.config.get('blankTemplateId'),
     storageDomains: state.storageDomains,
-    maxNumOfVmCpus: state.config.get('maxNumOfVmCpus', 384),
+    maxNumOfVmCpus: state.config.get('maxNumOfVmCpus', 512),
     maxMemorySizeInMiB: 4194304, // TODO: 4TiB, no config option pulled as of 2019-Mar-22
     defaultGeneralTimezone: state.config.get('defaultGeneralTimezone'),
     defaultWindowsTimezone: state.config.get('defaultWindowsTimezone'),

--- a/src/sagas/server-configs.js
+++ b/src/sagas/server-configs.js
@@ -14,6 +14,7 @@ import {
 } from '_/actions'
 
 import { callExternalAction } from './utils'
+import { isNumber } from '_/utils'
 
 export function* fetchServerConfiguredValues () {
   const optionVersion = yield select(state => {
@@ -52,7 +53,8 @@ export function* fetchServerConfiguredValues () {
     maxNumberOfSockets: parseInt(maxNumberOfSockets, 10),
     maxNumberOfCores: parseInt(maxNumberOfCores, 10),
     maxNumberOfThreads: parseInt(maxNumberOfThreads, 10),
-    maxNumOfVmCpus: parseInt(maxNumOfVmCpus, 10),
+    // TODO: need to replace this by the actual map value parsing for maxNumOfVmCpus
+    maxNumOfVmCpus: isNumber(parseInt(maxNumOfVmCpus, 10)) ? parseInt(maxNumOfVmCpus, 10) : 512,
   }))
 
   if (usbAutoShare) {


### PR DESCRIPTION
Since "MaxNumOfVmCpus" config value was changed to a Map format on backend in
patch https://gerrit.ovirt.org/113576, then we need to fix that on web-ui as well by parsing the config val for supporting that per version.

As a temp & quick solution, this value in just hard-coded in case of engine >=4.4.5 in this PR
This should be replaced by the actual parsing in a followed patch.