### PR TITLE
regressions: missing card IDs on the VM List screen

### DIFF
--- a/src/components/VmsList/BaseCard.js
+++ b/src/components/VmsList/BaseCard.js
@@ -127,7 +127,7 @@ const BaseCard = ({ children, idPrefix, topLineColor = 'transparent' }) => {
   })
   return (
     <IdPrefixContext.Provider value={idPrefix}>
-      <Card style={topBorderStyling}>
+      <Card style={topBorderStyling} id={`${idPrefix}-box`}>
         {childs[BaseCardHeader.displayName]}
         <CardBody>
           <div className={style['card-icon']}>


### PR DESCRIPTION
Provide IDs for cards on the VM List screen.

Note that in the PF3 version the IDs were part of the layout not the card itself:
```
<Col xs={12} sm={6} md={4} lg={3} id={`${idPrefix}-box`} className={style['card-box']}>
        <Card className='card-pf-view card-pf-view-select card-pf-view-single-select'>
```