### PR TITLE
Bump version to 1.8.0 for ovirt 4.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,8 +17,8 @@ dnl
 AC_PREREQ(2.60)
 
 define([VERSION_MAJOR], [1])
-define([VERSION_MINOR], [7])
-define([VERSION_FIX], [3])
+define([VERSION_MINOR], [8])
+define([VERSION_FIX], [0])
 define([VERSION_NUMBER], VERSION_MAJOR[.]VERSION_MINOR[.]VERSION_FIX)
 define([VERSION_RELEASE], [0])
 

--- a/ovirt-web-ui.spec.in
+++ b/ovirt-web-ui.spec.in
@@ -18,7 +18,7 @@ BuildRequires: autoconf
 BuildRequires: automake
 %if %{offline_build}
 # nodejs-modules embeds yarn and requires nodejs
-BuildRequires: ovirt-engine-nodejs-modules >= 2.1.3-1
+BuildRequires: ovirt-engine-nodejs-modules >= 2.2.0
 %else
 BuildRequires: nodejs >= 14.15
 BuildRequires: yarn >= 1.22

--- a/zanata.xml
+++ b/zanata.xml
@@ -2,7 +2,7 @@
 <config xmlns="http://zanata.org/namespace/config/">
     <url>https://zanata.ovirt.org/</url>
     <project>ovirt-web-ui</project>
-    <project-version>1.7</project-version>
+    <project-version>1.8</project-version>
     <project-type>gettext</project-type>
 
     <src-dir>extra/to-zanata</src-dir>


### PR DESCRIPTION
To keep translations and other dependencies between ovirt 4.4 (project version 1.7) and ovirt 4.5 separate, bump the project version to 1.8.  

The zanata project version has been updated accordingly:
 - Translations for ovirt 4.4 / project 1.7 are at: https://zanata.ovirt.org/iteration/view/ovirt-web-ui/1.7
 - Translations for ovirt 4.5 / project 1.8 are at: https://zanata.ovirt.org/iteration/view/ovirt-web-ui/1.8