### PR TITLE
regressions: logo click to welcome page, account settings button unique id

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -13,7 +13,7 @@ const Header = ({ children }) => {
   return (
     <Masthead className='obrand_masthead' display={{ default: 'inline' }}>
       <MastheadMain>
-        <MastheadBrand className='obrand_headerLogoLink' id='pageheader-logo'>
+        <MastheadBrand className='obrand_headerLogoLink' id='pageheader-logo' href="/">
           <Brand className='obrand_mastheadLogo' src={resourcesUrls.clearGif}/>
         </MastheadBrand>
       </MastheadMain>

--- a/src/components/VmsPageHeader/index.js
+++ b/src/components/VmsPageHeader/index.js
@@ -72,7 +72,7 @@ const VmsPageHeader = ({ appReady, onRefresh, onCloseNotificationDrawer, isDrawe
             {appReady && (
               <ToolbarItem>
                 <Tooltip id={`${idPrefix}-tooltip`} tooltip={msg.accountSettings()} placement='bottom'>
-                  <Button aria-label={msg.accountSettings()} variant={ButtonVariant.plain} onClick={goToSettings} id={`${idPrefix}-refresh`}>
+                  <Button aria-label={msg.accountSettings()} variant={ButtonVariant.plain} onClick={goToSettings} id={`${idPrefix}-settings`}>
                     <CogIcon />
                   </Button>
                 </Tooltip>


### PR DESCRIPTION
Fixes a regression after migration to PF4.

Additional change: provide unique id for Account Settings button.

Resolves: #1608