### PR TITLE
refactor - remove the rest of the OvirtApi toInternal functions

### DIFF
--- a/src/components/VmDetails/cards/SnapshotsCard/sagas.js
+++ b/src/components/VmDetails/cards/SnapshotsCard/sagas.js
@@ -1,6 +1,6 @@
 import { takeEvery, put } from 'redux-saga/effects'
 
-import Api from '_/ovirtapi'
+import Api, { Transforms } from '_/ovirtapi'
 import { callExternalAction, delay, delayInMsSteps } from '_/sagas/utils'
 import { fetchVmSnapshots, startProgress, stopProgress } from '_/sagas'
 import {
@@ -49,7 +49,7 @@ function* deleteVmSnapshot (action) {
       snapshotRemoved = true
       break
     } else {
-      const snapshotInternal = Api.snapshotToInternal({ snapshot })
+      const snapshotInternal = Transforms.Snapshot.toInternal({ snapshot })
       yield put(updateVmSnapshot({ vmId, snapshot: snapshotInternal }))
     }
     yield delay(delaySec * 1000)

--- a/src/mock/ovirtapi.mock.js
+++ b/src/mock/ovirtapi.mock.js
@@ -1,25 +1,9 @@
 /* eslint-disable prefer-promise-reject-errors */
 import AppConfiguration from '../config'
 import { vms, disks, api } from './data.mock'
-import MainApi from '../ovirtapi'
 
 let OvirtApi = {}
 OvirtApi = {
-  // ----
-  /**
-   * @param vm - Single entry from oVirt REST /api/vms
-   * @returns {} - Internal representation of a VM
-   */
-  vmToInternal: MainApi.vmToInternal,
-  /**
-   *
-   * @param attachment - single entry from vms/[VM_ID]/diskattachments
-   * @param disk - disk corresponding to the attachment
-   * @returns {} - Internal representation of a single VM disk
-   */
-  diskToInternal: MainApi.diskToInternal,
-  iconToInternal: MainApi.iconToInternal,
-  consolesToInternal: MainApi.consolesToInternal,
   // ----
   login ({ credentials }) {
     return Promise.resolve({

--- a/src/ovirtapi/index.js
+++ b/src/ovirtapi/index.js
@@ -33,31 +33,6 @@ const OvirtApi = {
 
   //
   //
-  // ---- Data transform functions (API -> internal, internal -> API)
-  //
-  //
-  poolToInternal: Transforms.Pool.toInternal,
-
-  diskToInternal: Transforms.DiskAttachment.toInternal,
-
-  nicToInternal: Transforms.Nic.toInternal,
-
-  sessionsToInternal: Transforms.VmSessions.toInternal,
-
-  iconToInternal: Transforms.Icon.toInternal,
-
-  cdRomToInternal: Transforms.CdRom.toInternal,
-
-  SSHKeyToInternal: Transforms.SSHKey.toInternal,
-
-  consolesToInternal: Transforms.VmConsoles.toInternal,
-
-  snapshotToInternal: Transforms.Snapshot.toInternal,
-
-  eventToInternal: Transforms.Event.toInternal,
-
-  //
-  //
   // ---- API interaction functions
   //
   //

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -260,7 +260,7 @@ export function* fetchPools (action) {
 
   const apiPools = yield callExternalAction('getPools', Api.getPools, action)
   if (apiPools && apiPools.vm_pool) {
-    const internalPools = apiPools.vm_pool.map(pool => Api.poolToInternal({ pool }))
+    const internalPools = apiPools.vm_pool.map(pool => Transforms.Pool.toInternal({ pool }))
     internalPools.forEach(pool => fetchedPoolIds.push(pool.id))
 
     yield put(updatePools({ pools: internalPools }))
@@ -276,7 +276,7 @@ export function* fetchSinglePool (action) {
   const pool = yield callExternalAction('getPool', Api.getPool, action, true)
   let internalPool = false
   if (pool && pool.id) {
-    internalPool = Api.poolToInternal({ pool })
+    internalPool = Transforms.Pool.toInternal({ pool })
     yield put(updatePools({ pools: [internalPool] }))
   } else {
     if (pool && pool.error && pool.error.status === 404) {
@@ -298,7 +298,7 @@ function* fetchVmCdRom ({ vmId, current }) {
 
   let cdromInternal = null
   if (cdrom) {
-    cdromInternal = Api.cdRomToInternal({ cdrom })
+    cdromInternal = Transforms.CdRom.toInternal({ cdrom })
   }
   return cdromInternal
 }
@@ -377,7 +377,7 @@ function* fetchAllEvents (action) {
         event.user &&
         (event.user.id === user.id || event.user.name === user.name)
       )
-      .map((event) => Api.eventToInternal({ event }))
+      .map((event) => Transforms.Event.toInternal({ event }))
     : []
   yield put(setUserMessages({ messages: internalEvents }))
 }
@@ -424,7 +424,7 @@ export function* fetchVmSessions ({ vmId }) {
   const sessions = yield callExternalAction('sessions', Api.sessions, { payload: { vmId } })
 
   if (sessions && sessions.session) {
-    return Api.sessionsToInternal({ sessions })
+    return Transforms.VmSessions.toInternal({ sessions })
   }
   return []
 }
@@ -450,7 +450,7 @@ function* saveFilters (actions) {
 function* fetchVmNics ({ vmId }) {
   const nics = yield callExternalAction('getVmNic', Api.getVmNic, { type: 'GET_VM_NICS', payload: { vmId } })
   if (nics && nics.nic) {
-    const nicsInternal = nics.nic.map(nic => Api.nicToInternal({ nic }))
+    const nicsInternal = nics.nic.map(nic => Transforms.Nic.toInternal({ nic }))
     return nicsInternal
   }
   return []
@@ -461,7 +461,7 @@ export function* fetchVmSnapshots ({ vmId }) {
   let snapshotsInternal = []
 
   if (snapshots && snapshots.snapshot) {
-    snapshotsInternal = snapshots.snapshot.map(snapshot => Api.snapshotToInternal({ snapshot }))
+    snapshotsInternal = snapshots.snapshot.map(snapshot => Transforms.Snapshot.toInternal({ snapshot }))
 
     // NOTE: Snapshot Disks and Nics are not currently (Sept-2018) available via
     //       additional/follow param on the snapshot fetch.  We need to fetch them
@@ -483,7 +483,7 @@ function* fetchVmSnapshotDisks ({ vmId, snapshotId }) {
   const disks = yield callExternalAction('snapshotDisks', Api.snapshotDisks, { payload: { vmId, snapshotId } }, true)
   let disksInternal = []
   if (disks && disks.disk) {
-    disksInternal = disks.disk.map(disk => Api.diskToInternal({ disk }))
+    disksInternal = disks.disk.map(disk => Transforms.DiskAttachment.toInternal({ disk }))
   }
   return disksInternal
 }
@@ -492,7 +492,7 @@ function* fetchVmSnapshotNics ({ vmId, snapshotId }) {
   const nics = yield callExternalAction('snapshotNics', Api.snapshotNics, { payload: { vmId, snapshotId } }, true)
   let nicsInternal = []
   if (nics && nics.nic) {
-    nicsInternal = nics.nic.map((nic) => Api.nicToInternal({ nic }))
+    nicsInternal = nics.nic.map((nic) => Transforms.Nic.toInternal({ nic }))
   }
   return nicsInternal
 }

--- a/src/sagas/options.js
+++ b/src/sagas/options.js
@@ -46,7 +46,7 @@ function* fetchSSHKey (action: Object): any {
     return
   }
 
-  yield put(A.setSSHKey(Api.SSHKeyToInternal({ sshKey: result })))
+  yield put(A.setSSHKey(Transforms.SSHKey.toInternal({ sshKey: result })))
 }
 
 function* saveSSHKey ([sshPropName, submittedKey]: any): any | ResultType {
@@ -219,7 +219,7 @@ function* saveGlobalOptions ({
   }
 
   if (!ssh.error && ssh.change && !ssh.sameAsCurrent) {
-    yield put(A.setSSHKey(Api.SSHKeyToInternal({ sshKey: ssh.data })))
+    yield put(A.setSSHKey(Transforms.SSHKey.toInternal({ sshKey: ssh.data })))
   }
 
   if (showNotifications !== undefined || notificationSnoozeDuration !== undefined) {

--- a/src/sagas/osIcons.js
+++ b/src/sagas/osIcons.js
@@ -1,7 +1,7 @@
 import { all, call, put, select } from 'redux-saga/effects'
 import { loadFromLocalStorage, saveToLocalStorage } from '_/storage'
 import { updateIcons } from '_/actions'
-import Api from '_/ovirtapi'
+import Api, { Transforms } from '_/ovirtapi'
 
 import { callExternalAction } from './utils'
 
@@ -49,6 +49,6 @@ function* fetchIcon ({ iconId }) {
 
   const icon = yield callExternalAction('icon', Api.icon, { payload: { id: iconId } })
   if (icon.media_type && icon.data) {
-    yield put(updateIcons({ icons: [Api.iconToInternal({ icon })] }))
+    yield put(updateIcons({ icons: [Transforms.Icon.toInternal({ icon })] }))
   }
 }


### PR DESCRIPTION
Replace the remaining /.*ToInternal/ data transform functions in the `OvirtApi` object with direct calls to the `Transforms`
objects.  Now, everything that does a transform between API and internal object formats will be using the `Transforms` object directly.
