### PR TITLE
containers: Specify COPR chroot explicitly

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -30,7 +30,7 @@ for your platform to use the same packages that will be used by CI to build the 
 
 For CentOS stream 9:
 
-    dnf copr enable -y ovirt/ovirt-master-snapshot
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9
     dnf install -y ovirt-engine-nodejs-modules
 
 **Note**: The project will not currently build on CentOS stream 9.  See


### PR DESCRIPTION
A recent change to DNF COPR plugin [1] makes 'epel-9' the default chroot
used for CentOS Stream 9. Let's specify the 'centos-stream-9' chroot
name that we use in oVirt's COPR explictly.

[1] https://github.com/rpm-software-management/dnf-plugins-core/pull/459

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
