### PR TITLE
Mark a default option for the Notifications' SelectBox in Account Settings

### DIFF
--- a/src/components/UserSettings/GlobalSettings.js
+++ b/src/components/UserSettings/GlobalSettings.js
@@ -244,7 +244,8 @@ class GlobalSettings extends Component {
               <div className={style['half-width']}>
                 <SelectBox
                   id={`${idPrefix}-dont-disturb-for`}
-                  items={this.dontDisturbList(msg)}
+                  items={this.dontDisturbList(msg)
+                    .map(({ id, value }) => ({ id, value, isDefault: id === AppConfiguration.notificationSnoozeDurationInMinutes }))}
                   selected={draftValues.notificationSnoozeDuration}
                   onChange={onChange('notificationSnoozeDuration')}
                   disabled={draftValues.showNotifications}


### PR DESCRIPTION
Issue: https://github.com/oVirt/ovirt-web-ui/issues/1434

This PR supports marking a default option for the SelectBox of the `notificationSnoozeDurationInMinutes`, in Account Settings, which is 10 minutes.

**Before:**
![default_before2](https://user-images.githubusercontent.com/13417815/122039430-fa3e1480-cdd6-11eb-9992-81f274b0e6a8.png)
![default_before](https://user-images.githubusercontent.com/13417815/122039439-fd390500-cdd6-11eb-8c52-c2a14cb86e7a.png)

**After:**
![default_after2](https://user-images.githubusercontent.com/13417815/122039465-01fdb900-cdd7-11eb-8db2-e362b668745d.png)
![default_after](https://user-images.githubusercontent.com/13417815/122039475-03c77c80-cdd7-11eb-9131-7930fb0d87c2.png)
