### PR TITLE
Show VM's IP address if the vm is up and guest agent is running on the vm

### DIFF
--- a/src/components/EllipsisValue/index.js
+++ b/src/components/EllipsisValue/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { xor } from '_/propTypeExtras'
 import style from './style.css'
 import classnames from 'classnames'
+import Tooltip from '_/components/tooltips/Tooltip'
 
 class EllipsisValue extends React.Component {
   constructor (props) {
@@ -46,14 +47,18 @@ class EllipsisValue extends React.Component {
     const { className, id, children, tooltip } = this.props
 
     if (children) {
-      return <span
+      const ellipsisValue = (<span
         className={classnames(style['field-value'], className)}
         id={id}
-        title={this.state.isOverflow ? tooltip : ''}
         ref={this.ref}
       >
         {children}
-      </span>
+      </span>)
+
+      return this.state.isOverflow ? (<Tooltip tooltip={tooltip} id={`ellipsis_tooltip${id}`} >
+        {ellipsisValue}
+      </Tooltip>)
+        : (ellipsisValue)
     }
     return null
   }

--- a/src/components/VmDetails/cards/DetailsCard/index.js
+++ b/src/components/VmDetails/cards/DetailsCard/index.js
@@ -624,6 +624,7 @@ class DetailsCard extends React.Component {
 
     const idPrefix = 'vmdetail-details'
 
+    const showIPs = vm.get('status') === 'up'
     const isPoolVm = vm.getIn(['pool', 'id']) !== undefined
     const canEditDetails = vm.get('canUserEditVm') && !isPoolVm
     let pool = null
@@ -637,8 +638,13 @@ class DetailsCard extends React.Component {
     const hostName = hosts && hosts.getIn([vm.get('hostId'), 'name'])
 
     // IP Addresses
-    const ip4Addresses = !vm.has('nics') ? [] : vm.get('nics').reduce((ipSet, nic) => [...ipSet, ...nic.get('ipv4')], [])
-    const ip6Addresses = !vm.has('nics') ? [] : vm.get('nics').reduce((ipSet, nic) => [...ipSet, ...nic.get('ipv6')], [])
+    const ip4Addresses = [...(new Set(!vm.has('nics') || !showIPs
+      ? []
+      : vm.get('nics').reduce((ipSet, nic) => [...ipSet, ...nic.get('ipv4')], [])))]
+    const ip6Addresses = [...(new Set(
+      !vm.has('nics') || !showIPs
+        ? []
+        : vm.get('nics').reduce((ipSet, nic) => [...ipSet, ...nic.get('ipv6')], [])))]
 
     // FQDN
     const fqdn = vm.get('fqdn')

--- a/src/components/VmDetails/cards/NicsCard/NicListItem.js
+++ b/src/components/VmDetails/cards/NicsCard/NicListItem.js
@@ -20,7 +20,7 @@ import EllipsisValue from '_/components/EllipsisValue'
  * If _edit_ then render the appropriate action buttons linked to provided
  * handler functions.
  */
-const NicListItem = ({ idPrefix, nic, vmStatus, vnicProfileList, isEditing, onEdit, onDelete }) => {
+const NicListItem = ({ idPrefix, nic, vmStatus, vnicProfileList, isEditing, onEdit, onDelete, showNicIPs }) => {
   const { msg } = useContext(MsgContext)
   const canEdit = !!onEdit
   const canDelete = !!onDelete
@@ -45,7 +45,7 @@ const NicListItem = ({ idPrefix, nic, vmStatus, vnicProfileList, isEditing, onEd
       <Grid>
         <Row>
           <Col cols={4} wrapExpand className={style['ip4-container']} id={`${idPrefix}-ipv4`}>
-            { nic.ipv4.length > 0 &&
+            { showNicIPs && nic.ipv4.length > 0 &&
               nic.ipv4.map((ip4, index) =>
                 <EllipsisValue
                   tooltip={ip4}
@@ -57,7 +57,7 @@ const NicListItem = ({ idPrefix, nic, vmStatus, vnicProfileList, isEditing, onEd
             }
           </Col>
           <Col cols={8} wrapExpand className={style['ip6-container']} id={`${idPrefix}-ipv6`}>
-            { nic.ipv6.length > 0 &&
+            { showNicIPs && nic.ipv6.length > 0 &&
               nic.ipv6.map((ip6, index) =>
                 <EllipsisValue
                   tooltip={ip6}
@@ -143,6 +143,7 @@ NicListItem.propTypes = {
   vmStatus: PropTypes.string.isRequired,
   vnicProfileList: PropTypes.object.isRequired,
   isEditing: PropTypes.bool.isRequired,
+  showNicIPs: PropTypes.bool.isRequired,
 
   onEdit: PropTypes.func,
   onDelete: PropTypes.func,

--- a/src/components/VmDetails/cards/NicsCard/index.js
+++ b/src/components/VmDetails/cards/NicsCard/index.js
@@ -173,6 +173,7 @@ class NicsCard extends React.Component {
               <Row key={nic.id} id={`${idPrefix}-${nic.name}`}>
                 <Col style={{ display: 'block' }}>
                   <NicListItem
+                    showNicIPs={showNicIPs}
                     idPrefix={`${idPrefix}-${nic.name}`}
                     nic={nic}
                     vmStatus={vmStatus}

--- a/src/ovirtapi/index.js
+++ b/src/ovirtapi/index.js
@@ -584,7 +584,7 @@ const OvirtApi = {
 
   getVmNic ({ vmId }: { vmId: string }): Promise<Object> {
     assertLogin({ methodName: 'getVmNic' })
-    return httpGet({ url: `${AppConfiguration.applicationContext}/api/vms/${vmId}/nics` })
+    return httpGet({ url: `${AppConfiguration.applicationContext}/api/vms/${vmId}/nics?follow=reporteddevices` })
   },
   getAllNetworks (): Promise<Object> {
     assertLogin({ methodName: 'getNetworks' })

--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -715,10 +715,11 @@ const Cluster = {
 //
 const Nic = {
   toInternal ({ nic }: { nic: ApiNicType }): NicType {
+    const { mac: { address: nicMacAddress = '' } = {} } = nic
     const ips =
       nic.reported_devices && nic.reported_devices.reported_device
         ? nic.reported_devices.reported_device
-          .filter(device => !!device.ips && !!device.ips.ip)
+          .filter(device => !!device.ips && !!device.ips.ip && device.mac && device.mac.address === nicMacAddress)
           .map(device => device.ips.ip)
           .reduce((ips, ipArray) => [...ipArray, ...ips], [])
         : []

--- a/src/ovirtapi/types.js
+++ b/src/ovirtapi/types.js
@@ -114,6 +114,26 @@ export type ApiClusterType = Object
 export type ClusterType = Object
 
 export type ApiNicType = Object
+
+type IpType = {
+  address: string,
+  version: 'v4' | 'v6'
+}
+
+export type ReportedDevicesType = {
+  description: string,
+  href: string,
+  id: string,
+  ips?: { ip: Array<IpType> },
+  mac: { address: string },
+  name: string,
+  type: string,
+  vm: {
+    href: string,
+    id: string
+  }
+}
+
 export type NicType = {
   id: string,
   name: string,

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -108,7 +108,7 @@ const VM_FETCH_ADDITIONAL_DEEP = [
   'cdroms',
   'disk_attachments.disk',
   'graphics_consoles',
-  'nics',
+  'nics.reporteddevices',
   'permissions',
   'sessions',
   'snapshots',


### PR DESCRIPTION
According to this [BZ comment](https://bugzilla.redhat.com/show_bug.cgi?id=1441741#c4) the guest_info data has been removed from the nics data and is available in `reporteddevices` entity.

So I added the `reporteddevices` to the `VM_FETCH_ADDITIONAL_DEEP` array so the data will be fetched and showed in the vmDetails page, due to the REST response changes I changed the `Nic.toInternal` function as well to map the data correctly.

Before:
![image](https://user-images.githubusercontent.com/64131213/111302623-4eace900-865c-11eb-9765-0d27e88b0db9.png)

 After:
![image](https://user-images.githubusercontent.com/64131213/111302770-73a15c00-865c-11eb-96fa-de7b33d831de.png)

Fixes: [BZ#1924610](https://bugzilla.redhat.com/1924610)