### PR TITLE
Avoid using translated strings in  "key" property

### DIFF
--- a/src/components/Settings/SettingsBase.js
+++ b/src/components/Settings/SettingsBase.js
@@ -44,8 +44,8 @@ const Section = ({ name, section }) => (
       { section.tooltip && <InfoTooltip id={`${name}-info-tooltip`} tooltip={section.tooltip} /> }
     </h3>
     { section.fields.map((field) => (
-      <FormGroup key={field.title} className={style['settings-field']}>
-        <LabelCol fieldPath={`${name}-${field.title}`} tooltip={field.tooltip} sm={3} className={style['field-label']}>
+      <FormGroup key={field.name} className={style['settings-field']}>
+        <LabelCol fieldPath={`${name}-${field.name}`} tooltip={field.tooltip} sm={3} className={style['field-label']}>
           { field.title }
         </LabelCol>
         <Col sm={9}>

--- a/src/components/Settings/SettingsToolbar.js
+++ b/src/components/Settings/SettingsToolbar.js
@@ -43,7 +43,7 @@ const SettingsToolbar = ({ onSave, onReset, onCancel, enableSave, enableReset, t
     <ul className={style['changes-list']}>{
       changes.map(name => {
         const value = translatedLabels[name] || name
-        return (<li key={`${idPrefix}_li_${value}`}>{value}</li>)
+        return (<li key={`${idPrefix}_li_${name}`}>{value}</li>)
       })
     }
     </ul>

--- a/src/components/UserSettings/GlobalSettings.js
+++ b/src/components/UserSettings/GlobalSettings.js
@@ -153,14 +153,17 @@ class GlobalSettings extends Component {
         fields: [
           {
             title: msg.username(),
+            name: 'username',
             body: <span>{config.userName}</span>,
           },
           {
             title: msg.email(),
+            name: 'email',
             body: <span>{config.email}</span>,
           },
           {
             title: translatedLabels.language,
+            name: 'language',
             body: (
               <div className={style['half-width']}>
                 <SelectBox
@@ -175,6 +178,7 @@ class GlobalSettings extends Component {
           {
             title: translatedLabels.sshKey,
             tooltip: msg.sshKeyTooltip(),
+            name: 'sshKey',
             body: (
               <div className={style['half-width']}>
                 <FormControl
@@ -195,6 +199,7 @@ class GlobalSettings extends Component {
         fields: [
           {
             title: translatedLabels.refreshInterval,
+            name: 'refreshInterval',
             body: (
               <div className={style['half-width']}>
                 <SelectBox
@@ -215,6 +220,7 @@ class GlobalSettings extends Component {
         fields: [
           {
             title: translatedLabels.showNotifications,
+            name: 'showNotificatons',
             body: (
               <Switch
                 id={`${idPrefix}-dont-disturb`}
@@ -229,6 +235,7 @@ class GlobalSettings extends Component {
           },
           {
             title: translatedLabels.notificationSnoozeDuration,
+            name: 'notificationSnoozeDuration',
             body: (
               <div className={style['half-width']}>
                 <SelectBox


### PR DESCRIPTION
React uses "key" property to identify items in collections and reports
error if the assigned value is not unique.
After translation some fields may share the same name which violates
this requirement.

Steps to recreate:
1. change language to Japanese
2. go to Account Settings -> Notifications
3. note that both `Do not disturb` and `Do not disturb for` share the same translation
4. check console for errors similar to:
```
Encountered two children with the same key, `%s`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.%s 妨害しない 
    in Section (created by SettingsBase)
    in div (created by SettingsBase)
```
5. change notification settings and save - confirmation dialog will be displayed
6. note that listed changed properties are the same 
7. check console for errors similar to:
```
Encountered two children with the same key, `%s`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.%s settings_toolbar_li_妨害しない 
    in ul (created by SettingsToolbar)
    in div (created by ConfirmationModal)
```