### PR TITLE
Fix README - removing deprecated Cockpit reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ VM Portal is a modern lightweight UI for oVirt that allows oVirt users to create
 ![Dashboard](https://github.com/oVirt/ovirt-web-ui/raw/master/doc/screenshots/v1.5.0_2019-Feb/01_vm_dashboard.png)
 
 ## Installation
-VM Portal is installed automatically when you [install oVirt using Cockpit](https://ovirt.org/download). Once oVirt is installed,
+VM Portal is installed automatically when you [install oVirt using the command line](https://ovirt.org/download). Once oVirt is installed,
 navigate to https://[ENGINE_FQDN]/ovirt-engine and click VM Portal.
 
 ## Bugs and Enhancements


### PR DESCRIPTION
Fixes issue: https://github.com/oVirt/ovirt-site/issues/2668

Since Cockpit is deprecated, replace the Cockpit installation reference
within readme file with oVirt command line installation.

The content within the reference link https://ovirt.org/download will be
replaced by https://github.com/oVirt/ovirt-site/pull/2672

Bug-Url: https://github.com/oVirt/ovirt-site/issues/2668