### PR TITLE
Remove deprecated std-ci/jenkins automations

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -1,5 +1,0 @@
----
-distros:
-  - el8
-release_branches:
-  master: [ovirt-master, ovirt-4.4]

--- a/automation/README.md
+++ b/automation/README.md
@@ -1,7 +1,0 @@
-Continuous Integration Scripts
-==============================
-
-This directory contains scripts for Continuous Integration provided by
-[oVirt Jenkins](http://jenkins.ovirt.org/) system and follows the standard documented at the
-[Build and test standards](https://ovirt-infra-docs.readthedocs.io/en/latest/CI/Build_and_test_standards)
-page.

--- a/automation/build-artifacts.packages
+++ b/automation/build-artifacts.packages
@@ -1,1 +1,0 @@
-build.packages

--- a/automation/build-artifacts.repos
+++ b/automation/build-artifacts.repos
@@ -1,1 +1,0 @@
-build.repos

--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -1,1 +1,0 @@
-build.sh

--- a/automation/build.packages
+++ b/automation/build.packages
@@ -1,5 +1,0 @@
-make
-autoconf
-automake
-git
-dnf

--- a/automation/build.repos
+++ b/automation/build.repos
@@ -1,5 +1,0 @@
-# normally ovirt "tested" repo is enough as we want packages pass through OST
-ovirt-tested,https://resources.ovirt.org/repos/ovirt/tested/master/rpm/$distro/
-
-# but we keep requiring latest jenkins build of ovirt-node-js-modules since we build in a lock-step
-ovirt-engine-nodejs-modules_master,https://jenkins.ovirt.org/job/ovirt-engine-nodejs-modules_standard-on-merge/lastSuccessfulBuild/artifact/build-artifacts.$distro.x86_64

--- a/automation/build.sh
+++ b/automation/build.sh
@@ -6,14 +6,6 @@
 
 # During a full, offline build, install build dependencies
 if [[ $source_build -eq 0 && $use_nodejs_modules -eq 1 ]] ; then
-  # To ensure the most currently available nodejs-modules is installed, clean the ovirt
-  # repo metadata so repo data cached on the build host doesn't cause problems (this is
-  # useful mostly for STD-CI)
-  # Note: When the project drops STD-CI (automation.yaml) support, the `clean metadata`
-  #       commands may be removed.
-  REPOS=$(dnf repolist | grep ovirt | cut -f 1 -d ' ' | paste -s -d,)
-  dnf --disablerepo='*' --enablerepo="${REPOS}" clean metadata
-
   dnf -y install ovirt-engine-nodejs-modules
 fi
 
@@ -42,7 +34,7 @@ if [[ "${version_release}" == "0" ]]; then
 
   # For a source only build, setup PACKAGE_RPM_SUFFIX for configure.ac to directly embed
   # the snapshot suffix in the spec file.  This is necessary when the suffix info cannot
-  # be passed via commandline, specifically during a copr style pure chroot rpmbuild srpm
+  # be passed via command line, specifically during a copr style pure chroot rpmbuild srpm
   # and rpm rebuild.
   if [[ $source_build -eq 1 ]] ; then
     export SNAPSHOT_DATE=$(date --utc +%Y%m%d)

--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -1,1 +1,0 @@
-build.packages

--- a/automation/check-patch.repos
+++ b/automation/check-patch.repos
@@ -1,1 +1,0 @@
-build.repos

--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -1,1 +1,0 @@
-build.sh


### PR DESCRIPTION
  - Remove `automation.yaml` and related `automation/*.packages`, `automation/*.repos` and `automation/*.sh` files.  Without the base yaml file, std-ci won't attempt to run anything.

  - Github actions take over PR CI testing and builds

  - copr provides builds from the master branch (https://copr.fedorainfracloud.org/coprs/ovirt/ovirt-master-snapshot/)

  - `automation/build.sh` is retained with specific accommodations for std-ci/jenkins package caching issues removed