### PR TITLE
Add check/validation if permission response is an array, to prevent web ui from crashing

### DIFF
--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -899,7 +899,7 @@ const VmSessions = {
 //
 //
 const Permissions = {
-  toInternal ({ permissions }: { permissions: Array<ApiPermissionType> }): Array<PermissionType> {
+  toInternal ({ permissions = [] }: { permissions: Array<ApiPermissionType> }): Array<PermissionType> {
     return permissions.map(permission => ({
       name: permission.role.name,
       userId: permission.user && permission.user.id,

--- a/src/sagas/utils.js
+++ b/src/sagas/utils.js
@@ -162,7 +162,10 @@ export function* delayInMsSteps (count = 20, msMultiplier = 2000) {
 
 export function* fetchPermits ({ entityType, id }) {
   const permissions = yield callExternalAction(`get${entityType}Permissions`, Api[`get${entityType}Permissions`], { payload: { id } })
-  return getUserPermits(Api.permissionsToInternal({ permissions: permissions.permission }))
+  if (permissions && Array.isArray(permissions.permission)) {
+    return getUserPermits(Api.permissionsToInternal({ permissions: permissions.permission }))
+  }
+  return []
 }
 
 export const PermissionsType = {


### PR DESCRIPTION
Hi guys,
it's a small fix that should prevent web ui from crashing in case of backend 500 error.
It's an extreme edge case but it should be handled.
Fixes: #1385 .