### PR TITLE
Github Actions to implement CI / check-patch

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,92 @@
+#
+# CI for this project needs to do two things:
+#   1. Setup the environment for and run `yarn build`
+#   2. Build the distribution rpm for use in QE/OST/Integration testing
+#
+name: run CI on PRs
+on:
+  pull_request:
+
+jobs:
+  test_el8_offline:
+    name: EL8 - Check the PR (offline build)
+    env:
+      OFFLINE_BUILD: 1
+
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/centos/centos:stream8
+
+    steps:
+      - name: Enable repos and choose module versions
+        run: |
+          dnf -y copr enable ovirt/ovirt-master-snapshot centos-stream-8
+          dnf -y module enable nodejs:14
+
+      - name: Install build.sh required packages
+        run: |
+          dnf -y install git make autoconf automake rpm-build
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Run automation/build.sh
+        run: ./automation/build.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts
+          path: exported-artifacts/
+
+
+  test_el8_online:
+    name: EL8 - Check the PR (online build)
+    env:
+      OFFLINE_BUILD: 0
+      MOVE_ARTIFACTS: 0
+      SRPM_PATH: tmp.repos/SRPMS
+
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/centos/centos:stream8
+
+    steps:
+      - name: Enable repos and choose module versions
+        run: |
+          dnf -y copr enable ovirt/ovirt-master-snapshot centos-stream-8
+          dnf -y config-manager --add-repo https://dl.yarnpkg.com/rpm/yarn.repo
+          dnf -y module enable nodejs:14
+
+      - name: Install build.sh required packages
+        run: |
+          dnf -y install git make autoconf automake rpm-build
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Build srpm
+        run: |
+          ./automation/build.sh copr
+
+      - name: Install build dependencies from srpm
+        run: |
+          dnf -y builddep ${{ env.SRPM_PATH }}/ovirt-web-ui*.src.rpm
+
+      - name: Build rpm directly from srpm
+        run: |
+          rpmbuild \
+            --define="_topdir `pwd`/tmp.repos" \
+            --rebuild ${{ env.SRPM_PATH }}/ovirt-web-ui*.src.rpm
+
+      - name: Collect artifacts
+        run: |
+          [[ -d exported-artifacts ]] || mkdir -p exported-artifacts
+          find tmp.repos -iname \*rpm -exec mv "{}" exported-artifacts/ \;
+          mv ./*tar.gz exported-artifacts/
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts (online build)
+          path: exported-artifacts/

--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,8 @@ AM_INIT_AUTOMAKE([-Wall -Werror foreign -Wno-portability tar-pax])
 AC_ARG_VAR([RPMBUILD], [path to rpmbuild utility])
 AC_CHECK_PROGS([RPMBUILD], [rpmbuild])
 
+dnl TODO: Fail if rpmbuild is not present
+
 PACKAGE_RPM_SUFFIX=${PACKAGE_RPM_SUFFIX:-"%{?release_suffix}"}
 AC_ARG_VAR([PACKAGE_RPM_SUFFIX], [suffix to use on the rpm's release string])
 


### PR DESCRIPTION
Add `check.yaml` to replicate the std-ci **check-patch** stage
of CI.  This will run the FULL build from sources to srpm to rpm.
The full build includes linting, unit tests, dist build and rpm
packaging.

Two jobs are setup.  The first will run the full build in offline
mode using ovirt-engine-nodejs-modules.  The second will run an
online build directly downloading yarn dependencies.

Note: If the online build succeeds but the offline build fails, then
the **ovirt-engine-nodejs-modules** project probably needs to be
updated with a pre-seed for the PR being worked on.