### PR TITLE
Load Portuguese or Chinese languages by reading locales from the url

### DIFF
--- a/src/intl/initialize.js
+++ b/src/intl/initialize.js
@@ -64,11 +64,16 @@ export function coerceToSupportedLocale (locale: ?string): ?string {
     return 'en'
   }
 
-  if (BASE_LOCALE_SET.has(locale)) {
-    return locale
+  let commonLocale = locale.replace('_', '-')
+  const localeArray = commonLocale.split(/[-]/)
+  if (localeArray.length === 2) {
+    commonLocale = localeArray[0] + '-' + localeArray[1].toUpperCase()
+  }
+  if (BASE_LOCALE_SET.has(commonLocale)) {
+    return commonLocale
   }
 
-  const languageOnlyLocale = locale.split(/[-_]/)[0]
+  const languageOnlyLocale = localeArray[0]
   return BASE_LOCALE_SET.has(languageOnlyLocale) ? languageOnlyLocale : null
 }
 

--- a/src/intl/initialize.test.js
+++ b/src/intl/initialize.test.js
@@ -1,0 +1,32 @@
+/* eslint-env jest */
+import { coerceToSupportedLocale } from './initialize'
+
+describe('coerce to supported locale', () => {
+  test.each([null, '', 'pt', 'pt-PT', 'nv'])(
+    'returns null for [%s]',
+    locale => {
+      expect(coerceToSupportedLocale(locale)).toEqual(null)
+    }
+  )
+
+  test.each(['pt_BR', 'pt-BR', 'pt_br', 'pt-br'])(
+    'returns pt-BR for [%s]',
+    locale => {
+      expect(coerceToSupportedLocale(locale)).toEqual('pt-BR')
+    }
+  )
+
+  test.each(['en_US', 'en_us', 'en-US', 'en-us', 'en'])(
+    'returns en for [%s]',
+    locale => {
+      expect(coerceToSupportedLocale(locale)).toEqual('en')
+    }
+  )
+
+  test.each(['zh_CN', 'zh-CN', 'zh_cn', 'zh-cn'])(
+    'returns zh-CN for [%s]',
+    locale => {
+      expect(coerceToSupportedLocale(locale)).toEqual('zh-CN')
+    }
+  )
+})


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/1448

Load the chosen language successfully in web-ui after reading query string locale 'pt_BR' or 'zh_CN' from the URL (landing page locales).

**Before:**
 ![before](https://user-images.githubusercontent.com/13417815/123712451-9e619a00-d872-11eb-8258-05917b9392ea.png)

**After:**
![after](https://user-images.githubusercontent.com/13417815/123712456-a1f52100-d872-11eb-959f-81f25ecd5070.png)

