### PR TITLE
refactor sagas - improve disk permit/permissions calculations

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -10,3 +10,4 @@ module.name_mapper.extension='css' -> '<PROJECT_ROOT>/config/flow/css.js.flow'
 module.name_mapper='^_\/\(.*\)$' ->'<PROJECT_ROOT>/src/\1'
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
 suppress_comment=\\(.\\|\n\\)*\\$FlowIssue
+esproposal.optional_chaining=enable

--- a/src/ovirtapi/index.js
+++ b/src/ovirtapi/index.js
@@ -54,8 +54,6 @@ const OvirtApi = {
 
   snapshotToInternal: Transforms.Snapshot.toInternal,
 
-  permissionsToInternal: Transforms.Permissions.toInternal,
-
   eventToInternal: Transforms.Event.toInternal,
 
   //

--- a/src/ovirtapi/index.js
+++ b/src/ovirtapi/index.js
@@ -120,19 +120,6 @@ const OvirtApi = {
     return httpGet({ url })
   },
 
-  // TODO: Convert to use frontend based role to permission mapping
-  getDiskPermissions ({ id }: { id: string }): Promise<Object> {
-    assertLogin({ methodName: 'getDiskPermissions' })
-    const url = `${AppConfiguration.applicationContext}/api/disks/${id}/permissions?follow=role.permits`
-    return httpGet({ url, custHeaders: { Filter: true } })
-  },
-  // TODO: Convert to use frontend based role to permission mapping
-  getVmPermissions ({ vmId }: VmIdType): Promise<Object> {
-    assertLogin({ methodName: 'getVmPermissions' })
-    const url = `${AppConfiguration.applicationContext}/api/vms/${vmId}/permissions?follow=role.permits`
-    return httpGet({ url, custHeaders: { Filter: true } })
-  },
-
   // ---- VM fetching
   getVm ({ vmId, additional }: { vmId: string, additional: Array<string> }): Promise<Object> {
     assertLogin({ methodName: 'getVm' })
@@ -287,13 +274,13 @@ const OvirtApi = {
     return httpGet({ url: `${AppConfiguration.applicationContext}/api/vms/${vmId}/snapshots` })
   },
 
-  diskattachment ({ vmId, attachmentId }: { vmId: string, attachmentId: string}): Promise<Object> {
-    assertLogin({ methodName: 'diskattachment' })
-    return httpGet({ url: `${AppConfiguration.applicationContext}/api/vms/${vmId}/diskattachments/${attachmentId}?follow=disk` })
-  },
   diskattachments ({ vmId }: VmIdType): Promise<Object> {
     assertLogin({ methodName: 'diskattachments' })
-    return httpGet({ url: `${AppConfiguration.applicationContext}/api/vms/${vmId}/diskattachments` })
+    return httpGet({ url: `${AppConfiguration.applicationContext}/api/vms/${vmId}/diskattachments?follow=disk.permissions` })
+  },
+  diskattachment ({ vmId, attachmentId }: { vmId: string, attachmentId: string}): Promise<Object> {
+    assertLogin({ methodName: 'diskattachment' })
+    return httpGet({ url: `${AppConfiguration.applicationContext}/api/vms/${vmId}/diskattachments/${attachmentId}?follow=disk.permissions` })
   },
   disk ({ diskId }: { diskId: string }): Promise<Object> {
     assertLogin({ methodName: 'disk' })

--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -101,9 +101,7 @@ function getPoolColor (id: string): string {
 //
 const VM = {
   toInternal ({ vm }: { vm: ApiVmType }): VmType {
-    const permissions = vm.permissions && vm.permissions.permission
-      ? Permissions.toInternal({ permissions: vm.permissions.permission })
-      : []
+    const permissions = Permissions.toInternal({ permissions: vm?.permissions?.permission })
 
     const parsedVm: Object = {
       name: vm.name,
@@ -407,9 +405,7 @@ const Template = {
       baseTemplateId: template.version && template.version.base_template ? template.version.base_template.id : undefined,
     }
 
-    const permissions = template.permissions && template.permissions.permission
-      ? Permissions.toInternal({ permissions: template.permissions.permission })
-      : []
+    const permissions = Permissions.toInternal({ permissions: template?.permissions?.permission })
 
     return cleanUndefined({
       id: template.id,
@@ -537,9 +533,7 @@ const Snapshot = {
 // VM -> DiskAttachments.DiskAttachment[] -> Disk
 const DiskAttachment = {
   toInternal ({ attachment, disk }: { attachment?: ApiDiskAttachmentType, disk: ApiDiskType }): DiskType {
-    const permissions = disk.permissions && disk.permissions.permission
-      ? Permissions.toInternal({ permissions: disk.permissions.permission })
-      : []
+    const permissions = Permissions.toInternal({ permissions: disk?.permissions?.permission })
 
     const cleanBase = cleanUndefined({
       attachmentId: attachment && attachment.id,
@@ -622,9 +616,7 @@ const DiskAttachment = {
 //
 const DataCenter = {
   toInternal ({ dataCenter }: { dataCenter: ApiDataCenterType }): DataCenterType {
-    const permissions = dataCenter.permissions && dataCenter.permissions.permission
-      ? Permissions.toInternal({ permissions: dataCenter.permissions.permission })
-      : []
+    const permissions = Permissions.toInternal({ permissions: dataCenter?.permissions?.permission })
 
     const storageDomains = dataCenter.storage_domains && dataCenter.storage_domains.storage_domain
       ? dataCenter.storage_domains.storage_domain.reduce((acc, storageDomain) => {
@@ -655,9 +647,7 @@ const DataCenter = {
 //
 const StorageDomain = {
   toInternal ({ storageDomain }: { storageDomain: ApiStorageDomainType }): StorageDomainType {
-    const permissions = storageDomain.permissions && storageDomain.permissions.permission
-      ? Permissions.toInternal({ permissions: storageDomain.permissions.permission })
-      : []
+    const permissions = Permissions.toInternal({ permissions: storageDomain?.permissions?.permission })
 
     return {
       id: storageDomain.id,
@@ -722,9 +712,7 @@ const StorageDomainFile = {
 //
 const Cluster = {
   toInternal ({ cluster }: { cluster: ApiClusterType }): ClusterType {
-    const permissions = cluster.permissions && cluster.permissions.permission
-      ? Permissions.toInternal({ permissions: cluster.permissions.permission })
-      : []
+    const permissions = Permissions.toInternal({ permissions: cluster?.permissions?.permission })
 
     const c: Object = {
       id: cluster.id,
@@ -821,9 +809,7 @@ const Nic = {
 //
 const VNicProfile = {
   toInternal ({ vnicProfile }: { vnicProfile: ApiVnicProfileType }): VnicProfileType {
-    const permissions = vnicProfile.permissions && vnicProfile.permissions.permission
-      ? Permissions.toInternal({ permissions: vnicProfile.permissions.permission })
-      : []
+    const permissions = Permissions.toInternal({ permissions: vnicProfile?.permissions?.permission })
 
     const vnicProfileInternal = {
       id: vnicProfile.id,

--- a/src/sagas/disks.js
+++ b/src/sagas/disks.js
@@ -40,7 +40,7 @@ function* fetchVmDisks ({ vmId }) {
 
   const internalDisks = []
 
-  if (diskattachments && diskattachments.disk_attachment) {
+  if (diskattachments?.disk_attachment) {
     for (const attachment of diskattachments.disk_attachment) {
       internalDisks.push(yield transformAndPermitDiskAttachment(attachment))
     }

--- a/src/sagas/utils.js
+++ b/src/sagas/utils.js
@@ -10,7 +10,6 @@ import {
 import AppConfiguration from '_/config'
 import { hidePassword } from '_/helpers'
 import Api from '_/ovirtapi'
-import { getUserPermits } from '_/utils'
 import semverGte from 'semver/functions/gte'
 import semverValid from 'semver/functions/valid'
 
@@ -184,18 +183,6 @@ export function* delayInMsSteps (count = 20, msMultiplier = 2000) {
   for (let i = 2; i < (count + 2); i++) {
     yield Math.round(Math.log2(i) * msMultiplier)
   }
-}
-
-export function* fetchPermits ({ entityType, id }) {
-  const permissions = yield callExternalAction(`get${entityType}Permissions`, Api[`get${entityType}Permissions`], { payload: { id } })
-  if (permissions && Array.isArray(permissions.permission)) {
-    return getUserPermits(Api.permissionsToInternal({ permissions: permissions.permission }))
-  }
-  return []
-}
-
-export const PermissionsType = {
-  DISK_TYPE: 'Disk',
 }
 
 /**

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -1,6 +1,5 @@
 // @flow
-import Selectors from '_/selectors'
-import type { ClusterType, PermissionType, VnicProfileType } from '_/ovirtapi/types'
+import type { ClusterType, VnicProfileType } from '_/ovirtapi/types'
 
 function checkUserPermit (permit: string | Array<string>, permits: Set<string>): boolean {
   if (Array.isArray(permit)) {
@@ -67,22 +66,4 @@ export function canUserUseAnyVnicProfile (vnicProfiles: Array<VnicProfileType>, 
   return vnicProfiles.find(vnicProfile =>
     vnicProfile.get('canUserUseProfile') && vnicProfile.getIn(['network', 'dataCenterId']) === dataCenterId
   ) !== undefined
-}
-
-export function getUserPermits (permissions: Array<PermissionType>): Set<string> {
-  const userFilter = Selectors.getFilter()
-  const userGroups = Selectors.getUserGroups()
-  const userId = Selectors.getUserId()
-
-  const permits = new Set()
-  permissions.forEach((role) => {
-    if (userFilter ||
-      (
-        (role.groupId && userGroups.includes(role.groupId)) ||
-        (role.userId && role.userId === userId)
-      )) {
-      role.permits.map((permit) => permit.name).forEach((permit) => permits.add(permit))
-    }
-  })
-  return permits
 }


### PR DESCRIPTION
Refactor the disk related sagas to fetch the permissions and to calculate the permits on the front end. This follows existing permission -> permit -> canUser* calculations done in the rest of the app. Any remaining permission/permit only fetching support have been removed to avoid and future confusion.

Reduce the number of rest calls required to permit disks that are fetched:
  - on single vm fetch (disk_attachments.disk.permissions)
  - on update a vm's disks (disk.permissions)
  - on update a single disk attachment (disk.permsissions)

Remove unused direct fetch permit/permission functionality. Now, all permissions are fetched along with entities that need. The permission to permit mapping is all done on in the app.  `canUse*` constants are calculated during the fetch after the transforms.

