### PR TITLE
Ignore SSO failures when connecting to the console

### DIFF
--- a/src/components/VmActions/ConsoleNotificationsDialog.js
+++ b/src/components/VmActions/ConsoleNotificationsDialog.js
@@ -9,7 +9,6 @@ import * as Actions from '_/actions/console'
 
 import {
   CONSOLE_IN_USE,
-  CONSOLE_LOGON,
 } from '_/constants'
 
 import {
@@ -42,24 +41,6 @@ const ConsoleNotificationsDialog = ({
   }
 
   switch (status) {
-    case CONSOLE_LOGON:
-      return (
-        <ConfirmationModal
-          show={true}
-          onClose={onClose}
-          title={getTitle()}
-          body={msg.cantLogonToConsole()}
-          confirm={{
-            title: msg.yes(),
-            onClick: () => openConsole({
-              skipSSO: true,
-              logoutOtherUsers,
-              vmId,
-              consoleType,
-            }),
-          }}
-        />
-      )
     case CONSOLE_IN_USE:
       return (
         <ConfirmationModal

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -64,7 +64,7 @@ export const messages: { [messageId: string]: MessageType } = {
   bootSequence: 'Boot Sequence',
   cancel: 'Cancel',
   cannotUpdateCloudInitHostname: 'Host name cannot be synchronized with VM name because the VM name is not a valid host name.',
-  cantLogonToConsole: 'Single sign on failed. Please check to see if the guest agent is running on your virtual machine. Contact your administrator if the problem continues. Error message: {message}',
+  cantLogonToConsole: 'Single sign on failed. Please check to see if the guest agent is running on your virtual machine. Error message: {message}',
   cantOpenConsole: 'Can\'t open console: {message}',
   cardTitleDetails: 'Details',
   cd: 'CD',

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -64,7 +64,7 @@ export const messages: { [messageId: string]: MessageType } = {
   bootSequence: 'Boot Sequence',
   cancel: 'Cancel',
   cannotUpdateCloudInitHostname: 'Host name cannot be synchronized with VM name because the VM name is not a valid host name.',
-  cantLogonToConsole: 'Single sign on failed. Please check to see if the guest agent is running on your virtual machine. Contact your administrator if the problem continues.',
+  cantLogonToConsole: 'Single sign on failed. Please check to see if the guest agent is running on your virtual machine. Contact your administrator if the problem continues. Error message: {message}',
   cantOpenConsole: 'Can\'t open console: {message}',
   cardTitleDetails: 'Details',
   cd: 'CD',

--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -196,7 +196,13 @@ const VM = {
       nics: [],
       statistics: [],
 
-      ssoGuestAgent: vm.sso.methods && vm.sso.methods.method && vm.sso.methods.method.length > 0 && vm.sso.methods.method.findIndex(method => method.id === 'guest_agent') > -1,
+      /**
+       * console SSO logon is deprecated as it relies on deprecated ovirtGuestAgentChannel (by default not supported i.e. for RHEL 8+)
+       * 1. it may still be in use by older or custom OS
+       * 2. the flag may be left enabled after upgrade (it's admin responsibility to fix configuration)
+       * 3. flag can be enabled any time by the admin (even if not supported by the OS)
+       */
+      attemptSsoOnOpenConsole: vm.sso.methods && vm.sso.methods.method && vm.sso.methods.method.length > 0 && vm.sso.methods.method.findIndex(method => method.id === 'guest_agent') > -1,
       display: {
         smartcardEnabled: vm.display && vm.display.smartcard_enabled && convertBool(vm.display.smartcard_enabled),
       },

--- a/src/sagas/console/index.js
+++ b/src/sagas/console/index.js
@@ -44,10 +44,7 @@ function* downloadOrOpenVmConsole ({
   if (hasGuestAgent && !skipSSO) {
     const result = yield callExternalAction(Api.vmLogon, { payload: { vmId } }, true)
     if (!result || result.status !== 'complete') {
-      const message = result?.error?.responseJSON?.fault?.detail ?? ''
-      yield put(Actions.addConsoleError({ vmId, vmName, consoleType, status: C.CONSOLE_LOGON, consoleId, logoutOtherUsers }))
-      yield put(Actions.addUserMessage({ messageDescriptor: { id: 'cantOpenConsole', params: { message } }, type: 'error' }))
-      return
+      yield put(Actions.addUserMessage({ messageDescriptor: { id: 'cantLogonToConsole' }, type: 'warning' }))
     }
   }
 

--- a/src/sagas/console/index.js
+++ b/src/sagas/console/index.js
@@ -36,12 +36,12 @@ function* downloadOrOpenVmConsole ({
   consoleId,
   usbAutoshare,
   usbFilter,
-  hasGuestAgent,
+  attemptSsoOnOpenConsole,
   skipSSO,
   openInPage,
   logoutOtherUsers,
 }) {
-  if (hasGuestAgent && !skipSSO) {
+  if (attemptSsoOnOpenConsole && !skipSSO) {
     const result = yield callExternalAction(Api.vmLogon, { payload: { vmId } }, true)
     if (!result || result.status !== 'complete') {
       const message = result?.error?.responseJSON?.fault?.detail ?? ''
@@ -173,7 +173,7 @@ export function* openConsole ({
     usbAutoshare,
     usbFilter,
     vmName,
-    hasGuestAgent,
+    attemptSsoOnOpenConsole,
     consoleId,
     fqdn,
     domain,
@@ -185,7 +185,7 @@ export function* openConsole ({
     domain: config.get('domain'),
     username: config.getIn(['user', 'name']),
     vmName: vms.getIn(['vms', vmId, 'name']),
-    hasGuestAgent: vms.getIn(['vms', vmId, 'ssoGuestAgent']),
+    attemptSsoOnOpenConsole: vms.getIn(['vms', vmId, 'attemptSsoOnOpenConsole']),
     consoleId: idFromType({ consoleType, vm: vms.getIn(['vms', vmId]) }),
     fqdn: vms.getIn(['vms', vmId, 'fqdn']),
   }))
@@ -223,7 +223,7 @@ export function* openConsole ({
       vmId,
       usbAutoshare,
       usbFilter,
-      hasGuestAgent,
+      attemptSsoOnOpenConsole,
       consoleId,
       openInPage,
       skipSSO: skipSSO || doesVmSessionExistForUserId(sessionsInternal, userId),

--- a/src/sagas/console/index.js
+++ b/src/sagas/console/index.js
@@ -45,10 +45,7 @@ function* downloadOrOpenVmConsole ({
     const result = yield callExternalAction(Api.vmLogon, { payload: { vmId } }, true)
     if (!result || result.status !== 'complete') {
       const message = result?.error?.responseJSON?.fault?.detail ?? ''
-      if (message) {
-        yield put(Actions.addUserMessage({ messageDescriptor: { id: 'cantOpenConsole', params: { message } }, type: 'warning' }))
-      }
-      yield put(Actions.addUserMessage({ messageDescriptor: { id: 'cantLogonToConsole' }, type: 'warning' }))
+      yield put(Actions.addUserMessage({ messageDescriptor: { id: 'cantLogonToConsole', params: { message } }, type: 'warning' }))
     }
   }
 

--- a/src/sagas/console/index.js
+++ b/src/sagas/console/index.js
@@ -44,6 +44,10 @@ function* downloadOrOpenVmConsole ({
   if (hasGuestAgent && !skipSSO) {
     const result = yield callExternalAction(Api.vmLogon, { payload: { vmId } }, true)
     if (!result || result.status !== 'complete') {
+      const message = result?.error?.responseJSON?.fault?.detail ?? ''
+      if (message) {
+        yield put(Actions.addUserMessage({ messageDescriptor: { id: 'cantOpenConsole', params: { message } }, type: 'warning' }))
+      }
       yield put(Actions.addUserMessage({ messageDescriptor: { id: 'cantLogonToConsole' }, type: 'warning' }))
     }
   }


### PR DESCRIPTION
In case of unsuccessful SSO logon try to recover by connecting without SSO. The flow is the same as if the user manually ignored the error. This avoids disrupting the user with an error dialog that offers no real choice (beside ignoring the error).
The user will be still informed about unsuccessful logon via notification system (at warning level) so that he will be able to report the problem.
