### PR TITLE
Add () to msg.vmStatusIconTooltipPaused to solve propType issue

### DIFF
--- a/src/components/VmStatusIcon/index.js
+++ b/src/components/VmStatusIcon/index.js
@@ -11,7 +11,7 @@ const VM_STATUS_TO_ICON = {
   'up'                : { type: 'pf', name: 'on-running',         tooltip: msg.vmStatusIconTooltipUp(), className: style['green'] },
   'powering_up'       : { type: 'pf', name: 'in-progress',        tooltip: msg.vmStatusIconTooltipPoweringUp() },
   'down'              : { type: 'pf', name: 'off',                tooltip: msg.vmStatusIconTooltipDown() },
-  'paused'            : { type: 'pf', name: 'paused',             tooltip: msg.vmStatusIconTooltipPaused },
+  'paused'            : { type: 'pf', name: 'paused',             tooltip: msg.vmStatusIconTooltipPaused() },
   'suspended'         : { type: 'pf', name: 'asleep',             tooltip: msg.vmStatusIconTooltipSuspended() },
   'powering_down'     : { type: 'pf', name: 'in-progress',        tooltip: msg.vmStatusIconTooltipPoweringDown() },
   'not_responding'    : { type: 'pf', name: 'warning-triangle-o', tooltip: msg.vmStatusIconTooltipNotResponding() },


### PR DESCRIPTION
This PR is adding `()` to `msg.vmStatusIconTooltipPaused` message.
The `()` is missing from #1374 PR.
Resolves: #1403 .