### PR TITLE
User settings: Inform the user that cancel action is applied to all tabs

### DIFF
--- a/src/components/NavigationConfirmationModal/index.js
+++ b/src/components/NavigationConfirmationModal/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { Modal, Button, Alert } from 'patternfly-react'
 import { MsgContext } from '_/intl'
 
-const NavigationConfirmationModal = ({ show, onYes, onNo }) => {
+const NavigationConfirmationModal = ({ show, onYes, onNo, additionalNote }) => {
   const { msg } = useContext(MsgContext)
   const idPrefix = 'close-dialog-confim'
 
@@ -14,6 +14,7 @@ const NavigationConfirmationModal = ({ show, onYes, onNo }) => {
       </Modal.Header>
       <Modal.Body>
         <Alert type='warning' id={`${idPrefix}-body-text`}>{msg.unsavedChangesConfirmMessage()}</Alert>
+        {additionalNote}
       </Modal.Body>
       <Modal.Footer>
         <Button id={`${idPrefix}-button-no`} onClick={onNo} bsStyle='default'>{msg.no()}</Button>
@@ -26,6 +27,7 @@ NavigationConfirmationModal.propTypes = {
   show: PropTypes.bool,
   onYes: PropTypes.func.isRequired,
   onNo: PropTypes.func.isRequired,
+  additionalNote: PropTypes.string,
 }
 NavigationConfirmationModal.defaultProps = {
   show: false,

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -114,7 +114,7 @@ const Settings = ({
     <>
       <NavigationPrompt when={(currentLocation, nextLocation) => !!pendingChanges.length}>
         {({ isActive, onConfirm, onCancel }) => (
-          <NavigationConfirmationModal show={isActive} onYes={onConfirm} onNo={onCancel} />
+          <NavigationConfirmationModal show={isActive} onYes={onConfirm} onNo={onCancel} additionalNote={msg.allTabs()}/>
         )}
       </NavigationPrompt>
       <div className={showFullSuccess || partialSave.show || showCompleteFailure ? style['alert-container'] : null}>

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -46,6 +46,7 @@ export const messages: { [messageId: string]: MessageType } = {
     description: 'In sense of "human friendly name"',
   },
   allocatedVms: 'Allocated VMs',
+  allTabs: 'This action is applied to all tabs.',
   apiConnectionFailed: 'oVirt API connection failed',
   apiVersionCheckFailed: 'oVirt API version check failed',
   areYouSureYouWantToDeleteDisk: 'Are you sure you want to delete disk {diskName}?',


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/1440

Allow displaying the additional info in the confirmation dialog for cancel action in the user settings section. Note that the save and reset actions already contain the information that the action is applied to all tabs/settings.

**Before:** (_Cancel_ and _Reset_ actions)
![cancel_before](https://user-images.githubusercontent.com/13417815/128876664-abe0f22d-278a-4afb-80fb-06bd2806060a.png)
![reset_done](https://user-images.githubusercontent.com/13417815/128876817-908345ba-3175-47cf-a0a4-ecf23dac05e2.png)

**After:**
![cancel_after](https://user-images.githubusercontent.com/13417815/128876677-8de25918-80ed-499a-86c3-da6846135e9f.png)
![reset_after](https://user-images.githubusercontent.com/13417815/128932923-5620339e-f9c8-40cc-be90-3cde1863e542.png)

---

**The following screen wasn't changed:**

_Save_ action:
![save_done](https://user-images.githubusercontent.com/13417815/128876802-8301625a-fabd-477a-9e94-267f9bc6a2a9.png)
