### PR TITLE
refactor `callExternalAction()` to log the API method with `Function.name`

### DIFF
--- a/src/components/VmDetails/cards/SnapshotsCard/sagas.js
+++ b/src/components/VmDetails/cards/SnapshotsCard/sagas.js
@@ -17,12 +17,12 @@ import { ADD_VM_SNAPSHOT, DELETE_VM_SNAPSHOT, RESTORE_VM_SNAPSHOT } from './cons
 
 function* addVmSnapshot (action) {
   yield put(addSnapshotAddPendingTask())
-  const snapshot = yield callExternalAction('addNewSnapshot', Api.addNewSnapshot, action)
+  const snapshot = yield callExternalAction(Api.addNewSnapshot, action)
 
   if (snapshot && snapshot.id) {
     yield fetchVmSnapshots({ vmId: action.payload.vmId })
     for (const delayMilliSec of delayInMsSteps()) {
-      const apiSnapshot = yield callExternalAction('snapshot', Api.snapshot, { payload: { snapshotId: snapshot.id, vmId: action.payload.vmId } }, true)
+      const apiSnapshot = yield callExternalAction(Api.snapshot, { payload: { snapshotId: snapshot.id, vmId: action.payload.vmId } }, true)
       if (apiSnapshot.snapshot_status !== 'locked') {
         break
       }
@@ -36,7 +36,7 @@ function* addVmSnapshot (action) {
 function* deleteVmSnapshot (action) {
   const snapshotId = action.payload.snapshotId
   const vmId = action.payload.vmId
-  const result = yield callExternalAction('deleteVmSnapshot', Api.deleteSnapshot, { payload: { snapshotId, vmId } })
+  const result = yield callExternalAction(Api.deleteSnapshot, { payload: { snapshotId, vmId } })
   if (result.error) {
     return
   }
@@ -44,7 +44,7 @@ function* deleteVmSnapshot (action) {
   let snapshotRemoved = false
   yield fetchVmSnapshots({ vmId })
   for (const delaySec of delayInMsSteps()) {
-    const snapshot = yield callExternalAction('snapshot', Api.snapshot, { payload: { snapshotId, vmId } }, true)
+    const snapshot = yield callExternalAction(Api.snapshot, { payload: { snapshotId, vmId } }, true)
     if (snapshot.error && snapshot.error.status === 404) {
       snapshotRemoved = true
       break
@@ -63,7 +63,7 @@ function* deleteVmSnapshot (action) {
 function* restoreVmSnapshot (action) {
   yield put(addSnapshotRestorePendingTask())
   yield startProgress({ vmId: action.payload.vmId, name: 'restoreSnapshot' })
-  const result = yield callExternalAction('restoreSnapshot', Api.restoreSnapshot, action)
+  const result = yield callExternalAction(Api.restoreSnapshot, action)
   yield stopProgress({ vmId: action.payload.vmId, name: 'restoreSnapshot', result })
   yield put(removeSnapshotRestorePendingTask())
 }

--- a/src/sagas/base-data.js
+++ b/src/sagas/base-data.js
@@ -26,7 +26,7 @@ import { EVERYONE_GROUP_ID } from './index'
 import { fetchUnknownIcons } from './osIcons'
 
 export function* fetchAllClusters () {
-  const clusters = yield callExternalAction('getAllClusters', Api.getAllClusters)
+  const clusters = yield callExternalAction(Api.getAllClusters)
 
   if (clusters && clusters.cluster) {
     const clustersInternal = clusters.cluster.map(
@@ -49,7 +49,7 @@ export function* fetchAllClusters () {
 }
 
 export function* fetchAllHosts () {
-  const hosts = yield callExternalAction('getAllHosts', Api.getAllHosts)
+  const hosts = yield callExternalAction(Api.getAllHosts)
 
   if (hosts && hosts.host) {
     const hostsInternal = hosts.host.map(
@@ -61,7 +61,7 @@ export function* fetchAllHosts () {
 }
 
 export function* fetchAllOS () {
-  const operatingSystems = yield callExternalAction('getAllOperatingSystems', Api.getAllOperatingSystems)
+  const operatingSystems = yield callExternalAction(Api.getAllOperatingSystems)
 
   if (operatingSystems && operatingSystems.operating_system) {
     const operatingSystemsInternal = operatingSystems.operating_system.map(
@@ -74,7 +74,7 @@ export function* fetchAllOS () {
 }
 
 export function* fetchAllTemplates () {
-  const templates = yield callExternalAction('getAllTemplates', Api.getAllTemplates)
+  const templates = yield callExternalAction(Api.getAllTemplates)
 
   if (templates && templates.template) {
     const templatesInternal = templates.template.map(
@@ -101,7 +101,7 @@ export function* fetchAllTemplates () {
 }
 
 export function* fetchAllVnicProfiles () {
-  const vnicProfiles = yield callExternalAction('getAllVnicProfiles', Api.getAllVnicProfiles)
+  const vnicProfiles = yield callExternalAction(Api.getAllVnicProfiles)
 
   if (vnicProfiles && vnicProfiles.vnic_profile) {
     const vnicProfilesInternal = vnicProfiles.vnic_profile.map(
@@ -120,7 +120,7 @@ export function* fetchAllVnicProfiles () {
 
 export function* fetchCurrentUser () {
   const userId = yield select((state) => state.config.getIn(['user', 'id']))
-  const user = yield callExternalAction('user', Api.user, {
+  const user = yield callExternalAction(Api.user, {
     payload: {
       userId,
     },
@@ -147,12 +147,12 @@ export function* fetchUserGroups () {
     ovirtGroups,
   } = yield all({
     domainGroups: call(function* (userId) {
-      const { group: groups = [] } = yield callExternalAction('userDomainGroups', Api.userDomainGroups, { payload: { userId } })
+      const { group: groups = [] } = yield callExternalAction(Api.userDomainGroups, { payload: { userId } })
       return groups.map(group => group.id)
     }, userId),
 
     ovirtGroups: call(function* () {
-      const { group: groups = [] } = yield callExternalAction('groups', Api.groups)
+      const { group: groups = [] } = yield callExternalAction(Api.groups)
       return groups.map(group => ({
         domainEntryId: group.domain_entry_id,
         ovirtId: group.id,

--- a/src/sagas/console/index.js
+++ b/src/sagas/console/index.js
@@ -36,7 +36,7 @@ export function* downloadVmConsole (action) {
   const { modalId, vmId, consoleId, usbAutoshare, usbFilter, hasGuestAgent, skipSSO, openInPage, isNoVNC } = action.payload
 
   if (hasGuestAgent && !skipSSO) {
-    const result = yield callExternalAction('vmLogon', Api.vmLogon, { payload: { vmId } }, true)
+    const result = yield callExternalAction(Api.vmLogon, { payload: { vmId } }, true)
     if (!result || result.status !== 'complete') {
       const {
         error: {
@@ -56,7 +56,7 @@ export function* downloadVmConsole (action) {
 
   yield put(closeConsoleModal({ modalId }))
 
-  let data = yield callExternalAction('console', Api.console, { type: 'INTERNAL_CONSOLE', payload: { vmId, consoleId } })
+  let data = yield callExternalAction(Api.console, { type: 'INTERNAL_CONSOLE', payload: { vmId, consoleId } })
   if (data.error === undefined) {
     yield put(setActiveConsole({ vmId, consoleId }))
     /**
@@ -73,9 +73,9 @@ export function* downloadVmConsole (action) {
       fileDownload({ data, fileName: 'console.vv', mimeType: 'application/x-virt-viewer' })
       yield put(setConsoleStatus({ vmId, status: DOWNLOAD_CONSOLE }))
     } else {
-      const dataTicket = yield callExternalAction('consoleProxyTicket', Api.consoleProxyTicket,
+      const dataTicket = yield callExternalAction(Api.consoleProxyTicket,
         { type: 'INTRENAL_CONSOLE', payload: { vmId, consoleId } })
-      const ticket = yield callExternalAction('consoleTicket', Api.consoleTicket,
+      const ticket = yield callExternalAction(Api.consoleTicket,
         { type: 'INTRENAL_CONSOLE', payload: { vmId, consoleId } })
       yield put(setConsoleTickets({ vmId, proxyTicket: dataTicket.proxy_ticket.value, ticket: ticket.ticket }))
       yield put(setConsoleStatus({ vmId, status: INIT_CONSOLE }))

--- a/src/sagas/disks.js
+++ b/src/sagas/disks.js
@@ -29,7 +29,7 @@ function* transformAndPermitDiskAttachment (attachment) {
 }
 
 function* fetchVmDisks ({ vmId }) {
-  const diskattachments = yield callExternalAction('diskattachments', Api.diskattachments, { payload: { vmId } })
+  const diskattachments = yield callExternalAction(Api.diskattachments, { payload: { vmId } })
 
   const internalDisks = []
 
@@ -51,7 +51,7 @@ export function* createDiskForVm (action) {
     originalBootableDisk = yield clearBootableFlagOnVm(vmId)
   }
 
-  const result = yield callExternalAction('addDiskAttachment', Api.addDiskAttachment, action)
+  const result = yield callExternalAction(Api.addDiskAttachment, action)
   if (result.error) {
     if (originalBootableDisk) {
       yield updateDiskAttachmentBootable(vmId, originalBootableDisk, true)
@@ -66,7 +66,7 @@ function* removeDisk (action) {
   const diskId = action.payload.diskId
   const vmToRefreshId = action.payload.vmToRefreshId
 
-  const result = yield callExternalAction('removeDisk', Api.removeDisk, { payload: diskId })
+  const result = yield callExternalAction(Api.removeDisk, { payload: diskId })
   if (result.error) {
     return
   }
@@ -94,7 +94,7 @@ function* editDiskOnVm (action) {
   yield clearBootableFlagOnVm(vmId, disk)
 
   action.payload.disk = editableFieldsDisk
-  const result = yield callExternalAction('updateDiskAttachment', Api.updateDiskAttachment, action)
+  const result = yield callExternalAction(Api.updateDiskAttachment, action)
   if (result.error) {
     return
   }
@@ -118,7 +118,7 @@ function* clearBootableFlagOnVm (vmId, currentDisk) {
  * changed (async only operation + poll until desired result = simulated sync operation)
  */
 function* updateDiskAttachmentBootable (vmId, diskAttachmentId, isBootable) {
-  const result = yield callExternalAction('updateDiskAttachment', Api.updateDiskAttachment, {
+  const result = yield callExternalAction(Api.updateDiskAttachment, {
     payload: {
       disk: { attachmentId: diskAttachmentId, bootable: isBootable },
       vmId,
@@ -165,7 +165,6 @@ function* waitForDiskAttachment (vmId, attachmentId, test, canBeMissing = false)
 
   for (const delayMs of delayInMsSteps()) {
     const apiDiskAttachment = yield callExternalAction(
-      'diskattachment',
       Api.diskattachment,
       { payload: { vmId, attachmentId } },
       canBeMissing

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -191,7 +191,7 @@ export function* fetchVms ({ payload: { count, page, shallowFetch = true } }) {
   const fetchedVmIds = []
 
   const additional = shallowFetch ? VM_FETCH_ADDITIONAL_SHALLOW : VM_FETCH_ADDITIONAL_DEEP
-  const apiVms = yield callExternalAction('getVms', Api.getVms, { payload: { count, page, additional } })
+  const apiVms = yield callExternalAction(Api.getVms, { payload: { count, page, additional } })
   if (apiVms && apiVms.vm) {
     const internalVms = []
     for (const apiVm of apiVms.vm) {
@@ -219,7 +219,7 @@ export function* fetchSingleVm (action) {
 
   action.payload.additional = shallowFetch ? VM_FETCH_ADDITIONAL_SHALLOW : VM_FETCH_ADDITIONAL_DEEP
 
-  const vm = yield callExternalAction('getVm', Api.getVm, action, true)
+  const vm = yield callExternalAction(Api.getVm, action, true)
   let internalVm = null
   if (vm && vm.id) {
     internalVm = yield transformAndPermitVm(vm)
@@ -250,7 +250,7 @@ export function* fetchSingleVm (action) {
 export function* fetchPools (action) {
   const fetchedPoolIds = []
 
-  const apiPools = yield callExternalAction('getPools', Api.getPools, action)
+  const apiPools = yield callExternalAction(Api.getPools, action)
   if (apiPools && apiPools.vm_pool) {
     const internalPools = apiPools.vm_pool.map(pool => Transforms.Pool.toInternal({ pool }))
     internalPools.forEach(pool => fetchedPoolIds.push(pool.id))
@@ -265,7 +265,7 @@ export function* fetchPools (action) {
 export function* fetchSinglePool (action) {
   const { poolId } = action.payload
 
-  const pool = yield callExternalAction('getPool', Api.getPool, action, true)
+  const pool = yield callExternalAction(Api.getPool, action, true)
   let internalPool = false
   if (pool && pool.id) {
     internalPool = Transforms.Pool.toInternal({ pool })
@@ -286,7 +286,7 @@ export function* fetchSinglePool (action) {
  * next_run/"current=false" API parameter.
  */
 function* fetchVmCdRom ({ vmId, current }) {
-  const cdrom = yield callExternalAction('getCdRom', Api.getCdRom, getVmCdRom({ vmId, current }))
+  const cdrom = yield callExternalAction(Api.getCdRom, getVmCdRom({ vmId, current }))
 
   let cdromInternal = null
   if (cdrom) {
@@ -296,7 +296,7 @@ function* fetchVmCdRom ({ vmId, current }) {
 }
 
 export function* addVmNic (action) {
-  const nic = yield callExternalAction('addNicToVm', Api.addNicToVm, action)
+  const nic = yield callExternalAction(Api.addNicToVm, action)
 
   if (nic && nic.id) {
     const nicsInternal = yield fetchVmNics({ vmId: action.payload.vmId })
@@ -305,14 +305,14 @@ export function* addVmNic (action) {
 }
 
 function* deleteVmNic (action) {
-  yield callExternalAction('deleteNicFromVm', Api.deleteNicFromVm, action)
+  yield callExternalAction(Api.deleteNicFromVm, action)
 
   const nicsInternal = yield fetchVmNics({ vmId: action.payload.vmId })
   yield put(setVmNics({ vmId: action.payload.vmId, nics: nicsInternal }))
 }
 
 function* editVmNic (action) {
-  yield callExternalAction('editNicInVm', Api.editNicInVm, action)
+  yield callExternalAction(Api.editNicInVm, action)
 
   const nicsInternal = yield fetchVmNics({ vmId: action.payload.vmId })
   yield put(setVmNics({ vmId: action.payload.vmId, nics: nicsInternal }))
@@ -356,7 +356,7 @@ function* fetchAllEvents (action) {
     name: `${state.config.getIn(['user', 'name'])}@${state.config.get('domain')}`,
   }))
 
-  const events = yield callExternalAction('events', Api.events, { payload: {} })
+  const events = yield callExternalAction(Api.events, { payload: {} })
 
   if (events.error) {
     return
@@ -377,7 +377,7 @@ function* fetchAllEvents (action) {
 function* dismissEvent (action) {
   const { event } = action.payload
   if (event.source === 'server') {
-    const result = yield callExternalAction('dismissEvent', Api.dismissEvent, { payload: { eventId: event.id } })
+    const result = yield callExternalAction(Api.dismissEvent, { payload: { eventId: event.id } })
 
     if (result.status === 'complete') {
       yield fetchAllEvents(action)
@@ -392,7 +392,7 @@ function* clearEvents (action) {
     id: state.config.getIn(['user', 'id']),
     name: `${state.config.getIn(['user', 'name'])}@${state.config.get('domain')}`,
   }))
-  const events = yield callExternalAction('events', Api.events, { payload: {} })
+  const events = yield callExternalAction(Api.events, { payload: {} })
 
   if (events.error) {
     return
@@ -404,7 +404,7 @@ function* clearEvents (action) {
         event.severity === 'error' &&
         event.user &&
         (event.user.id === user.id || event.user.name === user.name)
-      ).map((event) => callExternalAction('dismissEvent', Api.dismissEvent, { payload: { eventId: event.id } }))
+      ).map((event) => callExternalAction(Api.dismissEvent, { payload: { eventId: event.id } }))
     : []
 
   yield all(sagaEvents)
@@ -413,7 +413,7 @@ function* clearEvents (action) {
 }
 
 export function* fetchVmSessions ({ vmId }) {
-  const sessions = yield callExternalAction('sessions', Api.sessions, { payload: { vmId } })
+  const sessions = yield callExternalAction(Api.sessions, { payload: { vmId } })
 
   if (sessions && sessions.session) {
     return Transforms.VmSessions.toInternal({ sessions })
@@ -440,7 +440,7 @@ function* saveFilters (actions) {
 }
 
 function* fetchVmNics ({ vmId }) {
-  const nics = yield callExternalAction('getVmNic', Api.getVmNic, { type: 'GET_VM_NICS', payload: { vmId } })
+  const nics = yield callExternalAction(Api.getVmNic, { type: 'GET_VM_NICS', payload: { vmId } })
   if (nics && nics.nic) {
     const nicsInternal = nics.nic.map(nic => Transforms.Nic.toInternal({ nic }))
     return nicsInternal
@@ -449,7 +449,7 @@ function* fetchVmNics ({ vmId }) {
 }
 
 export function* fetchVmSnapshots ({ vmId }) {
-  const snapshots = yield callExternalAction('snapshots', Api.snapshots, { type: 'GET_VM_SNAPSHOT', payload: { vmId } })
+  const snapshots = yield callExternalAction(Api.snapshots, { type: 'GET_VM_SNAPSHOT', payload: { vmId } })
   let snapshotsInternal = []
 
   if (snapshots && snapshots.snapshot) {
@@ -500,7 +500,7 @@ function* parallelFetchAndPopulateSnapshotDisksAndNics (vmId, snapshots) {
 }
 
 function* fetchVmSnapshotDisks ({ vmId, snapshotId }) {
-  const disks = yield callExternalAction('snapshotDisks', Api.snapshotDisks, { payload: { vmId, snapshotId } }, true)
+  const disks = yield callExternalAction(Api.snapshotDisks, { payload: { vmId, snapshotId } }, true)
   let disksInternal = []
   if (disks?.disk) {
     disksInternal = disks.disk.map(disk => Transforms.DiskAttachment.toInternal({ disk }))
@@ -509,7 +509,7 @@ function* fetchVmSnapshotDisks ({ vmId, snapshotId }) {
 }
 
 function* fetchVmSnapshotNics ({ vmId, snapshotId }) {
-  const nics = yield callExternalAction('snapshotNics', Api.snapshotNics, { payload: { vmId, snapshotId } }, true)
+  const nics = yield callExternalAction(Api.snapshotNics, { payload: { vmId, snapshotId } }, true)
   let nicsInternal = []
   if (nics?.nic) {
     nicsInternal = nics.nic.map((nic) => Transforms.Nic.toInternal({ nic }))

--- a/src/sagas/login.js
+++ b/src/sagas/login.js
@@ -70,7 +70,7 @@ function* login (action) {
   yield put(loginSuccessful({ token, userId, username, domain }))
 
   // Verify the API (exists and is the correct version)
-  const oVirtMeta = yield callExternalAction('getOvirtApiMeta', Api.getOvirtApiMeta, action)
+  const oVirtMeta = yield callExternalAction(Api.getOvirtApiMeta, action)
   const versionOk = yield checkOvirtApiVersion(oVirtMeta)
   if (!versionOk) {
     console.error('oVirt API version check failed')
@@ -171,7 +171,7 @@ function composeIncompatibleOVirtApiVersionMessage (oVirtMeta) {
 }
 
 function* checkUserFilterPermissions () {
-  const data = yield callExternalAction('checkFilter', Api.checkFilter, { action: 'CHECK_FILTER' }, true)
+  const data = yield callExternalAction(Api.checkFilter, { action: 'CHECK_FILTER' }, true)
 
   const isAdmin = data.error === undefined // expect an error on `checkFilter` if the user isn't admin
   yield put(setAdministrator(isAdmin))
@@ -234,7 +234,7 @@ function* initialLoad () {
 function* autoConnectCheck () {
   const vmId = OptionsManager.loadAutoConnectOption()
   if (vmId && vmId.length > 0) {
-    const vm = yield callExternalAction('getVm', Api.getVm, getSingleVm({ vmId }), true)
+    const vm = yield callExternalAction(Api.getVm, getSingleVm({ vmId }), true)
     if (vm && vm.error && vm.error.status === 404) {
       OptionsManager.clearAutoConnect()
     } else if (vm && vm.id && vm.status !== 'down') {

--- a/src/sagas/options.js
+++ b/src/sagas/options.js
@@ -41,7 +41,7 @@ function toResult ({ error = false, change = undefined, sameAsCurrent = false, .
 }
 
 function* fetchSSHKey (action: Object): any {
-  const result = yield call(callExternalAction, 'getSSHKey', Api.getSSHKey, action)
+  const result = yield call(callExternalAction, Api.getSSHKey, action)
   if (result.error) {
     return
   }
@@ -68,7 +68,6 @@ function* saveSSHKey ([sshPropName, submittedKey]: any): any | ResultType {
 
   const result = yield call(
     callExternalAction,
-    'saveSSHKey',
     Api.saveSSHKey,
     A.saveSSHKey({ sshId, key: submittedKey, userId }),
     true)
@@ -77,7 +76,7 @@ function* saveSSHKey ([sshPropName, submittedKey]: any): any | ResultType {
 }
 
 function* fetchUserOptions (action: Object): any {
-  const result = yield call(callExternalAction, 'fetchUserOptions', Api.fetchUserOptions, action)
+  const result = yield call(callExternalAction, Api.fetchUserOptions, action)
   if (!result || result.error) {
     return
   }
@@ -127,7 +126,6 @@ function* saveRemoteOption ([name, value]: any): any | ResultType {
 
   const result = (yield call(
     callExternalAction,
-    'persistUserOption',
     Api.persistUserOption,
     A.persistUserOption({ name, content: value, optionId, userId }),
     true
@@ -253,7 +251,6 @@ function* deleteUserOption (optionName: string): any {
   }
   const { error } = yield call(
     callExternalAction,
-    'deleteUserOption',
     Api.deleteUserOption,
     A.deleteUserOption({ optionId, userId }),
     true

--- a/src/sagas/osIcons.js
+++ b/src/sagas/osIcons.js
@@ -47,7 +47,7 @@ function* fetchIcon ({ iconId }) {
     return
   }
 
-  const icon = yield callExternalAction('icon', Api.icon, { payload: { id: iconId } })
+  const icon = yield callExternalAction(Api.icon, { payload: { id: iconId } })
   if (icon.media_type && icon.data) {
     yield put(updateIcons({ icons: [Transforms.Icon.toInternal({ icon })] }))
   }

--- a/src/sagas/roles.js
+++ b/src/sagas/roles.js
@@ -7,7 +7,7 @@ import {
 } from '_/actions'
 
 export function* fetchRoles (action) {
-  const rolesApi = yield callExternalAction('getRoles', Api.getRoles, action)
+  const rolesApi = yield callExternalAction(Api.getRoles, action)
 
   if (rolesApi && rolesApi.role) {
     const roles = rolesApi.role.map(role => Transforms.Role.toInternal({ role }))

--- a/src/sagas/server-configs.js
+++ b/src/sagas/server-configs.js
@@ -25,7 +25,7 @@ export function* fetchServerConfiguredValues () {
     maxNumOfVmCpusPerArch: call(fetchEngineOption, 'MaxNumOfVmCpus', DefaultEngineOptions.MaxNumOfVmCpusPerArch),
 
     usbAutoShare: call(fetchGeneralEngineOption, 'SpiceUsbAutoShare', DefaultEngineOptions.SpiceUsbAutoShare),
-    usbFilter: callExternalAction('getUSBFilter', Api.getUSBFilter, DefaultEngineOptions.getUSBFilter),
+    usbFilter: callExternalAction(Api.getUSBFilter, DefaultEngineOptions.getUSBFilter),
 
     userSessionTimeout: call(fetchGeneralEngineOption, 'UserSessionTimeOutInterval', DefaultEngineOptions.UserSessionTimeOutInterval),
 
@@ -74,7 +74,6 @@ export function* fetchServerConfiguredValues () {
 
 export function* fetchEngineOption (name, defaultValue) {
   const option = yield callExternalAction(
-    'getEngineOption',
     Api.getEngineOption,
     getEngineOption(name),
     true

--- a/src/sagas/storageDomains.js
+++ b/src/sagas/storageDomains.js
@@ -42,7 +42,7 @@ export function* fetchDataCentersAndStorageDomains () {
 
 function* fetchDataCenters () {
   const payload = { additional: ['permissions', 'storage_domains'] }
-  const dataCentersApi = yield callExternalAction('getAllDataCenters', Api.getAllDataCenters, { payload })
+  const dataCentersApi = yield callExternalAction(Api.getAllDataCenters, { payload })
 
   if (dataCentersApi && dataCentersApi.data_center) {
     const dataCentersInternal = dataCentersApi.data_center.map(
@@ -61,7 +61,7 @@ function* fetchDataCenters () {
 }
 
 function* fetchDataAndIsoStorageDomains () {
-  const storageDomainsApi = yield callExternalAction('getStorages', Api.getStorages, { payload: {} })
+  const storageDomainsApi = yield callExternalAction(Api.getStorages, { payload: {} })
 
   if (storageDomainsApi && storageDomainsApi.storage_domain) {
     const storageDomainsInternal = storageDomainsApi.storage_domain
@@ -95,7 +95,7 @@ export function* fetchIsoFiles () {
  * Fetch ISO disk images and distribute them to their storage domains as files
  */
 function* fetchIsoDiskImages () {
-  const images = yield callExternalAction('getIsoImages', Api.getIsoImages, { payload: {} })
+  const images = yield callExternalAction(Api.getIsoImages, { payload: {} })
   if (images && images.disk) {
     const storageDomainToDisks = images.disk.reduce(
       (acc, disk) => {
@@ -136,7 +136,7 @@ function* fetchIsoFilesFromIsoStorageDomains () {
  * Fetch 'files' from the single given ISO storage domain
  */
 function* fetchIsoFilesFromIsoStorageDomain (storageDomainId) {
-  const files = yield callExternalAction('getStorageFiles', Api.getStorageFiles, { payload: { storageId: storageDomainId } })
+  const files = yield callExternalAction(Api.getStorageFiles, { payload: { storageId: storageDomainId } })
   if (files && files.file) {
     const filesInternal = files.file.map(
       file => Transforms.StorageDomainFile.toInternal({ file })

--- a/src/sagas/utils.js
+++ b/src/sagas/utils.js
@@ -64,9 +64,9 @@ export function compareVersion (actual, required) {
   return !!semverValid(fullActual) && semverGte(fullActual, fullRequired)
 }
 
-export function* callExternalAction (methodName, method, action = {}, canBeMissing = false) {
+export function* callExternalAction (method, action = {}, canBeMissing = false) {
   try {
-    console.log(`External action: ${JSON.stringify(hidePassword({ action }))}, API method: ${methodName}()`)
+    console.log(`External action: ${JSON.stringify(hidePassword({ action }))}, API method: ${method.name}`)
     const result = yield call(method, action.payload || {})
     return result
   } catch (e) {

--- a/src/sagas/vmChanges.js
+++ b/src/sagas/vmChanges.js
@@ -235,7 +235,7 @@ function* createVm (action) {
   const correlationId = action.meta && action.meta.correlationId
 
   // Create the VM
-  const createVmResult = yield callExternalAction('createVm', Api.addNewVm, action)
+  const createVmResult = yield callExternalAction(Api.addNewVm, action)
   const successCreate = !!createVmResult.id
 
   // Log the success of the action via correlation id
@@ -285,7 +285,7 @@ function* waitForVmToBeUnlocked (vmId, isCloning = false) {
     for (const delayMs of delayInMsSteps(isCloning ? 20 : 200)) {
       yield delay(delayMs)
 
-      const check = yield callExternalAction('getVm', Api.getVm, { payload: { vmId } }, true)
+      const check = yield callExternalAction(Api.getVm, { payload: { vmId } }, true)
       if (check && check.id === vmId && check.status !== 'image_locked') {
         break
       }
@@ -309,7 +309,7 @@ function* editVm (action) {
 
   const editVmResult = onlyNeedChangeCd
     ? {}
-    : yield callExternalAction('editVm', Api.editVm, action)
+    : yield callExternalAction(Api.editVm, action)
 
   let commitError = editVmResult.error
   if (!commitError && vm.cdrom) {
@@ -342,7 +342,7 @@ function* editVm (action) {
 }
 
 function* changeVmCdRom (action) {
-  const result = yield callExternalAction('changeCdRom', Api.changeCdRom, action)
+  const result = yield callExternalAction(Api.changeCdRom, action)
 
   if (action.meta && action.meta.correlationId) {
     yield put(A.setVmActionResult({
@@ -357,7 +357,7 @@ function* changeVmCdRom (action) {
 
 function* shutdownVm (action) {
   yield startProgress({ vmId: action.payload.vmId, name: 'shutdown' })
-  const result = yield callExternalAction('shutdown', Api.shutdown, action)
+  const result = yield callExternalAction(Api.shutdown, action)
   const vmName = yield select(state => state.vms.getIn(['vms', action.payload.vmId, 'name']))
   if (result.status === 'complete') {
     yield put(A.addUserMessage({ messageDescriptor: { id: 'actionFeedbackShutdownVm', params: { VmName: vmName } }, type: 'success' }))
@@ -367,7 +367,7 @@ function* shutdownVm (action) {
 
 function* restartVm (action) {
   yield startProgress({ vmId: action.payload.vmId, name: 'restart' })
-  const result = yield callExternalAction('restart', Api.restart, action)
+  const result = yield callExternalAction(Api.restart, action)
   const vmName = yield select(state => state.vms.getIn(['vms', action.payload.vmId, 'name']))
   if (result.status === 'complete') {
     yield put(A.addUserMessage({ messageDescriptor: { id: 'actionFeedbackRestartVm', params: { VmName: vmName } }, type: 'success' }))
@@ -377,7 +377,7 @@ function* restartVm (action) {
 
 function* suspendVm (action) {
   yield startProgress({ vmId: action.payload.vmId, name: 'suspend' })
-  const result = yield callExternalAction('suspend', Api.suspend, action)
+  const result = yield callExternalAction(Api.suspend, action)
   const vmName = yield select(state => state.vms.getIn(['vms', action.payload.vmId, 'name']))
   if (result.status === 'pending') {
     yield put(A.addUserMessage({ messageDescriptor: { id: 'actionFeedbackSuspendVm', params: { VmName: vmName } }, type: 'success' }))
@@ -387,7 +387,7 @@ function* suspendVm (action) {
 
 function* startVm (action) {
   yield startProgress({ vmId: action.payload.vmId, name: 'start' })
-  const result = yield callExternalAction('start', Api.start, action)
+  const result = yield callExternalAction(Api.start, action)
   const vmName = yield select(state => state.vms.getIn(['vms', action.payload.vmId, 'name']))
   // TODO: check status at refresh --> conditional refresh wait_for_launch
   if (result.status === 'complete') {
@@ -398,7 +398,7 @@ function* startVm (action) {
 
 function* startPool (action) {
   yield startProgress({ poolId: action.payload.poolId, name: 'start' })
-  const result = yield callExternalAction('startPool', Api.startPool, action)
+  const result = yield callExternalAction(Api.startPool, action)
   const poolName = yield select(state => state.vms.getIn(['pools', action.payload.poolId, 'name']))
   if (result.status === 'complete') {
     yield put(A.addUserMessage({ messageDescriptor: { id: 'actionFeedbackAllocateVm', params: { poolname: poolName } }, type: 'success' }))
@@ -408,7 +408,7 @@ function* startPool (action) {
 
 function* removeVm (action) {
   yield startProgress({ vmId: action.payload.vmId, name: 'remove' })
-  const result = yield callExternalAction('remove', Api.remove, action)
+  const result = yield callExternalAction(Api.remove, action)
 
   if (result.status === 'complete') {
     // TODO: Remove the VM from the store so we don't see it on the list page!


### PR DESCRIPTION
Given:
  1. The `Function.name` attribute on every function will contain the function's name in the running source.

  2. The `TerserPlugin` webpack plugin allows us to keep class and function names instead of minimizing/mangling the names.

  3. The webpack production build configures `TerserPlugin` to keep class and function names intact.

The `callExternalAction()` helper saga can now use `Function.name` when logging the API call instead of relying on the callee passing in the method name as a string.  This saves having to maintain `methodName` and `method` everywhere `callExternalAction()` is used.