### PR TITLE
Adding confirmation modal on saving user settings changes

### DIFF
--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -120,7 +120,13 @@ const Settings = ({ draftValues, onSave, lastTransactionId, onCancel,
         />
       }
     </div>
-    <SettingsToolbar onSave={handleSave} onCancel={onCancel} enableSave={!!pendingChanges.length} />
+    <SettingsToolbar
+      onSave={handleSave}
+      onCancel={onCancel}
+      enableSave={!!pendingChanges.length}
+      changes={pendingChanges}
+      translatedLabels={translatedLabels}
+    />
     {children}
   </React.Fragment>
 }

--- a/src/components/Settings/SettingsToolbar.js
+++ b/src/components/Settings/SettingsToolbar.js
@@ -5,9 +5,13 @@ import { Toolbar } from 'patternfly-react'
 import { msg } from '_/intl'
 
 import style from './style.css'
+import ConfirmationModal from '_/components/VmActions/ConfirmationModal'
 
-const SettingsToolbar = ({ onSave, onCancel, enableSave }) => {
+const SettingsToolbar = ({ onSave, onCancel, enableSave, translatedLabels, changes = [] }) => {
   const [container] = useState(document.createElement('div'))
+  const [showConfirmModal, setShowConfirmModal] = useState(false)
+  const idPrefix = 'settings_toolbar'
+
   useEffect(() => {
     const root = document.getElementById('settings-toolbar')
     if (root) {
@@ -16,8 +20,38 @@ const SettingsToolbar = ({ onSave, onCancel, enableSave }) => {
     return () => root && root.removeChild(container)
   })
 
+  const onConfirm = () => {
+    onClose()
+    onSave()
+  }
+
+  const onClose = () => {
+    setShowConfirmModal(false)
+  }
+
+  const buildConfirmationModalSubContent = () => (
+    <ul className={style['changes-list']}>{
+      changes.map(name => {
+        const value = translatedLabels[name] || name
+        return (<li key={`${idPrefix}_li_${value}`}>{value}</li>)
+      })
+    }
+    </ul>
+  )
+
   return ReactDOM.createPortal(
     <Toolbar className={style['toolbar']}>
+      <ConfirmationModal
+        show={showConfirmModal}
+        title={msg.saveChanges()}
+        body={msg.saveSettingsChangesConfirmation()}
+        subContent={buildConfirmationModalSubContent()}
+        onClose={onClose}
+        confirm={{
+          title: msg.yes(),
+          onClick: onConfirm,
+        }}
+      />
       <Toolbar.RightContent>
         <button
           onClick={e => {
@@ -32,7 +66,7 @@ const SettingsToolbar = ({ onSave, onCancel, enableSave }) => {
           disabled={!enableSave}
           onClick={e => {
             e.preventDefault()
-            onSave()
+            setShowConfirmModal(true)
           }}
           className='btn btn-primary'
         >
@@ -47,7 +81,9 @@ const SettingsToolbar = ({ onSave, onCancel, enableSave }) => {
 SettingsToolbar.propTypes = {
   onSave: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
+  translatedLabels: PropTypes.object.isRequired,
   enableSave: PropTypes.bool,
+  changes: PropTypes.array,
 }
 
 export default SettingsToolbar

--- a/src/components/Settings/style.css
+++ b/src/components/Settings/style.css
@@ -61,3 +61,7 @@
 :global(#settings-toolbar) {
     margin-left: -20px;
 }
+.changes-list{
+    list-style-type: disc;
+    list-style: inside;
+}

--- a/src/components/VmActions/ConfirmationModal.js
+++ b/src/components/VmActions/ConfirmationModal.js
@@ -30,7 +30,9 @@ const ConfirmationModal = ({ show, title, confirm, body, subContent, onClose, ex
                   { body }
                 </p>
                 {
-                  subContent && <p>{ subContent }</p>
+                  subContent && typeof subContent === 'string'
+                    ? <p>{ subContent }</p>
+                    : subContent
                 }
               </div>
             </React.Fragment>
@@ -59,7 +61,7 @@ ConfirmationModal.propTypes = {
   }),
   extra: btnPropType,
   body: PropsTypes.oneOfType([PropsTypes.node, PropsTypes.string]).isRequired,
-  subContent: PropsTypes.string,
+  subContent: PropsTypes.oneOfType([PropsTypes.node, PropsTypes.string]),
 }
 
 export default ConfirmationModal

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -554,6 +554,8 @@ export const messages: { [messageId: string]: MessageType } = {
   },
   run: 'Run',
   save: 'Save',
+  saveChanges: 'Save Changes',
+  saveSettingsChangesConfirmation: 'Are you sure you want to make changes to the following settings?',
   secondDevice: 'Second Device',
   secondDeviceTooltip: 'Second device in order.',
   secondsShort: 's',


### PR DESCRIPTION
This PR prompting confirmation before saving changes in user settings.
Before this PR the settings were automatically saved, now before saving the changes will require confirmation.
I added the changed settings to modal's message so the user can see which fields were changed.
Screenshots:
![image](https://user-images.githubusercontent.com/64131213/113512676-621de680-956e-11eb-9027-d37200c2dbdd.png)

![image](https://user-images.githubusercontent.com/64131213/113512714-8b3e7700-956e-11eb-833d-51ce78c71e97.png)

Fixes: #1389.