### PR TITLE
Handle network errors during page refresh

### DIFF
--- a/src/reducers/vms.js
+++ b/src/reducers/vms.js
@@ -46,7 +46,7 @@ const vms = actionReducer(initialState, {
       state = updatePools(state, pools)
     }
 
-    if (removePoolIds && removePoolIds > 0) {
+    if (removePoolIds && removePoolIds.length > 0) {
       state = removePools(state, removePoolIds)
     }
 

--- a/src/sagas/console/index.js
+++ b/src/sagas/console/index.js
@@ -294,7 +294,7 @@ function* autoconnect () {
   }
 
   const { internalVm: vm, error } = yield call(fetchAndPutSingleVm, Actions.getSingleVm({ vmId, shallowFetch: true }))
-  if (error === 404) {
+  if (error?.status === 404) {
     yield put(Actions.deleteUserOption({ optionId, userId }))
     yield put(Actions.addUserMessage({ messageDescriptor: { id: 'clearAutoconnectVmNotAvailable' }, type: 'INFO' }))
     return


### PR DESCRIPTION
Steps to recreate:
1. enter main VM Portal page with VMs/pools
2. disable networking (i.e. using dev tools)
3. trigger manual refresh
Expected result: error notifications are displayed
Actual result: VM Portal crashes

Fixes:
1. error.status == 0  - if network is down the reported status code is
   zero which bypasses some of our checks. Fixed by returning
   the entire error object.
2. temporary network error causes VMs/pools to be removed from
   the dashboard. Fixed by removing only if the server reported 404.
3. use common filtering routine to process VMs and pools retrieved
   during page refresh

