### PR TITLE
Assign snapshot pending tasks to vm/snapshot

### DIFF
--- a/src/actions/pendingTasks.js
+++ b/src/actions/pendingTasks.js
@@ -11,8 +11,6 @@ import {
   REMOVE_SNAPSHOT_RESTORE_PENDING_TASK,
 } from '_/constants'
 
-import { PendingTaskTypes } from '_/reducers/pendingTasks'
-
 export function addDiskRemovalPendingTask (diskId: string): any {
   return {
     type: ADD_DISK_REMOVAL_PENDING_TASK,
@@ -31,48 +29,60 @@ export function removeDiskRemovalPendingTask (diskId: string): any {
   }
 }
 
-export function addSnapshotRemovalPendingTask (snapshotId: string): any {
+export function addSnapshotRemovalPendingTask (vmId: string, snapshotId: string): any {
   return {
     type: ADD_SNAPSHOT_REMOVAL_PENDING_TASK,
     payload: {
-      type: PendingTaskTypes.SNAPSHOT_REMOVAL,
-      started: new Date(),
+      vmId,
       snapshotId,
     },
   }
 }
 
-export function removeSnapshotRemovalPendingTask (snapshotId: string): any {
+export function removeSnapshotRemovalPendingTask (vmId: string, snapshotId: string): any {
   return {
     type: REMOVE_SNAPSHOT_REMOVAL_PENDING_TASK,
-    payload: { snapshotId },
+    payload: {
+      vmId,
+      snapshotId,
+    },
   }
 }
 
-export function addSnapshotRestorePendingTask (): any {
+export function addSnapshotRestorePendingTask (vmId: string, snapshotId: string): any {
   return {
     type: ADD_SNAPSHOT_RESTORE_PENDING_TASK,
     payload: {
-      type: PendingTaskTypes.SNAPSHOT_RESTORE,
-      started: new Date(),
+      vmId,
+      snapshotId,
     },
   }
 }
 
-export function removeSnapshotRestorePendingTask (): any {
-  return { type: REMOVE_SNAPSHOT_RESTORE_PENDING_TASK }
+export function removeSnapshotRestorePendingTask (vmId: string, snapshotId: string): any {
+  return {
+    type: REMOVE_SNAPSHOT_RESTORE_PENDING_TASK,
+    payload: {
+      vmId,
+      snapshotId,
+    },
+  }
 }
 
-export function addSnapshotAddPendingTask (): any {
+export function addSnapshotAddPendingTask (vmId: string): any {
   return {
     type: ADD_SNAPSHOT_ADD_PENDING_TASK,
     payload: {
-      type: PendingTaskTypes.SNAPSHOT_ADD,
-      started: new Date(),
+      vmId,
     },
   }
 }
 
-export function removeSnapshotAddPendingTask (): any {
-  return { type: REMOVE_SNAPSHOT_ADD_PENDING_TASK }
+export function removeSnapshotAddPendingTask (vmId: string): any {
+  return {
+    type: REMOVE_SNAPSHOT_ADD_PENDING_TASK,
+    payload: {
+      vmId,
+    },
+  }
 }

--- a/src/components/VmDetails/cards/SnapshotsCard/index.js
+++ b/src/components/VmDetails/cards/SnapshotsCard/index.js
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
 import { MsgContext } from '_/intl'
-import BaseCard from '../../BaseCard'
+import { PendingTaskTypes } from '_/reducers/pendingTasks'
+
 import style from './style.css'
 
+import BaseCard from '../../BaseCard'
 import NewSnapshotModal from './NewSnapshotModal'
 import SnapshotItem from './SnapshotItem'
-import { PendingTaskTypes } from '_/reducers/pendingTasks'
 
 const DOWN_STATUS = 'down'
 const RUNNING_STATUS = 'up'
@@ -63,11 +64,14 @@ Snapshots.propTypes = {
 }
 
 const ConnectedSnapshots = connect(
-  (state) => ({
-    beingCreated: !!state.pendingTasks.find(t => t.type === PendingTaskTypes.SNAPSHOT_ADD),
-    beingRestored: !!state.pendingTasks.find(task => task.type === PendingTaskTypes.SNAPSHOT_RESTORE),
-    beingDeleted: !!state.pendingTasks.find(task => task.type === PendingTaskTypes.SNAPSHOT_REMOVAL),
-  })
+  ({ pendingTasks }, { vmId }) => {
+    const vmTasks = pendingTasks.filter(task => task?.vmId === vmId)
+    return {
+      beingCreated: !!vmTasks.find(task => task.type === PendingTaskTypes.SNAPSHOT_ADD),
+      beingRestored: !!vmTasks.find(task => task.type === PendingTaskTypes.SNAPSHOT_RESTORE),
+      beingDeleted: !!vmTasks.find(task => task.type === PendingTaskTypes.SNAPSHOT_REMOVAL),
+    }
+  }
 )(Snapshots)
 
 /**

--- a/src/reducers/pendingTasks.js
+++ b/src/reducers/pendingTasks.js
@@ -51,43 +51,75 @@ export default actionReducer(initialState, {
     return pendingTasks.delete(index)
   },
 
-  [ADD_SNAPSHOT_REMOVAL_PENDING_TASK] (pendingTasks, { payload }) {
+  [ADD_SNAPSHOT_REMOVAL_PENDING_TASK] (pendingTasks, { payload: { vmId, snapshotId } }) {
     const existingTask = pendingTasks.find(task =>
-      task.type === PendingTaskTypes.SNAPSHOT_REMOVAL && task.snapshotId === payload)
+      task.type === PendingTaskTypes.SNAPSHOT_REMOVAL &&
+      task.vmId === vmId &&
+      task.snapshotId === snapshotId
+    )
     if (existingTask) {
       return pendingTasks
     }
-    return pendingTasks.push(payload)
+    return pendingTasks.push({
+      type: PendingTaskTypes.SNAPSHOT_REMOVAL,
+      started: new Date(),
+      vmId,
+      snapshotId,
+    })
   },
-  [REMOVE_SNAPSHOT_REMOVAL_PENDING_TASK] (pendingTasks, { payload }) {
-    const index = pendingTasks.findKey(
-      task => task.type === PendingTaskTypes.SNAPSHOT_REMOVAL && task.snapshotId === payload.snapshotId)
+  [REMOVE_SNAPSHOT_REMOVAL_PENDING_TASK] (pendingTasks, { payload: { vmId, snapshotId } }) {
+    const index = pendingTasks.findKey(task =>
+      task.type === PendingTaskTypes.SNAPSHOT_REMOVAL &&
+      task.vmId === vmId &&
+      task.snapshotId === snapshotId
+    )
     return pendingTasks.delete(index)
   },
-  [ADD_SNAPSHOT_RESTORE_PENDING_TASK] (pendingTasks, { payload }) {
+
+  [ADD_SNAPSHOT_RESTORE_PENDING_TASK] (pendingTasks, { payload: { vmId, snapshotId } }) {
     const existingTask = pendingTasks.find(task =>
-      task.type === PendingTaskTypes.SNAPSHOT_RESTORE)
+      task.type === PendingTaskTypes.SNAPSHOT_RESTORE &&
+      task.vmId === vmId &&
+      task.snapshotId === snapshotId
+    )
     if (existingTask) {
       return pendingTasks
     }
-    return pendingTasks.push(payload)
+    return pendingTasks.push({
+      type: PendingTaskTypes.SNAPSHOT_RESTORE,
+      started: new Date(),
+      vmId,
+      snapshotId,
+    })
   },
-  [REMOVE_SNAPSHOT_RESTORE_PENDING_TASK] (pendingTasks, { payload }) {
-    const index = pendingTasks.findKey(
-      task => task.type === PendingTaskTypes.SNAPSHOT_RESTORE)
+  [REMOVE_SNAPSHOT_RESTORE_PENDING_TASK] (pendingTasks, { payload: { vmId, snapshotId } }) {
+    const index = pendingTasks.findKey(task =>
+      task.type === PendingTaskTypes.SNAPSHOT_RESTORE &&
+      task.vmId === vmId &&
+      task.snapshotId === snapshotId
+    )
     return pendingTasks.delete(index)
   },
-  [ADD_SNAPSHOT_ADD_PENDING_TASK] (pendingTasks, { payload }) {
+
+  [ADD_SNAPSHOT_ADD_PENDING_TASK] (pendingTasks, { payload: { vmId } }) {
     const existingTask = pendingTasks.find(task =>
-      task.type === PendingTaskTypes.SNAPSHOT_ADD)
+      task.type === PendingTaskTypes.SNAPSHOT_ADD &&
+      task.vmId === vmId
+    )
     if (existingTask) {
       return pendingTasks
     }
-    return pendingTasks.push(payload)
+    return pendingTasks.push({
+      type: PendingTaskTypes.SNAPSHOT_ADD,
+      started: new Date(),
+      vmId,
+    })
   },
-  [REMOVE_SNAPSHOT_ADD_PENDING_TASK] (pendingTasks, { payload }) {
-    const index = pendingTasks.findKey(
-      task => task.type === PendingTaskTypes.SNAPSHOT_ADD)
+  [REMOVE_SNAPSHOT_ADD_PENDING_TASK] (pendingTasks, { payload: { vmId } }) {
+    const index = pendingTasks.findKey(task =>
+      task.type === PendingTaskTypes.SNAPSHOT_ADD &&
+      task.vmId === vmId
+    )
     return pendingTasks.delete(index)
   },
 })


### PR DESCRIPTION
Previously the `pendingTasks` for snapshot add, restore, and remove were stored globally.  This blocked ALL snapshot actions for ALL VMs when one task was running.

Snapshot action `pendingTasks` are now tagged to the vm/snapshot the action is working on.  This will allow snapshot actions to run independently between VMs.

Fixes: #1559