### PR TITLE
[WIP] Upgrade to ovirt-engine-nodejs-modules:2.1.0

### DIFF
--- a/automation/build.repos
+++ b/automation/build.repos
@@ -3,3 +3,8 @@ ovirt-tested,https://resources.ovirt.org/repos/ovirt/tested/master/rpm/$distro/
 
 # but we keep requiring latest jenkins build of ovirt-node-js-modules since we build in a lock-step
 ovirt-engine-nodejs-modules_master,https://jenkins.ovirt.org/job/ovirt-engine-nodejs-modules_standard-on-merge/lastSuccessfulBuild/artifact/build-artifacts.$distro.x86_64
+
+#
+# TEMPORARY TO TEST STDCI BUILD WITH nodejs-modules:2.1.0 (nodejs:14)
+#
+ovirt-upgrade-patch,https://jenkins.ovirt.org/job/ovirt-engine-nodejs-modules_standard-check-patch/416/artifact/build-artifacts.el8.x86_64/

--- a/ovirt-web-ui.spec.in
+++ b/ovirt-web-ui.spec.in
@@ -17,7 +17,7 @@ Source0:        %{source_basename}-%{version}.tar.gz
 BuildArch: noarch
 
 # nodejs-modules embeds yarn and requires nodejs
-BuildRequires: ovirt-engine-nodejs-modules >= 2.0.60-1
+BuildRequires: ovirt-engine-nodejs-modules >= 2.1.0-1
 
 %description
 This package provides the VM Portal for %{product}.


### PR DESCRIPTION
Why?
  - adopt latest yarn 1.x
  - adopt nodejs 14 for running builds (faster and better memory management)

Note: Currently the `build.repos` has a temporary repo link to the jenkins `ci build` for the patch that bumps ovirt-engine-nodejs-modules to 2.1.0 (https://gerrit.ovirt.org/c/ovirt-engine-nodejs-modules/+/116116) so the new version can be tested before merging that patch.  This PR should not be merged until that patch is merged.