### PR TITLE
Use semver to verify API level

### DIFF
--- a/ovirt-web-ui.spec.in
+++ b/ovirt-web-ui.spec.in
@@ -17,7 +17,7 @@ Source0:        https://github.com/oVirt/ovirt-web-ui/archive/%{source_basename}
 BuildArch: noarch
 
 # nodejs-modules embeds yarn and requires nodejs
-BuildRequires: ovirt-engine-nodejs-modules >= 2.0.41-1
+BuildRequires: ovirt-engine-nodejs-modules >= 2.0.42-1
 
 %description
 This package provides the VM Portal for %{product}.

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "react-test-renderer": "16.8.6",
     "redux": "4.0.0",
     "redux-saga": "0.16.0",
+    "semver": "^7.3.4",
     "victory": "32.3.1"
   },
   "resolutions": {

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -388,7 +388,7 @@ export const messages: { [messageId: string]: MessageType } = {
   hotPlugConfirmTitle: 'Apply Changes',
   hoursShort: 'h',
   htmlPleaseReferToDocumentationForMoreInformation: 'Please refer to <a href="{documentationUrl}" target="_blank">documentation</a> for more information.',
-  htmlUnsupportedOvirtVersionFoundButVersionAtLeastRequired: '<strong>Unsupported {version} {productName} version,</strong> found but version at least {requiredVersion} is required.',
+  htmlUnsupportedOvirtVersionFoundButVersionAtLeastRequired: '<strong>Unsupported {version} {productName} version</strong> found, but at least version {requiredVersion} is required.',
   icon: 'Icon',
   ifVmIsRunningClickToAccessItsGraphicsConsole: 'If the virtual machine is running, click the protocol name to access its Graphical Console.',
   inPreview: 'In Preview',

--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -28,6 +28,7 @@ import type {
   ApiUserType, UserType,
   UserOptionType,
   RemoteUserOptionsType,
+  VersionType,
 } from './types'
 
 import { isWindows } from '_/helpers'
@@ -1024,6 +1025,16 @@ const User = {
   toApi: undefined,
 }
 
+const Version = {
+  toInternal ({ major = 0, minor = 0, build = 0 }: any): VersionType {
+    return {
+      major: Number(major),
+      minor: Number(minor),
+      build: Number(build),
+    }
+  },
+}
+
 //
 // Export each transforms individually so they can be consumed individually
 //
@@ -1055,4 +1066,5 @@ export {
   User,
   RemoteUserOptions,
   RemoteUserOption,
+  Version,
 }

--- a/src/ovirtapi/types.js
+++ b/src/ovirtapi/types.js
@@ -249,3 +249,9 @@ export type EventType = {
   description: string,
   severity: string
 }
+
+export type VersionType = {|
+  major: number,
+  minor: number,
+  build: number
+|}

--- a/src/sagas/utils.js
+++ b/src/sagas/utils.js
@@ -9,6 +9,8 @@ import { hidePassword } from '_/helpers'
 import { msg } from '_/intl'
 import Api from '_/ovirtapi'
 import { getUserPermits } from '_/utils'
+import semverGte from 'semver/functions/gte'
+import semverValid from 'semver/functions/valid'
 
 import {
   checkTokenExpired,
@@ -22,23 +24,16 @@ import {
 export const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms))
 
 /**
- * Compare the actual { major, minor } version to the required { major, minor } and
+ * Compare the actual { major, minor, build} version to the required { major, minor} and
  * return if the **actual** is greater then or equal to **required**.
  *
  * Backward compatibility of the API is assumed.
  */
 export function compareVersion (actual, required) {
-  console.log(`compareVersion(), actual=${JSON.stringify(actual)}, required=${JSON.stringify(required)}`)
-
-  if (actual.major >= required.major) {
-    if (actual.major === required.major) {
-      if (actual.minor < required.minor) {
-        return false
-      }
-    }
-    return true
-  }
-  return false
+  const fullActual = `${actual.major}.${actual.minor}.${actual.build}`
+  const fullRequired = `${required.major}.${required.minor}.0`
+  console.log(`compareVersion(), actual=${fullActual}, required=${fullRequired}`)
+  return !!semverValid(fullActual) && semverGte(fullActual, fullRequired)
 }
 
 export function* callExternalAction (methodName, method, action = {}, canBeMissing = false) {

--- a/src/sagas/utils.test.js
+++ b/src/sagas/utils.test.js
@@ -1,0 +1,87 @@
+/* eslint-env jest */
+
+import { compareVersion } from './utils'
+
+describe('compareVersion', () => {
+  const cases = [
+    {
+      title: 'invalid string',
+      result: false,
+      actual: {
+        major: 'qwerty',
+        minor: 'qwerty',
+        build: 'qwerty',
+      },
+      required: {
+        major: 4,
+        minor: 4,
+      },
+    },
+    {
+      title: 'missing version',
+      result: false,
+      actual: {
+        major: undefined,
+        minor: undefined,
+        build: undefined,
+      },
+      required: {
+        major: 4,
+        minor: 4,
+      },
+    },
+    {
+      title: 'higher on major, lower on minor',
+      result: true,
+      actual: {
+        major: 5,
+        minor: 0,
+        build: 0,
+      },
+      required: {
+        major: 4,
+        minor: 4,
+      },
+    },
+    {
+      title: 'equal versions',
+      result: true,
+      actual: {
+        major: 4,
+        minor: 4,
+        build: 0,
+      },
+      required: {
+        major: 4,
+        minor: 4,
+      },
+    },
+    {
+      title: 'major too low',
+      result: false,
+      actual: {
+        major: 3,
+        minor: 4,
+        build: 0,
+      },
+      required: {
+        major: 4,
+        minor: 4,
+      },
+    },
+    {
+      title: 'minor too low',
+      result: false,
+      actual: {
+        major: 4,
+        minor: 3,
+        build: 0,
+      },
+      required: {
+        major: 4,
+        minor: 4,
+      },
+    },
+  ]
+  cases.forEach(({ title, actual, required, result }) => test(title, () => expect(compareVersion(actual, required)).toEqual(result)))
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -8110,6 +8110,13 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 macos-release@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
@@ -11518,6 +11525,13 @@ semver@^6.0.0, semver@^6.2.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.3.4:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"
@@ -13700,6 +13714,11 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.7.2:
   version "1.9.2"


### PR DESCRIPTION
REST API sends version numbers as strings. However the required version
numbers are defined as numbers. As result, the strict comparison(===)
always fails.

Example: 
```
> compareVersion({major: '4',minor:'3'}, {major: 4, minor:4})
> true
```