### PR TITLE
Update `entityPermissionsToUserPermits()` to correctly filter permissions

### DIFF
--- a/src/sagas/utils.js
+++ b/src/sagas/utils.js
@@ -179,18 +179,15 @@ export function* entityPermissionsToUserPermits (entity) {
     ? Array.isArray(entity.permissions) ? entity.permissions : [entity.permissions]
     : []
 
-  const userFilter = yield select(state => state.config.get('filter'))
   const userGroups = yield select(state => state.config.get('userGroups'))
   const userId = yield select(state => state.config.getIn(['user', 'id']))
   const roles = yield select(state => state.roles)
 
   const permitNames = []
   for (const permission of permissions) {
-    if (userFilter ||
-      (
-        (permission.groupId && userGroups.includes(permission.groupId)) ||
-        (permission.userId && permission.userId === userId)
-      )
+    if (
+      (permission.groupId && userGroups.includes(permission.groupId)) ||
+      (permission.userId && permission.userId === userId)
     ) {
       const role = roles.get(permission.roleId)
       if (!role) {


### PR DESCRIPTION
Fixes: #1411

The assumption that fetching permissions with `Filter: true` will
only return permissions that **apply** to requesting user was wrong.
All permissions that can be **read by** the requesting user are
returned.  Additional filtering needs to be done to make sure the
permissions that can be seen apply to the user (or a group the user
belongs to).

Now `entityPermissionsToUserPermits()` will verify that a permission
applies to the user before adding the permission's permits to the
set of permits for an entity.