### PR TITLE
Boolean transform for API - keep undefined as undefined

### DIFF
--- a/src/ovirtapi/types.js
+++ b/src/ovirtapi/types.js
@@ -66,8 +66,8 @@ export type DiskInterfaceType = "ide" | "sata" | "virtio" | "virtio_scsi"
 
 // http://ovirt.github.io/ovirt-engine-api-model/4.4/#types/disk_attachment
 export type ApiDiskAttachmentType = {
-  active: ApiBooleanType,
-  bootable: ApiBooleanType,
+  active?: ApiBooleanType,
+  bootable?: ApiBooleanType,
   disk?: Object,
   href?: string,
   comment?: string,
@@ -151,8 +151,8 @@ export type ApiNicType = {
   id: string,
   name: string,
   mac?: Object,
-  plugged: ApiBooleanType,
-  linked: ApiBooleanType,
+  plugged?: ApiBooleanType,
+  linked?: ApiBooleanType,
   interface: NicInterfaceType,
   vnic_profile?: {
     id: string | null | typeof undefined


### PR DESCRIPTION
Fixes: #1477

For boolean values to be sent to the REST API, the following values are expected:
  - `undefined` stays `undefined` ... no explicit value = no key in the JSON REST request = no change to the value
  - defined and truthy becomes the string 'true'
  - defined and falsey becomes the string 'false'

This change adds `undefined` handling.  `undefined` needs to stay as `undefined` not get converted to an explicit 'false'.