### PR TITLE
Add option to reset global user settings to default/installation settings

### DIFF
--- a/src/components/Settings/SettingsToolbar.js
+++ b/src/components/Settings/SettingsToolbar.js
@@ -7,10 +7,11 @@ import { MsgContext } from '_/intl'
 import style from './style.css'
 import ConfirmationModal from '_/components/VmActions/ConfirmationModal'
 
-const SettingsToolbar = ({ onSave, onCancel, enableSave, translatedLabels, changes = [] }) => {
+const SettingsToolbar = ({ onSave, onReset, onCancel, enableSave, enableReset, translatedLabels, changes = [] }) => {
   const { msg } = useContext(MsgContext)
   const [container] = useState(document.createElement('div'))
-  const [showConfirmModal, setShowConfirmModal] = useState(false)
+  const [showSaveConfirmModal, setShowSaveConfirmModal] = useState(false)
+  const [showResetConfirmModal, setShowResetConfirmModal] = useState(false)
   const idPrefix = 'settings_toolbar'
 
   useEffect(() => {
@@ -20,14 +21,22 @@ const SettingsToolbar = ({ onSave, onCancel, enableSave, translatedLabels, chang
     }
     return () => root && root.removeChild(container)
   })
+  const onResetConfirm = () => {
+    onResetClose()
+    onReset()
+  }
 
-  const onConfirm = () => {
-    onClose()
+  const onSaveConfirm = () => {
+    onSaveClose()
     onSave()
   }
 
-  const onClose = () => {
-    setShowConfirmModal(false)
+  const onSaveClose = () => {
+    setShowSaveConfirmModal(false)
+  }
+
+  const onResetClose = () => {
+    setShowResetConfirmModal(false)
   }
 
   const buildConfirmationModalSubContent = () => (
@@ -43,16 +52,37 @@ const SettingsToolbar = ({ onSave, onCancel, enableSave, translatedLabels, chang
   return ReactDOM.createPortal(
     <Toolbar className={style['toolbar']}>
       <ConfirmationModal
-        show={showConfirmModal}
+        show={showSaveConfirmModal}
         title={msg.saveChanges()}
         body={msg.saveSettingsChangesConfirmation()}
         subContent={buildConfirmationModalSubContent()}
-        onClose={onClose}
+        onClose={onSaveClose}
         confirm={{
           title: msg.yes(),
-          onClick: onConfirm,
+          onClick: onSaveConfirm,
         }}
       />
+      <ConfirmationModal
+        show={showResetConfirmModal}
+        title={msg.resetSettings()}
+        body={msg.resetSettingsQuestion()}
+        subContent={msg.resetSettingsWarning()}
+        onClose={onResetClose}
+        confirm={{
+          title: msg.reset(),
+          onClick: onResetConfirm,
+        }}
+      />
+      <button
+        className='btn btn-default'
+        disabled={!enableReset}
+        onClick={(e) => {
+          e.preventDefault()
+          setShowResetConfirmModal(true)
+        }}
+      >
+        {msg.resetSettings()}
+      </button>
       <Toolbar.RightContent>
         <button
           onClick={e => {
@@ -67,7 +97,7 @@ const SettingsToolbar = ({ onSave, onCancel, enableSave, translatedLabels, chang
           disabled={!enableSave}
           onClick={e => {
             e.preventDefault()
-            setShowConfirmModal(true)
+            setShowSaveConfirmModal(true)
           }}
           className='btn btn-primary'
         >
@@ -81,6 +111,7 @@ const SettingsToolbar = ({ onSave, onCancel, enableSave, translatedLabels, chang
 
 SettingsToolbar.propTypes = {
   onSave: PropTypes.func.isRequired,
+  onReset: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
   translatedLabels: PropTypes.object.isRequired,
   enableSave: PropTypes.bool,

--- a/src/components/UserSettings/GlobalSettings.js
+++ b/src/components/UserSettings/GlobalSettings.js
@@ -5,12 +5,13 @@ import { connect } from 'react-redux'
 import { push } from 'connected-react-router'
 import { saveGlobalOptions } from '_/actions'
 import { FormControl, Switch } from 'patternfly-react'
-import { withMsg, localeWithFullName } from '_/intl'
+import { withMsg, localeWithFullName, DEFAULT_LOCALE } from '_/intl'
 import style from './style.css'
 
 import { Settings, SettingsBase } from '../Settings'
 import SelectBox from '../SelectBox'
 import moment from 'moment'
+import AppConfiguration from '_/config'
 
 class GlobalSettings extends Component {
   dontDisturbList (msg) {
@@ -87,12 +88,19 @@ class GlobalSettings extends Component {
       // values submitted using 'save' action
       // inlcude both remote(server and store) or local(store only)
       sentValues: {},
+      defaultValues: {
+        language: DEFAULT_LOCALE,
+        showNotifications: AppConfiguration.showNotificationsDefault,
+        refreshInterval: AppConfiguration.schedulerFixedDelayInSeconds,
+        notificationSnoozeDuration: AppConfiguration.notificationSnoozeDurationInMinutes,
+      },
     }
     this.handleCancel = this.handleCancel.bind(this)
     this.buildSections = this.buildSections.bind(this)
     this.saveOptions = this.saveOptions.bind(this)
     this.resetBaseValues = this.resetBaseValues.bind(this)
     this.onChange = this.onChange.bind(this)
+    this.onReset = this.onReset.bind(this)
   }
 
   resetBaseValues () {
@@ -123,6 +131,15 @@ class GlobalSettings extends Component {
         },
       }))
     }
+  }
+  onReset (saveFields, id) {
+    this.setState(state => ({
+      draftValues: {
+        ...this.props.currentValues,
+        ...state.defaultValues,
+      },
+    }))
+    this.saveOptions(saveFields, id)
   }
 
   buildSections (onChange, translatedLabels) {
@@ -229,7 +246,7 @@ class GlobalSettings extends Component {
 
   render () {
     const { lastTransactionId, currentValues, msg } = this.props
-    const { draftValues, baseValues, sentValues } = this.state
+    const { draftValues, baseValues, sentValues, defaultValues } = this.state
     // required also in Settings for error handling: the case of partial success(only some fields saved)
     // the alert shows the names of the fields that were NOT saved
     const translatedLabels = {
@@ -252,6 +269,8 @@ class GlobalSettings extends Component {
           resetBaseValues={this.resetBaseValues}
           onSave={this.saveOptions}
           onCancel={this.handleCancel}
+          onReset={this.onReset}
+          defaultValues={defaultValues}
         >
           <SettingsBase sections={this.buildSections(this.onChange, translatedLabels)} />
         </Settings>

--- a/src/config.js
+++ b/src/config.js
@@ -12,6 +12,7 @@ const AppConfiguration = {
   pageLimit: 20,
   schedulerFixedDelayInSeconds: 60,
   notificationSnoozeDurationInMinutes: 10,
+  showNotificationsDefault: true,
 
   consoleClientResourcesURL: 'https://www.ovirt.org/documentation/admin-guide/virt/console-client-resources/',
   cockpitPort: '9090',

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -69,6 +69,7 @@ export const messages: { [messageId: string]: MessageType } = {
   cd: 'CD',
   cdCanOnlyChangeWhenVmRunning: 'CD can only be changed when the VM is running.',
   cdromBoot: 'CD-ROM',
+  changesResetSuccessfully: 'Settings have been successfully reset',
   changesSavedSuccesfully: {
     message: 'Changes to settings saved succesfully!',
     description: 'Message displayed when all user settings have been saved successfully',


### PR DESCRIPTION
This PR Resolves: #1390 .
In this PR I added the option to reset the Global settings to the default/installation settings.

The default values (for now) are locale, showNotifications and refreshInterval, in the future we should support also console options.
I added new button on the toolbar left side - "Reset Settings":
![image](https://user-images.githubusercontent.com/64131213/117113741-9403b200-ad93-11eb-860a-0f99d7edd8d6.png).
The button is disabled if the `curruntValues` are equals to the default.
I used the save mechanism so apply the changes and to prevent from the save button activation I added a flag `isReset` that helps us to identify if the current changes are reset or normal saving.

![image](https://user-images.githubusercontent.com/64131213/117113115-b1844c00-ad92-11eb-8b17-cc5cbea62e5f.png)
