### PR TITLE
Set constant widths on react-chart tooltips

### DIFF
--- a/src/components/VmDetails/cards/UtilizationCard/UtilizationCharts/AreaChart.js
+++ b/src/components/VmDetails/cards/UtilizationCard/UtilizationCharts/AreaChart.js
@@ -19,7 +19,8 @@ const AreaChart = ({ data, labels, id }) => {
         containerComponent={(
           <ChartVoronoiContainer
             labels={labels}
-            labelComponent={<ChartTooltip style={{ fontSize: 16 }} />}
+            // See https://github.com/patternfly/patternfly-react/issues/7923
+            labelComponent={<ChartTooltip style={{ fontSize: 16 }} flyoutWidth={55} />}
           />
         )}
       >

--- a/src/components/VmDetails/cards/UtilizationCard/UtilizationCharts/BarChart.js
+++ b/src/components/VmDetails/cards/UtilizationCard/UtilizationCharts/BarChart.js
@@ -9,7 +9,16 @@ const CustomLabel = ({ label, offsetX, text, ...rest }) => {
   return (
     <g>
       <ChartLabel {...rest} x={offsetX} dy={40} style={{ fontSize: 20 }} text={t} />
-      <ChartTooltip {...rest} text={text} style={{ fontSize: 18 }} orientation='top' dx={-5} dy={-20}/>
+      <ChartTooltip
+        {...rest}
+        text={text}
+        style={{ fontSize: 18 }}
+        orientation='top'
+        dx={-5}
+        dy={-20}
+        // See https://github.com/patternfly/patternfly-react/issues/7923
+        flyoutWidth={350}
+      />
     </g>
   )
 }
@@ -44,7 +53,16 @@ const BarChart = ({ data, additionalLabel, thresholdWarning, thresholdError, id,
             labels={({ datum }) => msg.utilizationCardLegendUsedWithDetails({ value: datum.y, diskPath: datum.x }) }
           />
           <ChartBar barWidth={40} domain={{ y: [0, 100] }}
-            labelComponent={<ChartTooltip style={{ fontSize: 18 }} orientation='top' dx={-5} dy={-20} />}
+            labelComponent={(
+              <ChartTooltip
+                style={{ fontSize: 18 }}
+                orientation='top'
+                dx={-5}
+                dy={-20}
+                // See https://github.com/patternfly/patternfly-react/issues/7923
+                flyoutWidth={350}
+              />
+            )}
             style={{ parent: { border: '0px' } }}
             data={availableInPercent}
             labels={({ datum }) => msg.utilizationCardLegendAvailableWithDetails({ value: datum.y, diskPath: datum.x }) }

--- a/src/components/VmDetails/cards/UtilizationCard/UtilizationCharts/DonutChart.js
+++ b/src/components/VmDetails/cards/UtilizationCard/UtilizationCharts/DonutChart.js
@@ -24,6 +24,7 @@ const DonutChart = ({ data, title, subTitle, id }) => {
         title={title}
         style={{ labels: { fontSize: 12 } }}
         titleComponent={<ChartLabel style={[{ fontSize: 30 }, { fontSize: 20, fill: '#bbb' }]} />}
+        // See https://github.com/patternfly/patternfly-react/issues/7923
         labelComponent={<ChartTooltip flyoutWidth={180} />}
       />
     </div>


### PR DESCRIPTION
Followup PR [1] and add constant widths for all react-chart based tooltips.  This is to work around patternfly-react issue [2] where tooltips with non-Latin characters are rendered too narrow.

Bug-Url: https://issues.redhat.com/browse/RHV-45439
[1] - https://github.com/oVirt/ovirt-web-ui/pull/1618
[2] - https://github.com/patternfly/patternfly-react/issues/7923
