### PR TITLE
regressions: cannot enter values into NumberInput

### DIFF
--- a/src/components/CreateVmWizard/steps/BasicSettings.js
+++ b/src/components/CreateVmWizard/steps/BasicSettings.js
@@ -595,7 +595,7 @@ class BasicSettings extends React.Component {
               id={`${idPrefix}-memory-edit`}
               className={style['memory-input']}
               value={data.memory}
-              onChange={value => this.handleChange('memory', value)}
+              onChange={event => this.handleChange('memory', Number(event?.target?.value)) }
               min={0}
               onMinus={() => this.handleChange('memory', data.memory - 1) }
               onPlus={() => this.handleChange('memory', data.memory + 1) }
@@ -614,7 +614,7 @@ class BasicSettings extends React.Component {
               id={`${idPrefix}-cpus-edit`}
               className={style['cpus-input']}
               value={data.cpus}
-              onChange={value => this.handleChange('cpus', value)}
+              onChange={event => this.handleChange('cpus', Number(event?.target?.value))}
               min={0}
               onMinus={() => this.handleChange('cpus', data.cpus - 1)}
               onPlus={() => this.handleChange('cpus', data.cpus + 1)}

--- a/src/components/VmDetails/cards/DetailsCard/index.js
+++ b/src/components/VmDetails/cards/DetailsCard/index.js
@@ -925,7 +925,7 @@ class DetailsCard extends React.Component {
                                 max={MAX_VM_VCPU_EDIT}
                                 value={vCpuCount}
                                 widthChars={5}
-                                onChange={e => this.handleChange('cpu', e.target.value)}
+                                onChange={e => this.handleChange('cpu', Number(e?.target?.value))}
                                 onPlus={() => this.handleChange('cpu', vCpuCount + 1)}
                                 onMinus={() => this.handleChange('cpu', vCpuCount - 1)}
                               />
@@ -948,7 +948,7 @@ class DetailsCard extends React.Component {
                             <NumberInput
                               id={`${idPrefix}-memory-edit`}
                               value={(memorySize / (1024 ** 2))}
-                              onChange={e => this.handleChange('memory', e.target.value)}
+                              onChange={e => this.handleChange('memory', Number(e?.target?.value))}
                               unit='MiB'
                               widthChars={5}
                               onPlus={() => this.handleChange('memory', (memorySize / (1024 ** 2)) + 1)}

--- a/src/components/VmDetails/cards/DisksCard/DiskImageEditor.js
+++ b/src/components/VmDetails/cards/DisksCard/DiskImageEditor.js
@@ -381,7 +381,7 @@ class DiskImageEditor extends Component {
                 <NumberInput
                   id={`${idPrefix}-size-edit`}
                   value={this.state.values.size}
-                  onChange={({ target: { value } }) => this.changeSize(value)}
+                  onChange={event => this.changeSize(Number(event?.target?.value))}
                   onMinus={() => this.changeSize(this.state.values.size - 1)}
                   onPlus={() => this.changeSize(this.state.values.size + 1)}
                   min={0}


### PR DESCRIPTION
The value passed to `onChange` callback is not the number but an event that encapsulates the value.