### PR TITLE
ACTION_IN_PROGRESS_START/STOP sagas need to unwrap the action

### DIFF
--- a/src/sagas/vmChanges.js
+++ b/src/sagas/vmChanges.js
@@ -486,8 +486,8 @@ export default [
   takeLatest(C.REMOVE_VM, removeVm),
 
   // VM Status Changes
-  takeEvery(C.ACTION_IN_PROGRESS_START, startProgress),
-  takeEvery(C.ACTION_IN_PROGRESS_STOP, stopProgress),
+  takeEvery(C.ACTION_IN_PROGRESS_START, function* (action) { yield startProgress(action.payload) }),
+  takeEvery(C.ACTION_IN_PROGRESS_STOP, function* (action) { yield stopProgress(action.payload) }),
   takeEvery(C.SHUTDOWN_VM, shutdownVm),
   takeEvery(C.RESTART_VM, restartVm),
   takeEvery(C.START_VM, startVm),


### PR DESCRIPTION
Since `startProgress()` and `stopProgress()` sagas are not top-level
action saga, the action handling sagas fro `ACTION_IN_PROGRESS_START`
and `ACTION_IN_PROGRESS_STOP` need to unwrap the payload from the
action.

Followup from #1472