### PR TITLE
github actions: use ovirt standard rpm upload action

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,6 +1,6 @@
 #
 # CI for this project needs to do two things:
-#   1. Setup the environment for and run `yarn build`
+#   1. Setup the environment and run `yarn build`
 #   2. Build the distribution rpm for use in QE/OST/Integration testing
 #
 name: run CI on PRs
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test_el8_offline:
-    name: EL8 - Check the PR (offline build)
+    name: EL8 - Test, build and publish rpm repo for the PR (ovirt-engine-nodejs-modules build)
     env:
       OFFLINE_BUILD: 1
 
@@ -34,14 +34,12 @@ jobs:
         run: ./automation/build.sh
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: ovirt/upload-rpms-action@v2
         with:
-          name: artifacts
-          path: exported-artifacts/
-
+          directory: exported-artifacts/
 
   test_el8_online:
-    name: EL8 - Check the PR (online build)
+    name: EL8 - Test and build the PR (online build)
     env:
       OFFLINE_BUILD: 0
       MOVE_ARTIFACTS: 0
@@ -78,15 +76,3 @@ jobs:
           rpmbuild \
             --define="_topdir `pwd`/tmp.repos" \
             --rebuild ${{ env.SRPM_PATH }}/ovirt-web-ui*.src.rpm
-
-      - name: Collect artifacts
-        run: |
-          [[ -d exported-artifacts ]] || mkdir -p exported-artifacts
-          find tmp.repos -iname \*rpm -exec mv "{}" exported-artifacts/ \;
-          mv ./*tar.gz exported-artifacts/
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: artifacts (online build)
-          path: exported-artifacts/


### PR DESCRIPTION
  - Use the ovirt standardized artifact building action to generate the standard rpm repo as needed and used by other tooling.
See: https://github.com/oVirt/upload-rpms-action
