### PR TITLE
Use lower case locale for updating moment

### DIFF
--- a/src/intl/initialize.js
+++ b/src/intl/initialize.js
@@ -94,7 +94,9 @@ export function initMomentTranslations (locale: string, defaultLocale: string) {
   if (translations[locale]) {
     const t:{ [messageId: string]: string } = translations[locale]
 
-    moment.updateLocale(locale, {
+    // for built-in translations moment.js uses lower case identifiers
+    // i.e. pt-br instead of pt-BR
+    moment.updateLocale(locale.toLowerCase(), {
       durationLabelsStandard: {
         S: t.durationLabelStandard_S || timeDurations.durationLabelStandard_S.message,
         SS: t.durationLabelStandard_SS || timeDurations.durationLabelStandard_SS.message,


### PR DESCRIPTION
Internally moment.js seems to use lower case identifiers for locales.
Standard locale format (i.e. pt-BR)  works for initialization but
not for updating built-in translations.

Check #1422  for details how to re-create.