### PR TITLE
Update create VM step navigation and disk create checks

### DIFF
--- a/src/components/CreateVmWizard/steps/Networking.js
+++ b/src/components/CreateVmWizard/steps/Networking.js
@@ -79,6 +79,8 @@ class Networking extends React.Component {
     this.rowRenderProps = this.rowRenderProps.bind(this)
     this.isVnicNameUniqueAndValid = this.isVnicNameUniqueAndValid.bind(this)
 
+    props.onUpdate({ valid: true })
+
     this.state = {
       editingErrors: {
         nicInvalidName: false,

--- a/src/components/CreateVmWizard/steps/Storage.js
+++ b/src/components/CreateVmWizard/steps/Storage.js
@@ -692,11 +692,18 @@ class Storage extends React.Component {
           <EmptyState.Icon />
           <EmptyState.Title>{msg.createVmStorageEmptyTitle()}</EmptyState.Title>
           <EmptyState.Info>{msg.createVmStorageEmptyInfo()}</EmptyState.Info>
-          <EmptyState.Action>
-            <Button bsStyle='primary' bsSize='large' onClick={this.onCreateDisk}>
-              {msg.diskActionCreateNew()}
-            </Button>
-          </EmptyState.Action>
+          { enableCreate &&
+            <EmptyState.Action>
+              <Button bsStyle='primary' bsSize='large' onClick={this.onCreateDisk}>
+                {msg.diskActionCreateNew()}
+              </Button>
+            </EmptyState.Action>
+          }
+          { !enableCreate &&
+            <EmptyState.Help>
+              {msg.diskNoCreate()}
+            </EmptyState.Help>
+          }
         </EmptyState>
       </React.Fragment> }
 

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -222,6 +222,7 @@ export const messages: { [messageId: string]: MessageType } = {
   diskEditorStorageDomainCreateHelp: 'Once you have selected a storage domain, you will not be able to change it.',
   diskEditorStorageDomainLabel: 'Storage Domain',
   diskEditorStorageDomainNotAvailable: 'N/A',
+  diskNoCreate: 'No storage domains are available. A new disk cannot be created.',
   diskStateActiveTooltip: 'Active',
   diskStateInactiveTooltip: 'Inactive',
   diskStateLockedTooltip: 'Locked',


### PR DESCRIPTION
Fixes: #1366

Creating a VM from a template with disks defined, and if the disks need to be cloned to a new storage domain, navigation buttons needed to be enabled differently.  Now, once on the storage domain wizard step:

  - The forward button is enabled ONLY when all of the disks are correct and no edit is active.

  - The back button is always enabled, including when:

    - an edit is active

    - no storage domain is available for the template disks

    - disk storage domains must be selected, but have not yet been selected (i.e. edits are active)

When no storage domains are available, and no disks have been defined by the selected template, the `EmptyState` place holder will now show a "cannot create a disk" message.  This message replaces the "Create Disk" button.


---
Active edit:
![VM Portal - Google Chrome_025](https://user-images.githubusercontent.com/3985964/115443951-ebc1eb00-a1e1-11eb-8d4d-8ff5482bc87b.png)

No SD available:
![VM Portal - Google Chrome_026](https://user-images.githubusercontent.com/3985964/115444112-275cb500-a1e2-11eb-8430-a7e35bdb42a5.png)

SD must be selected but has not yet been:
![VM Portal - Google Chrome_028](https://user-images.githubusercontent.com/3985964/115454669-0b134500-a1ef-11eb-8c32-c97676e43a1a.png)

SD has been selected, everything OK, forward enabled:
![VM Portal - Google Chrome_029](https://user-images.githubusercontent.com/3985964/115454849-3bf37a00-a1ef-11eb-90d5-c207afc74935.png)

Everything OK by default, no active edits, forward enabled:
![VM Portal - Google Chrome_027](https://user-images.githubusercontent.com/3985964/115444244-51ae7280-a1e2-11eb-812c-a3764cfbfcd9.png)

