### PR TITLE
Allow selection of ISO images from storage domains tagged `canUserUseIsoImages`

### DIFF
--- a/src/components/utils/build-select-box-lists.js
+++ b/src/components/utils/build-select-box-lists.js
@@ -46,7 +46,7 @@ function createIsoList (storageDomains, dataCenterId = null) {
     .toList()
     .filter(storageDomain =>
       storageDomain.has('files') &&
-      storageDomain.get('canUserUseDomain') &&
+      storageDomain.get('canUserUseIsoImages') &&
       (dataCenterId === null
         ? true
         : storageDomain.getIn(['statusPerDataCenter', dataCenterId]) === 'active')

--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -790,6 +790,7 @@ const StorageDomain = {
       permissions,
       userPermits: new Set(),
       canUserUseDomain: false,
+      canUserUseIsoImages: false,
     }
   },
 

--- a/src/sagas/storageDomains.js
+++ b/src/sagas/storageDomains.js
@@ -2,7 +2,7 @@ import Api, { Transforms } from '_/ovirtapi'
 import { all, call, put, select } from 'redux-saga/effects'
 
 import { callExternalAction, entityPermissionsToUserPermits } from './utils'
-import { canUserUseStorageDomain } from '_/utils'
+import { canUserUseStorageDomain, canUserUseIsoImages } from '_/utils'
 
 import {
   setDataCenters,
@@ -72,6 +72,7 @@ function* fetchDataAndIsoStorageDomains () {
     for (const storageDomain of storageDomainsInternal) {
       storageDomain.userPermits = yield entityPermissionsToUserPermits(storageDomain)
       storageDomain.canUserUseDomain = canUserUseStorageDomain(storageDomain.userPermits)
+      storageDomain.canUserUseIsoImages = canUserUseIsoImages(storageDomain.userPermits)
     }
 
     return storageDomainsInternal

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -42,6 +42,10 @@ export function canUserUseStorageDomain (permits: Array<string>): boolean {
   return checkUserPermit(['create_disk', 'attach_disk_profile'], permits)
 }
 
+export function canUserUseIsoImages (permits: Array<string>): boolean {
+  return checkUserPermit(['attach_disk_profile'], permits)
+}
+
 export function canUserEditVmStorage (permits: Array<string>): boolean {
   return checkUserPermit('configure_vm_storage', permits)
 }


### PR DESCRIPTION
Fixes: #1572

### Summary

A user that has the proper permits (`edit_vm_properties`) to edit a VM's
CD should be allowed to choose any ISO from any Storage Domain in which
they have an `attach_disk_profile` permit.

Add a flag to Storage Domains called `canUserUseIsoImages` to indicate
the current user can see and select and ISO held in that storage domain.
A user is not required to have `canUserUseDomain` on a SD to be able to
use the ISOs in the SD.

### Setup
1. As per issue #1572, create a new Role with the following permits:
  - 1563 / attach_disk_profile / Disk - Disk Profile >> Attach Disk Profile
  - 1106 / access_image_storage / Disk - Provisioning Operations >> Access Image Storage Domains
  - 1101 / attach_disk / Disk - Provisioning Operations >> Attach
  
2. For a Storage Domain with ISO images, assign a Permission to a User (or a Group) with the new role.

3. Permission the User (or Group) to be able to edit a VM

4. Open the VM Details page and edit the Details card.

5. All of the ISO images in the storage domain permissioned in step 2 should be visible.

Note: Depending on the user's permissions on the VM, they may only be able to change the CD while the VM is running.  In this case, the CD will revert to the base VM setting after a reboot.