### PR TITLE
Fix uptime render in VM Details, Overview Card

### DIFF
--- a/src/components/VmDetails/cards/OverviewCard/index.js
+++ b/src/components/VmDetails/cards/OverviewCard/index.js
@@ -192,7 +192,7 @@ class OverviewCard extends React.Component {
     const { vm, icons, vms, operatingSystems, isEditable, msg } = this.props
     const { isEditing, correlatedMessages, nameError, updateCloudInit, disableHostnameToggle } = this.state
 
-    const elapsedUptime = vm.getIn(['statistics', 'elapsedUptime', 'datum'], 0)
+    const elapsedUptime = vm.getIn(['statistics', 'elapsedUptime', 'firstDatum'], 0)
     const uptime = elapsedUptime <= 0
       ? formatUptimeDuration({ start: vm.get('startTime') })
       : formatUptimeDuration({ interval: elapsedUptime * 1000 })


### PR DESCRIPTION
After changing the way VM statistics were parsed, the `elapsedUptime`
field on the Overview card was not being accessed properly.  This
caused the uptime string not to be rendered at all.  The access has
been updated to the current standard and the uptime is displaying
as it should.