### PR TITLE
Use finer RPM versions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -73,7 +73,7 @@ srpm:	dist-gzip
 	@echo "srpm available at '$(TMPREPOS)'"
 	@echo
 
-snapshot-srpm: SNAPSHOT_DATE = $(shell date --utc +%Y%m%d)
+snapshot-srpm: SNAPSHOT_DATE = $(shell date --utc +%Y%m%d%H%M%S)
 snapshot-srpm: SNAPSHOT_COMMIT ?= $(shell git log -1 --pretty=format:%h)
 snapshot-srpm:
 	make srpm RELEASE_SUFFIX=".$(SNAPSHOT_DATE).git$(SNAPSHOT_COMMIT)"
@@ -84,7 +84,7 @@ rpm:	srpm
 	@echo "rpm(s) available at '$(TMPREPOS)'"
 	@echo
 
-snapshot-rpm: SNAPSHOT_DATE = $(shell date --utc +%Y%m%d)
+snapshot-rpm: SNAPSHOT_DATE = $(shell date --utc +%Y%m%d%H%M%S)
 snapshot-rpm: SNAPSHOT_COMMIT ?= $(shell git log -1 --pretty=format:%h)
 snapshot-rpm:
 	make rpm RELEASE_SUFFIX=".$(SNAPSHOT_DATE).git$(SNAPSHOT_COMMIT)"

--- a/automation/build.sh
+++ b/automation/build.sh
@@ -37,7 +37,7 @@ if [[ "${version_release}" == "0" ]]; then
   # be passed via command line, specifically during a copr style pure chroot rpmbuild srpm
   # and rpm rebuild.
   if [[ $source_build -eq 1 ]] ; then
-    export SNAPSHOT_DATE=$(date --utc +%Y%m%d)
+    export SNAPSHOT_DATE=$(date --utc +%Y%m%d%H%M%S)
     export PACKAGE_RPM_SUFFIX=".$SNAPSHOT_DATE.git$SNAPSHOT_COMMIT"
   fi
 


### PR DESCRIPTION
Using only the date part in RPM names is not fine enough - when a couple
of builds land in COPR with the same date, the one with the "biggest SHA"
wins, i.e.:

  1.8.2-0.20220607.gitf519b50.fc35 > 1.8.2-0.20220607.git26ac92c.fc35 > 1.8.2-0.20220607.git703b8f7.fc35

even though it might not actually be the latest build.
