### PR TITLE
Force tooltips on the DonutChart to a constant width

### DIFF
--- a/src/components/VmDetails/cards/UtilizationCard/UtilizationCharts/DonutChart.js
+++ b/src/components/VmDetails/cards/UtilizationCard/UtilizationCharts/DonutChart.js
@@ -1,6 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { ChartDonut, ChartLabel } from '@patternfly/react-charts'
+import {
+  ChartDonut,
+  ChartLabel,
+  ChartTooltip,
+} from '@patternfly/react-charts'
 
 import style from '../style.css'
 
@@ -20,6 +24,7 @@ const DonutChart = ({ data, title, subTitle, id }) => {
         title={title}
         style={{ labels: { fontSize: 12 } }}
         titleComponent={<ChartLabel style={[{ fontSize: 30 }, { fontSize: 20, fill: '#bbb' }]} />}
+        labelComponent={<ChartTooltip flyoutWidth={180} />}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
By default the `@patternfly/react-charts` chart tooltips use the same text width estimation as is used in the Victory charts [1]. This estimation works ok for ASCII characters, but underestimate sizes for other non-Latin character code pages.

Instead of creating another text size estimation function that can handle non-Latin characters (e.g. see [2]), just pick a constant width that should accommodate the expected text widths of most languages we support.

[1] - https://github.com/FormidableLabs/victory/blob/main/packages/victory-core/src/victory-util/textsize.ts
[2] - https://stackoverflow.com/questions/118241/calculate-text-width-with-javascript

## Examples
How it looks now in English:
![screenshot-localhost_3000-2022 07 21-13_34_40](https://user-images.githubusercontent.com/3985964/180277977-08f08150-5e2a-4829-98db-99b621e5d406.png)


Previously in Japanese:
![screenshot-localhost_3000-2022 07 21-13_32_02](https://user-images.githubusercontent.com/3985964/180277892-d6e31e35-0f21-4269-aecf-0798d3966e70.png)

Now in Japanese:
![screenshot-localhost_3000-2022 07 21-13_33_36](https://user-images.githubusercontent.com/3985964/180277925-ab752c4d-4475-49f8-9d46-5decebb271ed.png)

