### PR TITLE
Download Remote Destop file with the proper file extension .rdp

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -91,12 +91,12 @@ export function fileDownload ({ data, fileName = 'myFile.dat', mimeType = 'appli
 
       myForm.target = targetName
       myForm.method = 'post'
-      myForm.action = `${AppConfiguration.applicationContext}/services/attachment/console.vv`
+      myForm.action = `${AppConfiguration.applicationContext}/services/attachment/${fileName}`
       myForm.enctype = 'application/x-www-form-urlencoded'
       myForm.style = 'display: none;'
 
       textArea1.name = 'contenttype'
-      textArea1.appendChild(document.createTextNode('application/x-virt-viewer;+charset=UTF-8'))
+      textArea1.appendChild(document.createTextNode(`${mimeType};+charset=UTF-8`))
       myForm.appendChild(textArea1)
 
       textArea2.name = 'content'


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/1505

Allow downloading the VM console file _console.rdp_ instead of _onsole.vv_ from a Windows VM also for Firefox browser. The other browsers didn't have the problem with the incorrect file extension.

**Before:**
![before](https://user-images.githubusercontent.com/13417815/130786894-b16f6e6c-2be7-4e72-8244-dc0d24869056.png)

**After:**
![after](https://user-images.githubusercontent.com/13417815/130786920-fe845095-c7fe-45fe-ad61-f2e8b0bd3a92.png)

