### PR TITLE
add babel plugin fancy-console

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,7 @@ EXTRA_DIST = \
 	ovirt-web-ui.spec.in \
 	README.md \
 	LICENSE \
+	babel-plugin \
 	branding \
 	src \
 	config \
@@ -38,6 +39,8 @@ EXTRA_DIST = \
 
 DISTCLEANFILES = $(PACKAGE)-$(VERSION).tar.gz \
 	aclocal.m4 \
+	config.log \
+	config.status \
 	configure \
 	install-sh \
 	missing \

--- a/babel-plugin/__snapshots__/fancy-console.test.js.snap
+++ b/babel-plugin/__snapshots__/fancy-console.test.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fancy-console-test test [error] 1`] = `
+"const foo = 1;
+const bar = {};
+console.error(\\"%c error %c\\" + (\\" \\" + 'just a message'), \\"font-weight: bold; background-color: #ed403c; color: white;\\", \\"\\");
+console.error(\\"%c error %c\\", \\"font-weight: bold; background-color: #ed403c; color: white;\\", \\"\\", bar);
+console.error(\\"%c error %c\\" + (\\" \\" + 'bar'), \\"font-weight: bold; background-color: #ed403c; color: white;\\", \\"\\", bar);
+console.error(\\"%c error %c\\" + (\\" \\" + \`bar: \${bar}\`), \\"font-weight: bold; background-color: #ed403c; color: white;\\", \\"\\");"
+`;
+
+exports[`fancy-console-test test [group] 1`] = `
+"console.group('groupName');
+console.group('groupName, level 2');
+console.groupEnd();
+console.groupEnd();"
+`;
+
+exports[`fancy-console-test test [info] 1`] = `
+"const foo = 1;
+const bar = {};
+console.info(\\"%c info %c\\" + (\\" \\" + 'just a message'), \\"font-weight: bold; background-color: #01acac; color: white;\\", \\"\\");
+console.info(\\"%c info %c\\", \\"font-weight: bold; background-color: #01acac; color: white;\\", \\"\\", bar);
+console.info(\\"%c info %c\\" + (\\" \\" + 'bar'), \\"font-weight: bold; background-color: #01acac; color: white;\\", \\"\\", bar);
+console.info(\\"%c info %c\\" + (\\" \\" + \`bar: \${bar}\`), \\"font-weight: bold; background-color: #01acac; color: white;\\", \\"\\");"
+`;
+
+exports[`fancy-console-test test [log] 1`] = `
+"const foo = 1;
+const bar = {};
+console.log(\\"%c debug %c\\" + (\\" \\" + \\"just a message\\"), \\"font-weight: bold; background-color: #21409a; color: white;\\", \\"\\");
+console.log(\\"%c debug %c\\", \\"font-weight: bold; background-color: #21409a; color: white;\\", \\"\\", foo);
+console.log(\\"%c debug %c\\" + (\\" \\" + \\"foo\\"), \\"font-weight: bold; background-color: #21409a; color: white;\\", \\"\\", foo);
+console.log(\\"%c debug %c\\" + (\\" \\" + \\"foo\\"), \\"font-weight: bold; background-color: #21409a; color: white;\\", \\"\\", foo, \\"bar\\", bar);
+console.log(\\"%c debug %c\\" + (\\" \\" + \\"%cFANCY%c - \\"), \\"font-weight: bold; background-color: #21409a; color: white;\\", \\"\\", \\"color: red\\", \\"\\", foo);"
+`;
+
+exports[`fancy-console-test test [warn] 1`] = `
+"const foo = 1;
+const bar = {};
+console.warn(\\"%c warn %c\\" + (\\" \\" + 'just a message'), \\"font-weight: bold; background-color: #f8a51b; color: white;\\", \\"\\");
+console.warn(\\"%c warn %c\\", \\"font-weight: bold; background-color: #f8a51b; color: white;\\", \\"\\", bar);
+console.warn(\\"%c warn %c\\" + (\\" \\" + 'bar'), \\"font-weight: bold; background-color: #f8a51b; color: white;\\", \\"\\", bar);
+console.warn(\\"%c warn %c\\" + (\\" \\" + \`bar: \${bar}\`), \\"font-weight: bold; background-color: #f8a51b; color: white;\\", \\"\\");"
+`;

--- a/babel-plugin/fancy-console.js
+++ b/babel-plugin/fancy-console.js
@@ -1,0 +1,57 @@
+
+const ENHANCEMENETS_PER_METHOD = {
+  log: ['%c debug %c', 'font-weight: bold; background-color: #21409a; color: white;', ''],
+  info: ['%c info %c', 'font-weight: bold; background-color: #01acac; color: white;', ''],
+  warn: ['%c warn %c', 'font-weight: bold; background-color: #f8a51b; color: white;', ''],
+  error: ['%c error %c', 'font-weight: bold; background-color: #ed403c; color: white;', ''],
+}
+
+const DEFAULT_LOGGERS = [
+  {
+    object: 'console',
+    methods: Object.keys(ENHANCEMENETS_PER_METHOD),
+    enhancements: ENHANCEMENETS_PER_METHOD,
+  },
+]
+
+module.exports = ({ types: t }) => ({
+  visitor: {
+    CallExpression (path, state = {}) {
+      const { opts: { loggers = DEFAULT_LOGGERS } } = state
+      const { node } = path
+
+      const logger = matchEnhancementLogger(path, loggers)
+      if (logger && node.arguments.length > 0) {
+        const enhancement = logger.enhancements[path.node.callee.property.name]
+        const first = node.arguments.shift()
+
+        if (['StringLiteral', 'TemplateLiteral'].includes(first.type)) {
+          const newFirst = t.binaryExpression(
+            '+',
+            t.stringLiteral(enhancement[0]),
+            t.binaryExpression('+', t.stringLiteral(' '), first)
+          )
+
+          node.arguments.unshift(
+            newFirst,
+            ...enhancement.slice(1).map(e => t.stringLiteral(e))
+          )
+        } else {
+          node.arguments.unshift(
+            ...enhancement.map(e => t.stringLiteral(e)),
+            first
+          )
+        }
+      }
+    },
+  },
+})
+
+function matchEnhancementLogger (path, loggers) {
+  const { object, property } = path.node.callee
+
+  return loggers.find(logger =>
+    logger.object === (object && object.name) &&
+    logger.methods.includes(property && property.name)
+  )
+}

--- a/babel-plugin/fancy-console.test.js
+++ b/babel-plugin/fancy-console.test.js
@@ -1,0 +1,167 @@
+import * as babel from '@babel/core'
+import plugin from './fancy-console'
+
+// remove indentation from a string in a way similar to how babel does
+function deindent (strings, ...keys) {
+  const out = []
+  strings.forEach((part, index) => {
+    out.push(part.replace(/\n +/g, '\n'))
+    if (keys.length > 0) {
+      out.push(keys.shift())
+    }
+  })
+  out.unshift(out.shift().replace(/^ *\n */g, ''))
+  out.push(out.pop().replace(/\n *$/g, ''))
+  return out.join('')
+}
+
+const SRC_TESTS = [
+  [
+    'log',
+    `
+      const foo = 1;
+      const bar = {};
+
+      console.log("just a message");
+      console.log(foo);
+      console.log("foo", foo);
+      console.log("foo", foo, "bar", bar);
+      console.log("%cFANCY%c - ", "color: red", "", foo);
+    `,
+  ],
+  [
+    'info',
+    `
+      const foo = 1;
+      const bar = {};
+
+      console.info('just a message');
+      console.info(bar);
+      console.info('bar', bar);
+      console.info(\`bar: \${bar}\`);
+    `,
+  ],
+  [
+    'warn',
+    `
+      const foo = 1;
+      const bar = {};
+
+      console.warn('just a message');
+      console.warn(bar);
+      console.warn('bar', bar);
+      console.warn(\`bar: \${bar}\`);
+    `,
+  ],
+  [
+    'error',
+    `
+      const foo = 1;
+      const bar = {};
+
+      console.error('just a message');
+      console.error(bar);
+      console.error('bar', bar);
+      console.error(\`bar: \${bar}\`);
+    `,
+  ],
+  [
+    'group',
+    `
+      console.group('groupName');
+      console.group('groupName, level 2');
+      console.groupEnd();
+      console.groupEnd();
+    `,
+    deindent`
+      console.group('groupName');
+      console.group('groupName, level 2');
+      console.groupEnd();
+      console.groupEnd();
+    `,
+  ],
+]
+
+describe('fancy-console-test', () => {
+  it('deindent', () => {
+    const a = 'A'
+    const b = 'B'
+
+    const src = deindent`
+      ${a}
+      const foo;
+      something();
+      {${b}}
+    `
+
+    const res = `${a}
+const foo;
+something();
+{${b}}`
+
+    expect(src).toMatch(res)
+  })
+
+  test.each(SRC_TESTS)(
+    'test [%s]',
+    (title, src, expected = '') => {
+      const { code } = babel.transformSync(src, { plugins: [plugin], babelrc: false })
+      expect(code).toMatchSnapshot()
+      if (expected.length > 0) {
+        expect(code).toMatch(expected)
+      }
+    }
+  )
+
+  test('custom options', () => {
+    const enhancements = {
+      log: ['__ debug __'],
+      info: ['^^ info ^^'],
+      warn: ['** warn **'],
+    }
+
+    const src = `
+      con.log("this is debug");
+      con.info("this in info", "data");
+      con.warn("and a warning %s here", "string");
+      con.error("simple error");
+      con.start();
+      con.start("with a string argument");
+      con.stop();
+      con.stop("with a string argument");
+    `
+
+    const res = deindent`
+      con.log("${enhancements.log[0]}" + (" " + "this is debug"));
+      con.info("${enhancements.info[0]}" + (" " + "this in info"), "data");
+      con.warn("${enhancements.warn[0]}" + (" " + "and a warning %s here"), "string");
+      con.error("simple error");
+      con.start();
+      con.start("with a string argument");
+      con.stop();
+      con.stop("with a string argument");
+    `
+
+    const { code } = babel.transformSync(
+      src,
+      {
+        plugins: [
+          [
+            plugin,
+            {
+              loggers: [
+                {
+                  object: 'con',
+                  methods: Object.keys(enhancements),
+                  enhancements,
+                },
+              ],
+            },
+          ],
+        ],
+        babelrc: false,
+      })
+
+    expect(code).toMatch(res)
+  })
+})

--- a/config/babel.app.config.js
+++ b/config/babel.app.config.js
@@ -76,6 +76,8 @@ module.exports = function (api, opts = {}) {
       //   },
       // ],
 
+      isEnvDevelopment && './babel-plugin/fancy-console',
+
     ].filter(Boolean),
 
     // define overrides to configs for a specific test/include/exclude case

--- a/config/jest/babelTransform.js
+++ b/config/jest/babelTransform.js
@@ -1,4 +1,5 @@
 const babelJest = require('babel-jest')
+const chalk = require('chalk')
 
 module.exports = babelJest.createTransformer({
   babelrc: false,
@@ -6,5 +7,26 @@ module.exports = babelJest.createTransformer({
 
   // This should match the paths.appSrc 'babel-loader' options.preset in webpack.config.dev.js
   presets: [ './config/babel.app.config.js' ],
+
+  plugins: [
+    // Enable fancy logging that uses chalk to make console output colorful
+    [
+      './babel-plugin/fancy-console',
+      {
+        loggers: [
+          {
+            object: 'console',
+            methods: ['log', 'info', 'warn', 'error'],
+            enhancements: {
+              log: [chalk.bold.white.bgHex('#21409a')(' debug ')],
+              info: [chalk.bold.white.bgHex('#01acac')(' info ')],
+              warn: [chalk.bold.white.bgHex('#f8a51b')(' warn ')],
+              error: [chalk.bold.white.bgHex('#ed403c')(' error ')],
+            },
+          },
+        ],
+      },
+    ],
+  ]
 
 })

--- a/config/jest/chalk.logger.js
+++ b/config/jest/chalk.logger.js
@@ -1,9 +1,0 @@
-import { enhanceOutput } from '../../src/logger'
-import chalk from 'chalk'
-
-enhanceOutput({
-  debug: [ chalk.bold.white.bgHex('#21409a')(' debug ') ],
-  info: [ chalk.bold.white.bgHex('#01acac')(' info ') ],
-  warn: [ chalk.bold.white.bgHex('#f8a51b')(' warn ') ],
-  error: [ chalk.bold.white.bgHex('#ed403c')(' error ') ],
-})

--- a/package.json
+++ b/package.json
@@ -144,13 +144,13 @@
   },
   "jest": {
     "setupFiles": [
-      "<rootDir>/config/polyfills.js",
-      "<rootDir>/config/jest/chalk.logger.js"
+      "<rootDir>/config/polyfills.js"
     ],
     "testEnvironment": "jsdom",
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
-      "<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}"
+      "<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}",
+      "<rootDir>/babel-plugin/**/*.test.{js,jsx,ts,tsx}"
     ],
     "testURL": "http://localhost/",
     "transform": {

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,8 +1,5 @@
 let isDebugEnabled = true
 
-/**
- * Control output of console logging.
- */
 export function setLogDebug (enabled) {
   isDebugEnabled = enabled
 }
@@ -16,44 +13,19 @@ const BASE_FUNCTIONS = {
 }
 
 /*
- * Functions bound to the real console object, in the correct context for generating
- * appropriate file/line numbers.  Also provide the first few arguments to the real
- * function calls to add pretty line prefixes.
- */
-let consoleFunctions = {}
-
-export function enhanceOutput (enhancers) {
-  consoleFunctions = {
-    log: BASE_FUNCTIONS.log.bind(window.console, ...enhancers.debug),
-    info: BASE_FUNCTIONS.info.bind(window.console, ...enhancers.info),
-    warn: BASE_FUNCTIONS.warn.bind(window.console, ...enhancers.warn),
-    error: BASE_FUNCTIONS.error.bind(window.console, ...enhancers.error),
-  }
-}
-
-enhanceOutput({
-  debug: ['%c debug %c', 'font-weight: bold; background-color: #21409a; color: white;', ''],
-  info: ['%c info %c', 'font-weight: bold; background-color: #01acac; color: white;', ''],
-  warn: ['%c warn %c', 'font-weight: bold; background-color: #f8a51b; color: white;', ''],
-  error: ['%c error %c', 'font-weight: bold; background-color: #ed403c; color: white;', ''],
-})
-
-/*
  * Setup accessor properties on the given object to capture the base console logging
- * functions and provide our own "enhanced" function instead. Use `setLogDebug` to
- * control if the function returned will do any actual logging.
+ * functions and use `setLogDebug` to control if the function returned will do any
+ * actual logging.
  */
 function attachLoggers (object) {
   return Object.defineProperties(object, {
-    log: { get () { return isDebugEnabled ? consoleFunctions.log : NOOP } },
-    info: { get () { return isDebugEnabled ? consoleFunctions.info : NOOP } },
-    warn: { get () { return isDebugEnabled ? consoleFunctions.warn : NOOP } },
-    error: { get () { return isDebugEnabled ? consoleFunctions.error : NOOP } },
+    log: { get () { return isDebugEnabled ? BASE_FUNCTIONS.log : NOOP } },
+    info: { get () { return isDebugEnabled ? BASE_FUNCTIONS.info : NOOP } },
+    warn: { get () { return isDebugEnabled ? BASE_FUNCTIONS.warn : NOOP } },
+    error: { get () { return isDebugEnabled ? BASE_FUNCTIONS.error : NOOP } },
   })
 }
 
-/**
- * Enhance the standard browser console logging functions.  Output will be colored
- * and will log based on the `setLogDebug` value.
- */
 attachLoggers(window.console)
+
+export default attachLoggers({})


### PR DESCRIPTION
Sometimes the logging enhancements done in `src/logger.js` breaks some error logging.  This happen in react error logging where the `console.error()` string substitution characters are used in react code.  To step around this problem, `src/logger.js` is paired back to just enable turning console logging on and off and babel is used to add fancy output to the various logging functions.  The babel plugin will enhance every `console.(log|info|warn|error)` encountered in the code it processes.  Dependency code won't be touched, or will be properly enhanced and retain original logging functionality.

The fancy logging is only applied in development (using the default enhanced console css features for a browser runtime) and test (using chalk strings for a nodejs runtime) builds.