### PR TITLE
Change boolean into "true"/"false" strings in toApi functions to adjust to API interface.

### DIFF
--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -281,7 +281,7 @@ const VM = {
       bios: vm.hasOwnProperty('bootMenuEnabled')
         ? {
           boot_menu: {
-            enabled: vm.bootMenuEnabled,
+            enabled: toApiBoolean(vm.bootMenuEnabled),
           },
         }
         : undefined,
@@ -541,8 +541,8 @@ const DiskAttachment = {
     const forApi: ApiDiskAttachmentType = {
       // disk_attachment part
       id: disk.attachmentId,
-      active: disk.active,
-      bootable: disk.bootable,
+      active: toApiBoolean(disk.active),
+      bootable: toApiBoolean(disk.bootable),
       interface: disk.iface,
     }
 
@@ -554,7 +554,7 @@ const DiskAttachment = {
 
         storage_type: 'image',
         format: disk.format || (disk.sparse && disk.sparse ? 'cow' : 'raw'),
-        sparse: disk.sparse,
+        sparse: toApiBoolean(disk.sparse),
         provisioned_size: disk.provisionedSize,
 
         storage_domains: disk.storageDomainId && {
@@ -745,8 +745,8 @@ const Nic = {
     const res = {
       id: nic.id,
       name: nic.name,
-      plugged: nic.plugged,
-      linked: nic.linked,
+      plugged: toApiBoolean(nic.plugged),
+      linked: toApiBoolean(nic.linked),
       interface: nic.interface,
       vnic_profile: undefined,
     }

--- a/src/ovirtapi/types.js
+++ b/src/ovirtapi/types.js
@@ -62,9 +62,26 @@ export type SnapshotType = {
   isActive: boolean
 }
 
-export type ApiDiskAttachmentType = Object
-export type ApiDiskType = Object
 export type DiskInterfaceType = "ide" | "sata" | "virtio" | "virtio_scsi"
+
+// http://ovirt.github.io/ovirt-engine-api-model/4.4/#types/disk_attachment
+export type ApiDiskAttachmentType = {
+  active: ApiBooleanType,
+  bootable: ApiBooleanType,
+  disk?: Object,
+  href?: string,
+  comment?: string,
+  description?: string,
+  id?: string,
+  logical_name?: string,
+  pass_discard?: ApiBooleanType,
+  read_only?: ApiBooleanType,
+  uses_scsi_reservation?: ApiBooleanType,
+  template?: Object,
+  vm?: Object,
+  interface?: DiskInterfaceType
+}
+export type ApiDiskType = Object
 export type DiskTypeType = "image" | "cinder" | "lun"
 export type DiskType = {
   // attachment part
@@ -113,11 +130,33 @@ export type StorageDomainFileType = Object
 export type ApiClusterType = Object
 export type ClusterType = Object
 
-export type ApiNicType = Object
+type NicInterfaceType = 'e1000' | 'pci_passthrough' | 'rtl8139' | 'rtl8139_virtio' | 'virtio'
 
 type IpType = {
   address: string,
   version: 'v4' | 'v6'
+}
+
+export type ApiNicType = {
+  reported_devices?: {
+    reported_device: Array<{
+      mac: {
+        address: string
+      },
+      ips: {
+        ip: Array<IpType>
+      }
+    }>
+  },
+  id: string,
+  name: string,
+  mac?: Object,
+  plugged: ApiBooleanType,
+  linked: ApiBooleanType,
+  interface: NicInterfaceType,
+  vnic_profile?: {
+    id: string | null | typeof undefined
+  }
 }
 
 export type ReportedDevicesType = {
@@ -137,10 +176,10 @@ export type ReportedDevicesType = {
 export type NicType = {
   id: string,
   name: string,
-  mac: string,
+  mac?: string,
   plugged: boolean,
   linked: boolean,
-  interface: 'e1000' | 'pci_passthrough' | 'rtl8139' | 'rtl8139_virtio' | 'virtio',
+  interface: NicInterfaceType,
   ips: Array<{
     address: string,
     version: 'v4' | 'v6'
@@ -148,7 +187,7 @@ export type NicType = {
   ipv4: Array<string>,
   ipv6: Array<string>,
   vnicProfile: {
-    id: string | null
+    id: string | null | typeof undefined
   }
 }
 


### PR DESCRIPTION
> As triggered and mentioned by #1386 (comment), we should go over all "toApi" functions and and convert API Boolean attributes handled on web-ui to the new ApiBooleanType type (as done for persist_memorystate in PR # 1386).

In this PR I changed all the boolean types (that I found) in `toApi` functions to adjust to the API interface.
Fixes: #1406 .