### PR TITLE
Autoconnect console only after login

### DIFF
--- a/src/actions/vm.js
+++ b/src/actions/vm.js
@@ -1,7 +1,7 @@
 import AppConfiguration from '_/config'
 import * as C from '_/constants'
 
-export function login ({ username, domain, token, userId }) {
+export function login ({ username, domain, token, userId, sessionAgeInSecAtPageLoad }) {
   return {
     type: C.LOGIN,
     payload: {
@@ -9,6 +9,7 @@ export function login ({ username, domain, token, userId }) {
       domain,
       token,
       userId,
+      sessionAgeInSecAtPageLoad,
     },
   }
 }
@@ -170,7 +171,7 @@ export function setVmActionResult ({ vmId, correlationId, result }) {
 }
 
 // --- Internal State -------------------------
-export function loginSuccessful ({ username, domain, token, userId }) {
+export function loginSuccessful ({ username, domain, token, userId, sessionAgeInSecAtPageLoad }) {
   return {
     type: C.LOGIN_SUCCESSFUL,
     payload: {
@@ -178,6 +179,7 @@ export function loginSuccessful ({ username, domain, token, userId }) {
       domain,
       token,
       userId,
+      sessionAgeInSecAtPageLoad,
     },
   }
 }

--- a/src/actions/vm.js
+++ b/src/actions/vm.js
@@ -171,7 +171,7 @@ export function setVmActionResult ({ vmId, correlationId, result }) {
 }
 
 // --- Internal State -------------------------
-export function loginSuccessful ({ username, domain, token, userId, sessionAgeInSecAtPageLoad }) {
+export function loginSuccessful ({ username, domain, token, userId, firstLogin }) {
   return {
     type: C.LOGIN_SUCCESSFUL,
     payload: {
@@ -179,7 +179,7 @@ export function loginSuccessful ({ username, domain, token, userId, sessionAgeIn
       domain,
       token,
       userId,
-      sessionAgeInSecAtPageLoad,
+      firstLogin,
     },
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -17,7 +17,7 @@ const AppConfiguration = {
   showNotificationsDefault: true,
   persistLocale: true,
   smartcardSpice: true,
-  sessionAgeFirstLoginThreshold: 15,
+  sessionAgeFirstLoginThresholdInSeconds: 60,
 
   consoleClientResourcesURL: 'https://www.ovirt.org/documentation/admin-guide/virt/console-client-resources/',
   cockpitPort: '9090',

--- a/src/config.js
+++ b/src/config.js
@@ -17,6 +17,7 @@ const AppConfiguration = {
   showNotificationsDefault: true,
   persistLocale: true,
   smartcardSpice: true,
+  sessionAgeFirstLoginThreshold: 15,
 
   consoleClientResourcesURL: 'https://www.ovirt.org/documentation/admin-guide/virt/console-client-resources/',
   cockpitPort: '9090',

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ function renderApp (store: Object, errorBridge: Object) {
  *
  * See web.xml.
  */
-function fetchToken (): { token: string, username: string, domain: string, userId: string } {
+function fetchToken (): { token: string, username: string, domain: string, userId: string, sessionAgeInSecAtPageLoad: number } {
   const userInfo = window.userInfo
   console.log(`SSO userInfo: ${JSON.stringify(userInfo)}`)
 
@@ -63,6 +63,7 @@ function fetchToken (): { token: string, username: string, domain: string, userI
       username: userInfo.userName,
       domain: userInfo.domain,
       userId: userInfo.userId,
+      sessionAgeInSecAtPageLoad: Number(userInfo.sessionAgeInSec) || 0,
     }
   }
   return {
@@ -70,6 +71,7 @@ function fetchToken (): { token: string, username: string, domain: string, userI
     username: '',
     domain: '',
     userId: '',
+    sessionAgeInSecAtPageLoad: 0,
   }
 }
 
@@ -120,9 +122,15 @@ function onResourcesLoaded () {
   renderApp(store, new SagaErrorBridge(store.rootTask))
 
   // and start the login/init-data-load action
-  const { token, username, domain, userId }: { token: string, username: string, domain: string, userId: string } = fetchToken()
+  const {
+    token,
+    username,
+    domain,
+    userId,
+    sessionAgeInSecAtPageLoad,
+  }: { token: string, username: string, domain: string, userId: string, sessionAgeInSecAtPageLoad: number } = fetchToken()
   if (token) {
-    store.dispatch(login({ username, token, userId, domain }))
+    store.dispatch(login({ username, token, userId, domain, sessionAgeInSecAtPageLoad }))
   } else {
     console.error('Missing SSO Token!')
   }

--- a/src/ovirt-web-ui.config
+++ b/src/ovirt-web-ui.config
@@ -4,7 +4,7 @@
   "applicationContext": "/ovirt-engine",
   "applicationURL": "/ovirt-engine/web-ui",
   "applicationLogoutURL": "/ovirt-engine/web-ui/sso/logout",
-  "sessionAgeFirstLoginThreshold" : 15,
+  "sessionAgeFirstLoginThresholdInSeconds" : 60,
 
   "consoleClientResourcesURL": "https://www.ovirt.org/documentation/admin-guide/virt/console-client-resources/",
   "cockpitPort": "9090"

--- a/src/ovirt-web-ui.config
+++ b/src/ovirt-web-ui.config
@@ -4,6 +4,7 @@
   "applicationContext": "/ovirt-engine",
   "applicationURL": "/ovirt-engine/web-ui",
   "applicationLogoutURL": "/ovirt-engine/web-ui/sso/logout",
+  "sessionAgeFirstLoginThreshold" : 15,
 
   "consoleClientResourcesURL": "https://www.ovirt.org/documentation/admin-guide/virt/console-client-resources/",
   "cockpitPort": "9090"

--- a/src/reducers/config.js
+++ b/src/reducers/config.js
@@ -86,13 +86,13 @@ const initialState = Immutable.fromJS({
 })
 
 const config = actionReducer(initialState, {
-  [LOGIN_SUCCESSFUL] (state, { payload: { username, domain, token, userId, sessionAgeInSecAtPageLoad } }) {
+  [LOGIN_SUCCESSFUL] (state, { payload: { username, domain, token, userId, firstLogin } }) {
     return state.merge({
       loginToken: token,
       user: {
         name: username,
         id: userId,
-        sessionAgeInSecAtPageLoad,
+        firstLogin,
       },
       domain,
     })

--- a/src/reducers/config.js
+++ b/src/reducers/config.js
@@ -86,12 +86,13 @@ const initialState = Immutable.fromJS({
 })
 
 const config = actionReducer(initialState, {
-  [LOGIN_SUCCESSFUL] (state, { payload: { username, domain, token, userId } }) {
+  [LOGIN_SUCCESSFUL] (state, { payload: { username, domain, token, userId, sessionAgeInSecAtPageLoad } }) {
     return state.merge({
       loginToken: token,
       user: {
         name: username,
         id: userId,
+        sessionAgeInSecAtPageLoad,
       },
       domain,
     })

--- a/src/sagas/console/index.js
+++ b/src/sagas/console/index.js
@@ -268,22 +268,22 @@ function* autoconnect () {
 
   const {
     userId,
-    sessionAgeInSecAtPageLoad,
+    firstLogin,
     websocket,
     defaultVncMode,
     preferredConsole,
     autoconnectOption,
   } = yield select(({ config, options }) => ({
     userId: config.getIn(['user', 'id']),
-    sessionAgeInSecAtPageLoad: config.getIn(['user', 'sessionAgeInSecAtPageLoad'], 0),
+    firstLogin: config.getIn(['user', 'firstLogin'], true),
     websocket: config.get('websocket'),
     defaultVncMode: config.get('defaultVncMode'),
     preferredConsole: options.getIn(['remoteOptions', 'preferredConsole', 'content'], config.getIn(['defaultUiConsole'])),
     autoconnectOption: toJS(options.getIn(['remoteOptions', 'autoconnect'])),
   }))
 
-  if (sessionAgeInSecAtPageLoad > 15) {
-    console.warn(`Autoconnect aborted - based on the session age (${sessionAgeInSecAtPageLoad} sec) it's a page refresh not the first page load`)
+  if (!firstLogin) {
+    console.warn('Autoconnect aborted - page refresh detected')
     return
   }
 

--- a/src/sagas/console/index.js
+++ b/src/sagas/console/index.js
@@ -268,17 +268,24 @@ function* autoconnect () {
 
   const {
     userId,
+    sessionAgeInSecAtPageLoad,
     websocket,
     defaultVncMode,
     preferredConsole,
     autoconnectOption,
   } = yield select(({ config, options }) => ({
     userId: config.getIn(['user', 'id']),
+    sessionAgeInSecAtPageLoad: config.getIn(['user', 'sessionAgeInSecAtPageLoad'], 0),
     websocket: config.get('websocket'),
     defaultVncMode: config.get('defaultVncMode'),
     preferredConsole: options.getIn(['remoteOptions', 'preferredConsole', 'content'], config.getIn(['defaultUiConsole'])),
     autoconnectOption: toJS(options.getIn(['remoteOptions', 'autoconnect'])),
   }))
+
+  if (sessionAgeInSecAtPageLoad > 15) {
+    console.warn(`Autoconnect aborted - based on the session age (${sessionAgeInSecAtPageLoad} sec) it's a page refresh not the first page load`)
+    return
+  }
 
   const { content: vmId, id: optionId } = autoconnectOption || {}
 

--- a/src/sagas/login.js
+++ b/src/sagas/login.js
@@ -48,7 +48,7 @@ import { loadUserOptions } from './options'
  * Perform login checks, and if they pass, perform initial data loading
  */
 function* login (action) {
-  const { payload: { token, userId, username, domain } } = action
+  const { payload: { token, userId, username, domain, sessionAgeInSecAtPageLoad } } = action
   console.group('Login Verification')
 
   // Verify a SSO token exists
@@ -60,7 +60,7 @@ function* login (action) {
     return
   }
 
-  yield put(loginSuccessful({ token, userId, username, domain }))
+  yield put(loginSuccessful({ token, userId, username, domain, sessionAgeInSecAtPageLoad }))
 
   // Verify the API (exists and is the correct version)
   const oVirtMeta = yield callExternalAction(Api.getOvirtApiMeta, action)

--- a/src/sagas/login.js
+++ b/src/sagas/login.js
@@ -45,8 +45,8 @@ import { loadFromLocalStorage, removeFromLocalStorage } from '_/storage'
 import { loadUserOptions } from './options'
 
 function isFirstLogin (sessionAgeInSecAtPageLoad) {
-  const threshold = AppConfiguration.sessionAgeFirstLoginThreshold
-  return !threshold || sessionAgeInSecAtPageLoad < threshold
+  const threshold = AppConfiguration.sessionAgeFirstLoginThresholdInSeconds
+  return !threshold || sessionAgeInSecAtPageLoad <= threshold
 }
 
 /**

--- a/src/sagas/login.js
+++ b/src/sagas/login.js
@@ -44,6 +44,11 @@ import { loadIconsFromLocalStorage } from './osIcons'
 import { loadFromLocalStorage, removeFromLocalStorage } from '_/storage'
 import { loadUserOptions } from './options'
 
+function isFirstLogin (sessionAgeInSecAtPageLoad) {
+  const threshold = AppConfiguration.sessionAgeFirstLoginThreshold
+  return !threshold || sessionAgeInSecAtPageLoad < threshold
+}
+
 /**
  * Perform login checks, and if they pass, perform initial data loading
  */
@@ -60,7 +65,9 @@ function* login (action) {
     return
   }
 
-  yield put(loginSuccessful({ token, userId, username, domain, sessionAgeInSecAtPageLoad }))
+  const firstLogin = isFirstLogin(sessionAgeInSecAtPageLoad)
+
+  yield put(loginSuccessful({ token, userId, username, domain, firstLogin }))
 
   // Verify the API (exists and is the correct version)
   const oVirtMeta = yield callExternalAction(Api.getOvirtApiMeta, action)


### PR DESCRIPTION
Fixes: #1459 

Connect automatically to the console at the first page load after
login but not on subsequent page refreshes.

First page load after login is recognized indirectly based
on the session age. Session older than ~~15~~ 60 sec indicates a page refresh.