### PR TITLE
build: add conditional build for offline/online builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,6 +64,7 @@ TMPREPOS = tmp.repos
 RPMBUILD_ARGS :=
 RPMBUILD_ARGS += --define="_topdir `pwd`/$(TMPREPOS)"
 RPMBUILD_ARGS += $(if $(RELEASE_SUFFIX), --define="release_suffix $$RELEASE_SUFFIX")
+RPMBUILD_ARGS += $(if $(filter 0,$(OFFLINE_BUILD)), --without ovirt_use_nodejs_modules)
 
 srpm:	dist-gzip
 	rm -fr "$(TMPREPOS)"

--- a/configure.ac
+++ b/configure.ac
@@ -38,9 +38,6 @@ dnl TODO: Fail if rpmbuild is not present
 PACKAGE_RPM_SUFFIX=${PACKAGE_RPM_SUFFIX:-"%{?release_suffix}"}
 AC_ARG_VAR([PACKAGE_RPM_SUFFIX], [suffix to use on the rpm's release string])
 
-OFFLINE_BUILD=${OFFLINE_BUILD:-1}
-AC_ARG_VAR([OFFLINE_BUILD], [control if rpm builds will use an offline build via ovirt-engine-nodejs-modules (1) or should use an online build (0)])
-
 AC_CONFIG_FILES([
 	Makefile
 	ovirt-web-ui.spec

--- a/ovirt-web-ui.spec.in
+++ b/ovirt-web-ui.spec.in
@@ -2,7 +2,12 @@
 %global product oVirt
 %global source_basename @PACKAGE_TARNAME@
 %define debug_package %{nil}
-%define offline_build @OFFLINE_BUILD@
+
+# build condition `ovirt_use_nodejs_modules`
+#   - on by default, requires a build with `--without ovirt_use_nodejs_modules` to turn off
+#   - if on, the build uses `ovirt-engine-nodejs-modules`
+#   - if off, the build uses standard `yarn` accessing all node_modules packages directly
+%bcond_without ovirt_use_nodejs_modules
 
 Name:           ovirt-web-ui
 Version:        @PACKAGE_RPM_VERSION@
@@ -23,7 +28,7 @@ BuildRequires: rpm-build
 # requirements for building the rpm from src.rpm
 BuildRequires: autoconf
 BuildRequires: automake
-%if %{offline_build}
+%if %{with ovirt_use_nodejs_modules}
 # nodejs-modules embeds yarn and requires nodejs
 BuildRequires: ovirt-engine-nodejs-modules >= 2.3.2
 %else
@@ -40,7 +45,7 @@ This package provides the VM Portal for %{product}.
 %build
 %configure
 export SKIP_AUTOGEN=1
-%if %{offline_build}
+%if %{with ovirt_use_nodejs_modules}
 rpm -qa | grep ovirt-engine-nodejs
 source /usr/share/ovirt-engine-nodejs-modules/setup-env.sh
 %else


### PR DESCRIPTION
Instead of autoconf swapping in a 0 or 1 for a `%define` variable
in the `spec.in` file for `OFFLINE_BUILD`, add a conditional build.
See [1] for how they work.

With a conditional build, source rpms retain the ability to build with
different options depending on how `rpmbuild` is called.  This allows
an offline (using virt-engine-nodejs-modules) or online (using
`yarn install`) build from srpm to be selected at build time using
`--with` or `--without` build options.

Since at least copr builds chroots directly from a srpm, conditional
builds can be used to change build options.  With this change, an
"online build" can be enabled simply by configuring the target chroot
setting "without" to include "ovirt_use_nodejs_modules".

Notes:
  - An offline build with `ovirt-engine-nodejs-modules` is the default

  - An online build using standard `yarn install` can be achieved by
    using `--without ovirt_use_nodejs_modules` on the call to rpmbuild

  - Setting env var `OFFLINE_BUILD=0` when calling `make rpm` will
    add the `--without` option, and run an offline build.  This is
    the same behavior as previous.

[1] - https://rpm-software-management.github.io/rpm/manual/conditionalbuilds.html

**Note**: PR https://github.com/oVirt/ovirt-engine-ui-extensions/pull/58 adds the same functionality to ovirt-engine-ui-extensions with the same option name.  With both in place, online and offline builds can be configured for both packages with the same single option on a copr chroot config.