### PR TITLE
i18n: Update zanata configurations and intl scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "jest": "27.3.1",
     "json-stable-stringify-without-jsonify": "1.0.1",
     "mini-css-extract-plugin": "^1.6.2",
+    "mkdirp": "1.0.4",
     "postcss": "8.3.11",
     "postcss-loader": "^4.3.0",
     "postcss-preset-env": "6.7.0",
@@ -102,7 +103,7 @@
   },
   "resolutions": {
     "bootstrap-select": ">=1.13.6",
-    "webpack/**/glob-parent": "^5.1.2",    
+    "webpack/**/glob-parent": "^5.1.2",
     "patternfly/**/jquery": ">=3.5.1",
     "immer": ">=9.0.6",
     "@patternfly/react-console/**/@novnc/novnc": "1.1.0"
@@ -129,8 +130,7 @@
     "intl:check-use": "scripts/intl/check-message-use.sh"
   },
   "jest": {
-    "setupFiles": [
-    ],
+    "setupFiles": [],
     "testEnvironment": "jsdom",
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",

--- a/scripts/intl/dummy-locale.js
+++ b/scripts/intl/dummy-locale.js
@@ -4,6 +4,9 @@ import path from 'path'
 import chalk from 'chalk'
 import stableStringify from 'json-stable-stringify-without-jsonify'
 
+import messages from '../../src/intl/messages.js'
+import timeDurations from '../../src/intl/time-durations.js'
+
 const DUMMY_LOCALE = 'aa'
 
 function insertDummyLocaleAndSave (messages, destination) {
@@ -22,11 +25,11 @@ function insertDummyLocaleAndSave (messages, destination) {
 }
 
 insertDummyLocaleAndSave(
-  require('../../src/intl/messages').messages,
+  messages.messages,
   path.join('src', 'intl', 'translated-messages.json')
 )
 
 insertDummyLocaleAndSave(
-  require('../../src/intl/time-durations').timeDurations,
+  timeDurations.timeDurations,
   path.join('src', 'intl', 'translated-time-durations.json')
 )

--- a/scripts/intl/extract-messages.js
+++ b/scripts/intl/extract-messages.js
@@ -1,7 +1,10 @@
 import fs from 'fs'
 import path from 'path'
-import { sync as mkdirpSync } from 'mkdirp'
 import chalk from 'chalk'
+import mkdirp from 'mkdirp'
+
+import messages from '../../src/intl/messages.js'
+import timeDurations from '../../src/intl/time-durations.js'
 
 function normalizeMessages (messages) {
   return Object.keys(messages)
@@ -33,19 +36,19 @@ function toReactIntlMessageDescriptor (messageId, messageValue) {
 function extractMessages (messages, destDir, destFile) {
   console.log(chalk.green(`> [extract-messages.js] write file -> ${destFile} ✔️`))
   const json2poMessages = normalizeMessages(messages)
-  mkdirpSync(destDir)
+  mkdirp.sync(destDir)
   fs.writeFileSync(destFile, JSON.stringify(json2poMessages, null, 4))
   console.log()
 }
 
 extractMessages(
-  require('../../src/intl/messages').messages,
+  messages.messages,
   path.join('extra', 'to-zanata'),
   path.join('extra', 'to-zanata', 'messages.json')
 )
 
 extractMessages(
-  require('../../src/intl/time-durations').timeDurations,
+  timeDurations.timeDurations,
   path.join('extra', 'to-zanata'),
   path.join('extra', 'to-zanata', 'time-durations.json')
 )

--- a/scripts/intl/intl-zanata-pull.sh
+++ b/scripts/intl/intl-zanata-pull.sh
@@ -1,10 +1,9 @@
 #! /usr/bin/env bash
 [[ -e package.json ]] || cd ../..
 
-JAVA_HOME=$(alternatives --list | grep 'jre_1.8.0' | head -1 | cut -f 3)
 ZANATA_LOCALES=de,es,fr,it,ja,ko,pt-BR,zh-CN,cs
 
 mvn \
-    org.zanata:zanata-maven-plugin:4.6.2:pull \
+    at.porscheinformatik.zanata:zanata-maven-plugin:4.7.8:pull \
     -Dzanata.pullType="trans" \
     -Dzanata.locales="$ZANATA_LOCALES"

--- a/scripts/intl/intl-zanata-push.sh
+++ b/scripts/intl/intl-zanata-push.sh
@@ -1,10 +1,9 @@
 #! /usr/bin/env bash
 [[ -e package.json ]] || cd ../..
 
-JAVA_HOME=$(alternatives --list | grep 'jre_1.8.0' | head -1 | cut -f 3)
 ZANATA_LOCALES=de,es,fr,it,ja,ko,pt-BR,zh-CN,cs
 
 mvn \
-    org.zanata:zanata-maven-plugin:4.6.2:push \
+    at.porscheinformatik.zanata:zanata-maven-plugin:4.7.8:push \
     -Dzanata.pushType="source" \
     -Dzanata.locales="$ZANATA_LOCALES"

--- a/scripts/intl/report.js
+++ b/scripts/intl/report.js
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import chalk from 'chalk'
 import { table } from 'table'
-import { messages as englishMessages } from '../../src/intl/messages'
+import messages from '../../src/intl/messages.js'
 
 function round (number, precision = 0) {
   const factor = Math.pow(10, precision)
@@ -133,6 +133,7 @@ function reportCoverage (englishMessages, translatedMessagesPerLocale) {
 //
 const TRANSLATED = path.join('src', 'intl', 'translated-messages.json')
 const translatedMessagesPerLocale = JSON.parse(fs.readFileSync(TRANSLATED, 'utf8'))
+const englishMessages = messages.messages
 
 console.log(chalk`English key count: {yellow ${Object.keys(englishMessages).length}}`)
 console.log()

--- a/scripts/intl/sync-messages.js
+++ b/scripts/intl/sync-messages.js
@@ -1,12 +1,11 @@
-// @flow
-
 import fs from 'fs'
 import path from 'path'
 
 import chalk from 'chalk'
 import stableStringify from 'json-stable-stringify-without-jsonify'
 
-import { messages as englishMessages } from '../../src/intl/messages'
+import messages from '../../src/intl/messages.js'
+const englishMessages = messages.messages
 
 const TRANSLATED_MESSAGES = path.join('src', 'intl', 'translated-messages.json')
 
@@ -27,7 +26,7 @@ function main () {
  *
  * @param translations object
  */
-function removeNotExistedMessages (translations: any) {
+function removeNotExistedMessages (translations) {
   Object.keys(translations).forEach(langKey => {
     const languageMessages = translations[langKey]
     console.log(chalk.green(`[sync-messages.js] Checking language '${langKey}'`))

--- a/yarn.lock
+++ b/yarn.lock
@@ -9476,17 +9476,17 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
+mkdirp@1.0.4, mkdirp@^1.0.3, mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
 "mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
-
-mkdirp@^1.0.3, mkdirp@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 modify-values@^1.0.0:
   version "1.0.1"

--- a/zanata.xml
+++ b/zanata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <config xmlns="http://zanata.org/namespace/config/">
-    <url>https://zanata.phx.ovirt.org/</url>
+    <url>https://zanata.ovirt.org/</url>
     <project>ovirt-web-ui</project>
     <project-version>1.7</project-version>
     <project-type>gettext</project-type>


### PR DESCRIPTION
Updates made:

  - Change https://zanata.phx.ovirt.org to https://zanata.ovirt.org

  - Use a newer version of the zanata maven plugin to manage pull and
    push transactions.  The older version references a version of JAXB
    that no longer works on the current 1.8 JDK.

  - Drop the use of Java 1.8 to run the zanata maven plugin, Java 11
    works with the updated plugin.

  - With recent updates a few scripts did not want to run.  They've
been modified to run as called.  Most of the changes are with how
the base and translated messages are imported.  The use of `require()`
to access things needed to be changed to `import`.