### PR TITLE
Create VM with the correct number of the VCPUs, in CreateVmWizard

### DIFF
--- a/src/components/CreateVmWizard/steps/BasicSettings.js
+++ b/src/components/CreateVmWizard/steps/BasicSettings.js
@@ -316,9 +316,8 @@ class BasicSettings extends React.Component {
         const { maxNumOfVmCpus } = this.grabCpuOptions()
         if (isNumberInRange(value, 0, maxNumOfVmCpus)) {
           changes.cpus = +value
+          changes.topology = this.getTopologySettings(changes.cpus)
         }
-
-        changes.topology = this.getTopologySettings(changes.cpus)
         break
       }
 


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/1473

The issue was introduced together with implementing [advanced CPU topology ](https://github.com/oVirt/ovirt-web-ui/pull/1279/files#diff-ecc9f96259bb1bc0ee42cc7ff4de2121caf4ac2bfecc640b2cc798f976565489R328) feature in the _Basic Settings_ step of the _CreateVmWizard_.
 
After clicking on up arrow for the _Total Virtual CPUs_ field, `handleChange` was called and the next code was executed:
```javascript
      case 'cpus': {
        const { maxNumOfVmCpus } = this.grabCpuOptions()
        if (isNumberInRange(value, 0, maxNumOfVmCpus)) {
          changes.cpus = +value
        }
        changes.topology = this.getTopologySettings(changes.cpus)
        break
      }
```
If we reach the max value of the total VCPUs, this value does not change anymore when trying to increase it. But the change in the topology was always "detected", new values set. This was the issue. VCPU Topology values depend on the number of the total VCPUs so the topology values shoud change only with the change of the number of the total VCPUs. Inappropriate change of the topology values lead to the creation of the VM with incorrect number of the total VCPUs. 

**Before:**
![before1](https://user-images.githubusercontent.com/13417815/127137909-998237c2-0bae-4b78-b8d4-8ad96e3af4cb.png)
![before2](https://user-images.githubusercontent.com/13417815/127137923-968fae27-934a-4d23-8e95-2fc5b278ab3a.png)

**After:**
![after1](https://user-images.githubusercontent.com/13417815/127137943-2478d78a-a836-40b8-8ecc-d6e0e7d708dd.png)
![after2](https://user-images.githubusercontent.com/13417815/127137951-71f400f8-a1b9-4938-9c57-4dcced68e194.png)
