### PR TITLE
Console options

### DIFF
--- a/src/actions/options.js
+++ b/src/actions/options.js
@@ -72,7 +72,22 @@ export function loadUserOptions (userOptions: RemoteUserOptionsType): LoadUserOp
   }
 }
 
-export function saveGlobalOptions ({ values: { sshKey, language, showNotifications, notificationSnoozeDuration, refreshInterval, persistLocale } = {} }: Object, { transactionId }: Object): SaveGlobalOptionsActionType {
+export function saveGlobalOptions ({
+  values: {
+    sshKey,
+    language,
+    persistLocale,
+    showNotifications,
+    notificationSnoozeDuration,
+    refreshInterval,
+    preferredConsole,
+    fullScreenVnc,
+    ctrlAltEndVnc,
+    fullScreenSpice,
+    ctrlAltEndSpice,
+    smartcardSpice,
+  } = {},
+}: Object, { transactionId }: Object): SaveGlobalOptionsActionType {
   return {
     type: C.SAVE_GLOBAL_OPTIONS,
     payload: {
@@ -82,6 +97,12 @@ export function saveGlobalOptions ({ values: { sshKey, language, showNotificatio
       showNotifications,
       notificationSnoozeDuration,
       refreshInterval,
+      preferredConsole,
+      fullScreenVnc,
+      ctrlAltEndVnc,
+      fullScreenSpice,
+      ctrlAltEndSpice,
+      smartcardSpice,
     },
     meta: {
       transactionId,

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -17,7 +17,13 @@ export type SaveGlobalOptionsActionType = {
     persistLocale?: boolean,
     showNotifications?: boolean,
     notificationSnoozeDuration?: number,
-    sshKey?: string
+    sshKey?: string,
+    preferredConsole?: string,
+    fullScreenVnc?: boolean,
+    ctrlAltEndVnc?: boolean,
+    fullScreenSpice?: boolean,
+    ctrlAltEndSpice?: boolean,
+    smartcardSpice?: boolean
   |},
   meta: {|
     transactionId: string

--- a/src/components/Settings/SettingsBase.js
+++ b/src/components/Settings/SettingsBase.js
@@ -62,13 +62,16 @@ Section.propTypes = {
 }
 
 const SettingsBase = ({ name, section }) => {
+  const sections = section.sections ? Object.entries(section.sections) : [[name, section]]
   return (
     <div className={style['search-content-box']}>
-      <Card key={name} className={style['main-content']}>
-        <div className={style['main-content-container']}>
-          <Section name={name} section={section} />
-        </div>
-      </Card>
+      { sections.map(([name, section]) =>
+        <Card key={name} className={style['main-content']}>
+          <div className={style['main-content-container']}>
+            <Section name={name} section={section} />
+          </div>
+        </Card>
+      )}
     </div>
   )
 }

--- a/src/components/UserSettings/GlobalSettings.js
+++ b/src/components/UserSettings/GlobalSettings.js
@@ -127,7 +127,7 @@ class GlobalSettings extends Component {
         ctrlAltEndVnc: false,
         ctrlAltEndSpice: false,
         preferredConsole: config.defaultUiConsole,
-        smartcardSpice: false,
+        smartcardSpice: AppConfiguration.smartcardSpice,
       },
     }
     this.handleCancel = this.handleCancel.bind(this)

--- a/src/components/UserSettings/GlobalSettings.js
+++ b/src/components/UserSettings/GlobalSettings.js
@@ -13,6 +13,7 @@ import { Settings, SettingsBase } from '../Settings'
 import SelectBox from '../SelectBox'
 import moment from 'moment'
 import AppConfiguration from '_/config'
+import { BROWSER_VNC, NATIVE_VNC, SPICE, RDP } from '_/constants/console'
 
 const GENERAL_SECTION = 'general'
 
@@ -59,8 +60,30 @@ class GlobalSettings extends Component {
     ]
   }
 
+  preferredConsoleList (msg) {
+    return [
+      {
+        id: NATIVE_VNC,
+        value: msg.vncConsole(),
+      },
+      {
+        id: BROWSER_VNC,
+        value: msg.vncConsoleBrowser(),
+      },
+      {
+        id: SPICE,
+        value: msg.spiceConsole(),
+      },
+      {
+        id: RDP,
+        value: msg.remoteDesktop(),
+      },
+    ]
+  }
+
   constructor (props) {
     super(props)
+    const { config } = props
     /**
      * Typical flow (happy path):
      * 1. at the begining:
@@ -99,6 +122,12 @@ class GlobalSettings extends Component {
         refreshInterval: AppConfiguration.schedulerFixedDelayInSeconds,
         notificationSnoozeDuration: AppConfiguration.notificationSnoozeDurationInMinutes,
         persistLocale: AppConfiguration.persistLocale,
+        fullScreenVnc: false,
+        fullScreenSpice: false,
+        ctrlAltEndVnc: false,
+        ctrlAltEndSpice: false,
+        preferredConsole: config.defaultUiConsole,
+        smartcardSpice: false,
       },
     }
     this.handleCancel = this.handleCancel.bind(this)
@@ -181,22 +210,6 @@ class GlobalSettings extends Component {
               </div>
             ),
           }))('language'),
-          ((name) => ({
-            title: msg.sshKey(),
-            tooltip: msg.sshKeyTooltip(),
-            name,
-            body: (
-              <div className={style['half-width']}>
-                <FormControl
-                  id={`${idPrefix}-${name}`}
-                  componentClass='textarea'
-                  onChange={e => onChange(name)(e.target.value)}
-                  value={draftValues[name] || ''}
-                  rows={8}
-                />
-              </div>
-            ),
-          }))('sshKey'),
         ],
       },
       refreshInterval: {
@@ -254,6 +267,144 @@ class GlobalSettings extends Component {
             ),
           }))('notificationSnoozeDuration'),
         ],
+      },
+      console: {
+        title: msg.console(),
+        fields: [ ],
+        sections: {
+          console: {
+            title: msg.console(),
+            tooltip: msg.globalSettingsTooltip(),
+            fields: [],
+          },
+          preferredConsole: {
+            title: '',
+            fields: [
+              ((name) => ({
+                title: msg.preferredConsole(),
+                tooltip: msg.preferredConsoleTooltip(),
+                name,
+                body: (
+                  <div className={style['half-width']}>
+                    <SelectBox
+                      id={`${idPrefix}-${name}`}
+                      items={this.preferredConsoleList(msg)
+                        .map(({ id, value }) => ({
+                          id,
+                          value,
+                          isDefault: id === config.defaultUiConsole,
+                        }))
+                      }
+                      selected={draftValues[name]}
+                      onChange={onChange(name)}
+                    />
+                  </div>
+                ),
+              }))('preferredConsole'),
+            ],
+          },
+          vnc: {
+            title: msg.vncOptions(),
+            fields: [
+              ((name) => ({
+                title: msg.fullScreenMode(),
+                name,
+                body: (
+                  <Switch
+                    id={`${idPrefix}-${name}`}
+                    isChecked={draftValues[name]}
+                    onChange={(fullScreen) => {
+                      onChange(name)(fullScreen)
+                    }}
+                  />
+                ),
+              }))('fullScreenVnc'),
+              ((name) => ({
+                title: msg.ctrlAltEnd(),
+                tooltip: msg.remapCtrlAltDelete(),
+                name,
+                body: (
+                  <Switch
+                    id={`${idPrefix}-${name}`}
+
+                    isChecked={draftValues[name]}
+                    onChange={(ctrlAltEnd) => {
+                      onChange(name)(ctrlAltEnd)
+                    }}
+                  />
+                ),
+              }))('ctrlAltEndVnc'),
+            ],
+          },
+          spice: {
+            title: msg.spiceOptions(),
+            fields: [
+              ((name) => ({
+                title: msg.fullScreenMode(),
+                name,
+                body: (
+                  <Switch
+                    id={`${idPrefix}-${name}`}
+                    isChecked={draftValues[name]}
+                    onChange={(fullScreen) => {
+                      onChange(name)(fullScreen)
+                    }}
+                  />
+                ),
+              }))('fullScreenSpice'),
+              ((name) => ({
+                title: msg.ctrlAltEnd(),
+                tooltip: msg.remapCtrlAltDelete(),
+                name,
+                body: (
+                  <Switch
+                    id={`${idPrefix}-${name}`}
+                    isChecked={draftValues[name]}
+                    onChange={(ctrlAltEnd) => {
+                      onChange(name)(ctrlAltEnd)
+                    }}
+                  />
+                ),
+              }))('ctrlAltEndSpice'),
+              ((name) => ({
+                title: msg.smartcard(),
+                tooltip: msg.smartcardTooltip(),
+                name,
+                body: (
+                  <Switch
+                    id={`${idPrefix}-${name}`}
+                    isChecked={draftValues[name]}
+                    onChange={(smartcard) => {
+                      onChange(name)(smartcard)
+                    }}
+                  />
+                ),
+              }))('smartcardSpice'),
+            ],
+          },
+          serial: {
+            title: msg.serialConsoleOptions(),
+            fields: [
+              ((name) => ({
+                title: msg.sshKey(),
+                tooltip: msg.sshKeyTooltip(),
+                name,
+                body: (
+                  <div className={style['half-width']}>
+                    <FormControl
+                      id={`${idPrefix}-${name}`}
+                      componentClass='textarea'
+                      onChange={e => onChange(name)(e.target.value)}
+                      value={draftValues[name] || ''}
+                      rows={8}
+                    />
+                  </div>
+                ),
+              }))('sshKey'),
+            ],
+          },
+        },
+
       },
       advancedOptions: {
         title: msg.advancedOptions(),
@@ -347,6 +498,7 @@ export default connect(
     config: {
       userName: config.getIn(['user', 'name']),
       email: config.getIn(['user', 'email']),
+      defaultUiConsole: config.getIn(['defaultUiConsole']),
     },
     currentValues: {
       sshKey: options.getIn(['ssh', 'key']),
@@ -355,6 +507,12 @@ export default connect(
       notificationSnoozeDuration: options.getIn(['localOptions', 'notificationSnoozeDuration']),
       refreshInterval: options.getIn(['remoteOptions', 'refreshInterval', 'content']),
       persistLocale: options.getIn(['remoteOptions', 'persistLocale', 'content']),
+      fullScreenVnc: options.getIn(['remoteOptions', 'fullScreenVnc', 'content']),
+      fullScreenSpice: options.getIn(['remoteOptions', 'fullScreenSpice', 'content']),
+      ctrlAltEndVnc: options.getIn(['remoteOptions', 'ctrlAltEndVnc', 'content']),
+      ctrlAltEndSpice: options.getIn(['remoteOptions', 'ctrlAltEndSpice', 'content']),
+      preferredConsole: options.getIn(['remoteOptions', 'preferredConsole', 'content'], config.getIn(['defaultUiConsole'])),
+      smartcardSpice: options.getIn(['remoteOptions', 'smartcardSpice', 'content']),
     },
     lastTransactionId: options.getIn(['lastTransactions', 'global', 'transactionId'], ''),
   }),

--- a/src/components/VmActions/index.js
+++ b/src/components/VmActions/index.js
@@ -128,6 +128,7 @@ class VmActions extends React.Component {
       onSuspend,
       onRDP,
       msg,
+      preferredConsole,
     } = this.props
     const isPoolVm = !!vm.getIn(['pool', 'id'], false)
     const isPool = !!pool && !isPoolVm
@@ -137,7 +138,6 @@ class VmActions extends React.Component {
     const vncConsole = vm.get('consoles').find(c => c.get('protocol') === VNC)
     const spiceConsole = vm.get('consoles').find(c => c.get('protocol') === SPICE)
     const hasRdp = isWindows(vm.getIn(['os', 'type']))
-    const defaultUiConsole = config.get('defaultUiConsole')
     let consoles = []
 
     if (vncConsole) {
@@ -197,7 +197,7 @@ class VmActions extends React.Component {
     }
 
     consoles = consoles
-      .map(({ uiConsole, ...props }) => ({ ...props, priority: uiConsole === defaultUiConsole ? 1 : 0 }))
+      .map(({ uiConsole, ...props }) => ({ ...props, priority: uiConsole === preferredConsole ? 1 : 0 }))
       .sort((a, b) => b.priority - a.priority)
 
     const actions = [
@@ -391,6 +391,7 @@ VmActions.propTypes = {
   onStartVm: PropTypes.func.isRequired,
   onRDP: PropTypes.func.isRequired,
   msg: PropTypes.object.isRequired,
+  preferredConsole: PropTypes.string,
 }
 
 export default withRouter(
@@ -398,6 +399,7 @@ export default withRouter(
     (state, { vm }) => ({
       isEditable: vm.get('canUserEditVm') && state.clusters.find(cluster => cluster.get('canUserUseCluster')) !== undefined,
       config: state.config,
+      preferredConsole: state.options.getIn(['remoteOptions', 'preferredConsole', 'content'], state.config.get('defaultUiConsole')),
     }),
     (dispatch, { vm, pool }) => ({
       onShutdown: () => dispatch(shutdownVm({ vmId: vm.get('id'), force: false })),

--- a/src/config.js
+++ b/src/config.js
@@ -16,6 +16,7 @@ const AppConfiguration = {
   notificationSnoozeDurationInMinutes: 10,
   showNotificationsDefault: true,
   persistLocale: true,
+  smartcardSpice: true,
 
   consoleClientResourcesURL: 'https://www.ovirt.org/documentation/admin-guide/virt/console-client-resources/',
   cockpitPort: '9090',

--- a/src/config.js
+++ b/src/config.js
@@ -27,7 +27,7 @@ export const DefaultEngineOptions = Object.seal({
   MaxNumOfThreadsPerCpu: 8,
   MaxNumOfVmCpusPerArch: `{${DEFAULT_ARCH}=1}`,
 
-  SpiceUsbAutoShare: 1,
+  SpiceUsbAutoShare: true,
   getUSBFilter: {},
 
   UserSessionTimeOutInterval: 30,

--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -1183,6 +1183,7 @@ const EngineOptionMaxNumOfVmCpusPerArch = {
 // Export each transforms individually so they can be consumed individually
 //
 export {
+  convertBool,
   VM,
   Pool,
   CdRom,

--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -1034,12 +1034,24 @@ const RemoteUserOptions = {
       locale,
       refreshInterval,
       persistLocale,
+      preferredConsole,
+      fullScreenVnc,
+      ctrlAltEndVnc,
+      fullScreenSpice,
+      ctrlAltEndSpice,
+      smartcardSpice,
     } = fromEntries
 
     return {
       locale,
       refreshInterval,
       persistLocale,
+      preferredConsole,
+      fullScreenVnc,
+      ctrlAltEndVnc,
+      fullScreenSpice,
+      ctrlAltEndSpice,
+      smartcardSpice,
     }
   },
 }

--- a/src/ovirtapi/types.js
+++ b/src/ovirtapi/types.js
@@ -232,9 +232,15 @@ export type GlobalUserSettingsType = {|
 |}
 
 export type RemoteUserOptionsType = {|
-  locale: Object,
+  locale?: UserOptionType<string>,
   refreshInterval?: UserOptionType<number>,
-  persistLocale?: UserOptionType<boolean>
+  persistLocale?: UserOptionType<boolean>,
+  preferredConsole?: UserOptionType<string>,
+  fullScreenVnc?: UserOptionType<boolean>,
+  ctrlAltEndVnc?: UserOptionType<boolean>,
+  fullScreenSpice?: UserOptionType<boolean>,
+  ctrlAltEndSpice?: UserOptionType<boolean>,
+  smartcardSpice?: UserOptionType<boolean>
 |}
 
 export type UserOptionsType = {|

--- a/src/reducers/options.js
+++ b/src/reducers/options.js
@@ -27,6 +27,26 @@ const defaultOptions: UserOptionsType = {
       id: undefined,
       content: AppConfiguration.schedulerFixedDelayInSeconds,
     },
+    fullScreenVnc: {
+      id: undefined,
+      content: false,
+    },
+    ctrlAltEndVnc: {
+      id: undefined,
+      content: false,
+    },
+    fullScreenSpice: {
+      id: undefined,
+      content: false,
+    },
+    ctrlAltEndSpice: {
+      id: undefined,
+      content: false,
+    },
+    smartcardSpice: {
+      id: undefined,
+      content: false,
+    },
   },
   ssh: undefined,
   lastTransactions: {},

--- a/src/reducers/options.js
+++ b/src/reducers/options.js
@@ -45,7 +45,7 @@ const defaultOptions: UserOptionsType = {
     },
     smartcardSpice: {
       id: undefined,
-      content: false,
+      content: AppConfiguration.smartcardSpice,
     },
   },
   ssh: undefined,

--- a/src/sagas/console/vvFileUtils.js
+++ b/src/sagas/console/vvFileUtils.js
@@ -1,15 +1,12 @@
 
-export function adjustVVFile ({ data, options, usbAutoshare, usbFilter }) {
-  // __options__ can either be a plain JS object or ImmutableJS Map
-  console.log('adjustVVFile options:', options)
-
-  if (options && ((options.get && options.get('fullscreen')) || options.fullscreen)) {
+export function adjustVVFile ({ data = '', options: { fullscreen, ctrlAltDelToEnd, smartcardEnabled, usbAutoshare, usbFilter } = {} } = {}) {
+  if (fullscreen) {
     data = data.replace(/^fullscreen=0/mg, 'fullscreen=1')
   }
 
   const pattern = /^secure-attention=.*$/mg
   let text = 'secure-attention=ctrl+alt+del'
-  if (options && ((options.get && options.get('ctrlAltDelToEnd')) || options.ctrlAltDelToEnd)) {
+  if (ctrlAltDelToEnd) {
     text = 'secure-attention=ctrl+alt+end'
   }
   if (data.match(pattern)) {
@@ -20,20 +17,14 @@ export function adjustVVFile ({ data, options, usbAutoshare, usbFilter }) {
     data = data.replace(/^\[virt-viewer\]$/mg, `[virt-viewer]\n${text}`) // ending \n is already there
   }
 
-  const isSpice = data.indexOf('type=spice') > -1
-
-  if (usbFilter && isSpice) {
+  if (usbFilter) {
     data = data.replace(/^\[virt-viewer\]$/mg, `[virt-viewer]\nusb-filter=${usbFilter}`)
     data = data.replace(/^usb-filter=null\n/mg, '') // remove an extra 'usb-filter=null' line if present
   }
 
-  if (options && isSpice) {
-    const smartcardEnabled = options.get ? options.get('smartcardEnabled') : options.smartcardEnabled
-    data = data.replace(/^enable-smartcard=[01]$/mg, `enable-smartcard=${smartcardEnabled ? 1 : 0}`)
-  }
+  data = data.replace(/^enable-smartcard=[01]$/mg, `enable-smartcard=${smartcardEnabled ? 1 : 0}`)
 
-  // make USB Auto-Share to be enabled/disabled in VM Portal according to the SpiceUsbAutoShare config value
-  data = data.replace(/^enable-usb-autoshare=.*$/mg, `enable-usb-autoshare=${usbAutoshare.toString() === 'true' ? 1 : 0}`)
+  data = data.replace(/^enable-usb-autoshare=.*$/mg, `enable-usb-autoshare=${usbAutoshare ? 1 : 0}`)
 
   console.log('adjustVVFile data after adjustment:', data)
   return data

--- a/src/sagas/console/vvFileUtils.test.js
+++ b/src/sagas/console/vvFileUtils.test.js
@@ -1,0 +1,43 @@
+import { adjustVVFile } from './vvFileUtils'
+
+describe('test error handling', function () {
+  it('should return empty string when no data', function () {
+    expect(adjustVVFile()).toEqual('')
+  })
+  it('should add secure attention when missing', function() {
+    const data = '[virt-viewer]\ntype=vnc\n'
+    expect(adjustVVFile({data})).toEqual('[virt-viewer]\nsecure-attention=ctrl+alt+del\ntype=vnc\n')
+  })
+})
+
+describe('test flags one-by-one', function () {
+  it('should set fullscreen', function () {
+    const data = '[virt-viewer]\nfullscreen=0\nsecure-attention=ctrl+alt+del\n'
+    const options = {fullscreen: true}
+    expect(adjustVVFile({data, options},)).toEqual('[virt-viewer]\nfullscreen=1\nsecure-attention=ctrl+alt+del\n')
+  })
+
+  it('should set secure-attention', function () {
+    const data = '[virt-viewer]\nsecure-attention=ctrl+alt+del\n'
+    const options = {ctrlAltDelToEnd: true}
+    expect(adjustVVFile({data, options},)).toEqual('[virt-viewer]\nsecure-attention=ctrl+alt+end\n')
+  })
+
+  it('should set usb filter', function () {
+    const data = '[virt-viewer]\nusb-filter=null\nsecure-attention=ctrl+alt+del\n'
+    const options = {usbFilter: '1,1,1,1'}
+    expect(adjustVVFile({data, options},)).toEqual('[virt-viewer]\nusb-filter=1,1,1,1\nsecure-attention=ctrl+alt+del\n')
+  })
+
+  it('should set enable-smartcard', function () {
+    const data = '[virt-viewer]\nenable-smartcard=0\nsecure-attention=ctrl+alt+del\n'
+    const options = {smartcardEnabled: true}
+    expect(adjustVVFile({data, options},)).toEqual('[virt-viewer]\nenable-smartcard=1\nsecure-attention=ctrl+alt+del\n')
+  })
+
+  it('should set enable-usb-autoshare', function () {
+    const data = '[virt-viewer]\nenable-usb-autoshare=0\nsecure-attention=ctrl+alt+del\n'
+    const options = {usbAutoshare: true}
+    expect(adjustVVFile({data, options},)).toEqual('[virt-viewer]\nenable-usb-autoshare=1\nsecure-attention=ctrl+alt+del\n')
+  })
+})

--- a/src/sagas/server-configs.js
+++ b/src/sagas/server-configs.js
@@ -46,7 +46,7 @@ export function* fetchServerConfiguredValues () {
   }))
 
   if (eo.usbAutoShare) {
-    yield put(setSpiceUsbAutoShare(eo.usbAutoShare))
+    yield put(setSpiceUsbAutoShare(Transforms.convertBool(eo.usbAutoShare)))
   }
 
   if (eo.usbFilter) {


### PR DESCRIPTION
**NOTE** that this PR depends on #1420  **AND**  #1456

### Add Console section to Account Settings

Added options (all options are persisted on the server):
1. preferredConsole - the console that will be the first console
   available to the user (if supported by the VM)
2. VNC options:
   a) full screen mode
   b) secure attention (mapping Ctrl+Alt+Del to Ctrl+Alt+End)
3. SPICE option
   a) full screen mode
   b) secure attention
   c) smartcard

Moved options:
1. SSH key moved from General section to Console - the key is only
  relevant for Serial Console access.

### Preserve the order and group options by section

Extracted to #1456 
    
### Apply custom Console settings
    
1. enhance vv files using the values configured via Account Settings
2. let preferredConsole override default console sent from the server


