### PR TITLE
Create general breadcrumbs root to resolve the confusion about "Virtual Machines" Breadcrumbs root

### DIFF
--- a/src/components/Breadcrumb/index.js
+++ b/src/components/Breadcrumb/index.js
@@ -4,8 +4,11 @@ import { Link } from 'react-router-dom'
 import { connect } from 'react-redux'
 import { msg } from '_/intl'
 
+const NONE_VM_ROUTES = [ '/settings' ]
+
 const buildPath = (vms, branches) => {
   const res = []
+  const isVmPath = !branches.find(branch => NONE_VM_ROUTES.includes(branch.match.path))
 
   for (const branch of branches) {
     if (typeof branch.route.title === 'function') {
@@ -19,18 +22,20 @@ const buildPath = (vms, branches) => {
         url: branch.match.url,
       })
     }
+    const { match: { path = '' } = {} } = branch
+    if (isVmPath && ['/'].includes(path)) {
+      res.push({
+        title: msg.virtualMachines(),
+        url: '/',
+      })
+    }
   }
 
   return res
 }
 
-const root = {
-  title: msg.virtualMachines(),
-  url: '/',
-}
-
 const Breadcrumb = ({ vms, branches }) => {
-  const crumbs = [ root, ...buildPath(vms, branches) ]
+  const crumbs = buildPath(vms, branches)
   const idPrefix = `breadcrumb`
 
   return (

--- a/src/routes.js
+++ b/src/routes.js
@@ -2,6 +2,8 @@ import React from 'react'
 
 import PageRouter from './components/PageRouter'
 
+import { HomeIcon } from '@patternfly/react-icons'
+
 import Handler404 from './Handler404'
 import {
   VmDetailToolbar,
@@ -43,40 +45,42 @@ export default function getRoutes (vms) {
     routes: [
       {
         path: '/',
-        exact: true,
+        title: () => (<HomeIcon style={{ fontSize: '1rem' }} />),
         component: VmsListPage,
         toolbars: (match) => (<VmsListToolbar match={match} vms={vms} key='addbutton' />),
         type: LIST_PAGE_TYPE,
         isToolbarFullWidth: true,
-      },
-
-      {
-        path: '/vm/:id',
-        title: (match, vms) => vms.getIn(['vms', match.params.id, 'name']) || match.params.id,
-        component: VmDetailsPage,
-        toolbars: (match) => (<VmDetailToolbar match={match} key='vmaction' />),
-        type: DETAIL_PAGE_TYPE,
         routes: [
           {
-            path: '/vm/:id/console/:console',
-            title: (match) => msg.console(),
-            component: VmConsolePage,
-            closeable: true,
-            toolbars: (match) => (<VmConsoleToolbar match={match} key='vmconsole' />),
-            isToolbarFullWidth: true,
-            type: CONSOLE_PAGE_TYPE,
+            path: '/vm/:id',
+            title: (match, vms) => vms.getIn(['vms', match.params.id, 'name']) || match.params.id,
+            component: VmDetailsPage,
+            toolbars: (match) => (<VmDetailToolbar match={match} key='vmaction' />),
+            type: DETAIL_PAGE_TYPE,
+            routes: [
+              {
+                path: '/vm/:id/console/:console',
+                title: (match) => msg.console(),
+                component: VmConsolePage,
+                closeable: true,
+                toolbars: (match) => (<VmConsoleToolbar match={match} key='vmconsole' />),
+                isToolbarFullWidth: true,
+                type: CONSOLE_PAGE_TYPE,
+              },
+            ],
           },
-        ],
-      },
 
-      {
-        path: '/settings',
-        exact: true,
-        title: msg.accountSettings(),
-        component: GlobalSettingsPage,
-        toolbars: SettingsToolbar,
-        isToolbarFullWidth: true,
-        type: SETTINGS_PAGE_TYPE,
+          {
+            path: '/settings',
+            exact: true,
+            title: msg.accountSettings(),
+            component: GlobalSettingsPage,
+            toolbars: SettingsToolbar,
+            isToolbarFullWidth: true,
+            type: SETTINGS_PAGE_TYPE,
+          },
+
+        ],
       },
 
       {


### PR DESCRIPTION
The old breadcrumbs root was "Virtual machines" and it was a little bit confusing since the settings not related only to virtual machines.
In this PR I changed the old root to home icon instead of "Virtual Machines" and I added a special case for `vmListPage` that adds the "Virtual Machines" to the breadcrumbs path:
![image](https://user-images.githubusercontent.com/64131213/114343546-c4767880-9b66-11eb-9188-d5e735dd4045.png)
![image](https://user-images.githubusercontent.com/64131213/114343582-d3f5c180-9b66-11eb-9a08-1113bff28da8.png)
![image](https://user-images.githubusercontent.com/64131213/114343610-e66ffb00-9b66-11eb-905f-7c3ab6d23229.png)

Fixes: #1388 .