### PR TITLE
Update how template disks are created

### DIFF
--- a/src/components/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/CreateVmWizard/CreateVmWizard.js
@@ -365,10 +365,20 @@ class CreateVmWizard extends React.Component {
                   const canUserUseStorageDomain =
                     !!dataCenterStorageDomainsList.find(sd => sd.id === disk.get('storageDomainId'))
 
+                  /*
+                   * To be consistent with webadmin create VM from a template, diskType needs
+                   * to match webadmin's default diskType. Webadmin derives the default disk
+                   * type for the template's default storage allocation value, which is derived
+                   * from the optimizedFor type.
+                   *
+                   * Optimized for -> Storage Allocation -> format / diskType:
+                   *   - desktop -> Thin -> cow / 'thin'
+                   *   - server or high performance -> Clone -> raw / as defined in the template
+                   */
                   const diskType = // constrain to values from createDiskTypeList()
-                    this.state.steps.basic.optimizedFor === 'desktop'
-                      ? disk.get('sparse') ? 'thin' : 'pre'
-                      : 'pre'
+                    template.get('type') === 'desktop' ? 'thin'
+                      : this.state.steps.basic.optimizedFor === 'desktop' ? 'thin'
+                        : disk.get('sparse') ? 'thin' : 'pre'
 
                   return {
                     id: disk.get('attachmentId'),

--- a/src/sagas/vmChanges.js
+++ b/src/sagas/vmChanges.js
@@ -79,12 +79,6 @@ function* composeAndCreateVm ({ payload: { basic, nics, disks }, meta: { correla
     merge(vm, vmUpdates)
   }
 
-  // TODO: TimeZone handling (https://github.com/oVirt/ovirt-web-ui/pull/1118)
-
-  const clone = (
-    (basic.provisionSource === 'template' && basic.optimizedFor !== 'desktop') ||
-    vmRequiresClone
-  )
   const clonePermissions = basic.provisionSource === 'template'
 
   /*
@@ -93,7 +87,7 @@ function* composeAndCreateVm ({ payload: { basic, nics, disks }, meta: { correla
    *       after the VM has been created and is no longer image locked.
    */
   const newVmId = yield createVm(
-    A.createVm({ vm, cdrom, clone, clonePermissions, transformInput: false }, { correlationId })
+    A.createVm({ vm, cdrom, clone: vmRequiresClone, clonePermissions, transformInput: false }, { correlationId })
   )
 
   if (newVmId === -1) {
@@ -101,7 +95,7 @@ function* composeAndCreateVm ({ payload: { basic, nics, disks }, meta: { correla
   }
 
   // Wait for the VM image to be unlocked before adding NICs and Disks
-  yield waitForVmToBeUnlocked(newVmId, clone)
+  yield waitForVmToBeUnlocked(newVmId, vmRequiresClone)
 
   // Assuming NICs cannot be added along with the VM create request, add them now
   yield all(nics.filter(nic => !nic.isFromTemplate).map(nic =>
@@ -167,7 +161,10 @@ function* composeProvisionSourceIso ({ vm, basic }) {
 
 function* composeProvisionSourceTemplate ({ vm, basic, disks }) {
   const template = yield select(state => state.templates.get(basic.templateId))
-  let vmRequiresClone = false
+
+  const vmStorageAllocation = basic.optimizedFor === 'desktop' ? 'thin' : 'clone'
+  const templateStorageAllocation = template.get('type') === 'desktop' ? 'thin' : 'clone'
+  let diskRequiresClone = false
 
   const vmUpdates = {
     template: { id: template.get('id') },
@@ -198,23 +195,23 @@ function* composeProvisionSourceTemplate ({ vm, basic, disks }) {
         id: disk.id,
       }
 
+      // make sure disk format (and therefore sparse) matches the template's storageAllocation
+      if (templateStorageAllocation === 'thin') {
+        changesToTemplateDisk.format = 'cow'
+      } else if (templateStorageAllocation === 'clone') {
+        changesToTemplateDisk.format = vmStorageAllocation === 'thin' ? 'cow' : 'raw'
+      }
+
       // did the storage domain change?
       if (disk.storageDomainId !== templateDisk.get('storageDomainId')) {
+        diskRequiresClone = true
         changesToTemplateDisk.format = 'raw'
         changesToTemplateDisk.storage_domains = {
           storage_domain: [{ id: disk.storageDomainId }],
         }
       }
 
-      // did the diskType (disk's sparse ) change?  'thin' === sparse, 'pre' === !sparse
-      const templateDiskType = templateDisk.get('sparse') ? 'thin' : 'pre'
-      if (disk.diskType !== templateDiskType) {
-        changesToTemplateDisk.sparse = disk.diskType === 'thin'
-      }
-
       if (Object.keys(changesToTemplateDisk).length > 1) {
-        vmRequiresClone = true
-
         if (vmUpdates.disk_attachments) {
           // add another disk to clone
           vmUpdates.disk_attachments.disk_attachment.push({ disk: changesToTemplateDisk })
@@ -229,7 +226,7 @@ function* composeProvisionSourceTemplate ({ vm, basic, disks }) {
       }
     })
 
-  return [ vmUpdates, vmRequiresClone ]
+  return [ vmUpdates, vmStorageAllocation === 'clone' || diskRequiresClone ]
 }
 
 /*

--- a/src/sagas/vmChanges.js
+++ b/src/sagas/vmChanges.js
@@ -205,7 +205,6 @@ function* composeProvisionSourceTemplate ({ vm, basic, disks }) {
       // did the storage domain change?
       if (disk.storageDomainId !== templateDisk.get('storageDomainId')) {
         diskRequiresClone = true
-        changesToTemplateDisk.format = 'raw'
         changesToTemplateDisk.storage_domains = {
           storage_domain: [{ id: disk.storageDomainId }],
         }


### PR DESCRIPTION
Changes have been made to following how Admin Portal works when creating VMs from a template.  How template disks are created depends on (1) the VM's optimized for selection, and (2) if a new storage domain needs to be selected.

The VM's "Optimized For" selection drives the default disk type for the template disks.  In Admin Portal, selecting **Desktop** resets the "Storage Allocation" selection to **Thin**.  Selecting **Server** or **High Performance** resets "Storage Allocation" to **Clone**.

If VM's optimized for selection is **Desktop**:
  - behavior matches when Admin Portal **Storage Allocation** is **Thin**
  - all of the template disks' disk types are forced to "Thin Provisioned"
  - the VM create is sent:
    - `clone=true` if AT LEAST ONE of the disks has a storage domain that differs from the template's disk
    - `clone=false` as long as all of the template disk's storage domains remain unchanged

If VM's optimized for selection is **Server**:
  - behavior matches when Admin Portal's **Storage Allocation** is **Clone**
  - the template disks use the disk type as defined by the template
  - the VM create is sent `clone=true`

Fixes: #1371