### PR TITLE
Cross reference user domain groups with ovirt groups

### DIFF
--- a/src/ovirtapi/index.js
+++ b/src/ovirtapi/index.js
@@ -73,14 +73,20 @@ const OvirtApi = {
     assertLogin({ methodName: 'icon' })
     return httpGet({ url: `${AppConfiguration.applicationContext}/api/icons/${id}` })
   },
+
   user ({ userId }: { userId: string }): Promise<Object> {
     assertLogin({ methodName: 'user' })
     return httpGet({ url: `${AppConfiguration.applicationContext}/api/users/${userId}` })
   },
-  groups ({ userId }: { userId: string }): Promise<Object> {
-    assertLogin({ methodName: 'groups' })
+  userDomainGroups ({ userId }: { userId: string }): Promise<Object> {
+    assertLogin({ methodName: 'userDomainGroups' })
     return httpGet({ url: `${AppConfiguration.applicationContext}/api/users/${userId}/groups` })
   },
+  groups (): Promise<Object> {
+    assertLogin({ methodName: 'groups' })
+    return httpGet({ url: `${AppConfiguration.applicationContext}/api/groups` })
+  },
+
   getRoles (): Promise<Object> {
     assertLogin({ methodName: 'getRoles' })
     const url = `${AppConfiguration.applicationContext}/api/roles?follow=permits`


### PR DESCRIPTION
At login, we want to know the uuids of the ovirt added domain user groups for the logged in user.  Group membership drives permission look ups.  Since the `/api/users/<userid>/groups` returns the domain user groups, additional work is required to figure out which of those groups are ovirt groups.

Now at login, the domain groups are cross referenced with the ovirt know user groups (i.e. domain groups that have been added
to ovirt in the Administration > Users > Group panels).  This result of the cross reference is a list of the ovirt uuids of the user groups the user is a member of.  With the ovirt uuids the permission calculations used to enable/disable functions of the app will work correctly.

Resolves: #1438

The group id problem surfaced as a result of the fix for issue #1411, PR #1412.