### PR TITLE
Use ms as delay time unit when deleting snapshots

### DIFF
--- a/src/components/VmDetails/cards/SnapshotsCard/sagas.js
+++ b/src/components/VmDetails/cards/SnapshotsCard/sagas.js
@@ -45,7 +45,7 @@ function* deleteVmSnapshot (action) {
   yield put(addSnapshotRemovalPendingTask(snapshotId))
   let snapshotRemoved = false
   yield fetchVmSnapshots({ vmId })
-  for (const delaySec of delayInMsSteps()) {
+  for (const delayMsSec of delayInMsSteps()) {
     const snapshot = yield callExternalAction(Api.snapshot, { payload: { snapshotId, vmId } }, true)
     if (snapshot.error && snapshot.error.status === 404) {
       snapshotRemoved = true
@@ -54,7 +54,7 @@ function* deleteVmSnapshot (action) {
       const snapshotInternal = Transforms.Snapshot.toInternal({ snapshot })
       yield put(updateVmSnapshot({ vmId, snapshot: snapshotInternal }))
     }
-    yield delay(delaySec * 1000)
+    yield delay(delayMsSec)
   }
   if (snapshotRemoved) {
     yield fetchVmSnapshots({ vmId })


### PR DESCRIPTION
Before, the number was interpreted as seconds which effectively
prevented checking if the snapshot was already deleted.

Resolves: #1558