### PR TITLE
Disable the docker container builds on travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,30 @@
 language: node_js
 
 services:
-  - docker
+  # - docker
 
 script:
   - yarn run build
-  - docker build --tag web-ui .
-  - docker run -d --rm -it -e ENGINE_URL=https://localhost/ovirt-engine -p 3000:3000 --name web-ui web-ui
-  - >
-    for i in {1..7}; do
-      docker logs web-ui
-      docker logs web-ui 2>&1  | grep -Pzl 'error'
-      if [ $? -eq 0 ]; then
-        echo 'oVirt VM Portal did not start up successfully'
-        exit 1
-      fi
-      docker logs web-ui 2>&1  | grep -Pzl 'Please authenticate against oVirt running at https://localhost/ovirt-engine'
-      if [ $? -eq 0 ]; then
-        break
-      fi
-      if [ $i -eq 7 ]; then
-        echo 'oVirt VM Portal did not start up successfully'
-        exit 1
-      fi
-      sleep 2
-    done
+  # - docker build --tag web-ui .
+  # - docker run -d --rm -it -e ENGINE_URL=https://localhost/ovirt-engine -p 3000:3000 --name web-ui web-ui
+  # - >
+  #   for i in {1..7}; do
+  #     docker logs web-ui
+  #     docker logs web-ui 2>&1  | grep -Pzl 'error'
+  #     if [ $? -eq 0 ]; then
+  #       echo 'oVirt VM Portal did not start up successfully'
+  #       exit 1
+  #     fi
+  #     docker logs web-ui 2>&1  | grep -Pzl 'Please authenticate against oVirt running at https://localhost/ovirt-engine'
+  #     if [ $? -eq 0 ]; then
+  #       break
+  #     fi
+  #     if [ $i -eq 7 ]; then
+  #       echo 'oVirt VM Portal did not start up successfully'
+  #       exit 1
+  #     fi
+  #     sleep 2
+  #   done
 
 node_js:
   - "10"


### PR DESCRIPTION
Due to (1) consistent docker container build problems on travisci,
and (2) container issues to be considered in issue #1442, disable
the docker container build.  Any updates to the docker hub image
will need to be manual until #1442 is resolved.