### PR TITLE
Optimize the entity permission to permit mappings

### DIFF
--- a/src/sagas/base-data.js
+++ b/src/sagas/base-data.js
@@ -87,7 +87,7 @@ export function* fetchAllTemplates () {
     // Calculate permits and 'canUser*'
     const _entityPermissionsToUserPermits = yield curryEntityPermissionsToUserPermits()
     for (const template of templatesInternal) {
-      template.userPermits = _entityPermissionsToUserPermits(template, true)
+      template.userPermits = _entityPermissionsToUserPermits(template)
       template.canUserUseTemplate = canUserUseTemplate(template.userPermits)
     }
 

--- a/src/sagas/base-data.js
+++ b/src/sagas/base-data.js
@@ -35,8 +35,9 @@ export function* fetchAllClusters () {
     )
 
     // Calculate permits and 'canUser*'
+    const _entityPermissionsToUserPermits = yield entityPermissionsToUserPermits.cached()
     for (const cluster of clustersInternal) {
-      cluster.userPermits = yield entityPermissionsToUserPermits(cluster)
+      cluster.userPermits = _entityPermissionsToUserPermits(cluster)
       cluster.canUserUseCluster = canUserUseCluster(cluster.userPermits)
     }
 
@@ -84,8 +85,9 @@ export function* fetchAllTemplates () {
     )
 
     // Calculate permits and 'canUser*'
+    const _entityPermissionsToUserPermits = yield entityPermissionsToUserPermits.cached()
     for (const template of templatesInternal) {
-      template.userPermits = yield entityPermissionsToUserPermits(template)
+      template.userPermits = _entityPermissionsToUserPermits(template, true)
       template.canUserUseTemplate = canUserUseTemplate(template.userPermits)
     }
 
@@ -114,8 +116,9 @@ export function* fetchAllVnicProfiles () {
     )
 
     // Calculate permits and 'canUser*'
+    const _entityPermissionsToUserPermits = yield entityPermissionsToUserPermits.cached()
     for (const vnicProfile of vnicProfilesInternal) {
-      vnicProfile.userPermits = yield entityPermissionsToUserPermits(vnicProfile)
+      vnicProfile.userPermits = _entityPermissionsToUserPermits(vnicProfile)
       vnicProfile.canUserUseProfile = canUserUseVnicProfile(vnicProfile.userPermits)
     }
 

--- a/src/sagas/base-data.js
+++ b/src/sagas/base-data.js
@@ -8,7 +8,7 @@ import {
 
 import {
   callExternalAction,
-  entityPermissionsToUserPermits,
+  curryEntityPermissionsToUserPermits,
   mapCpuOptions,
   mapConfigKeyVersion,
 } from './utils'
@@ -35,7 +35,7 @@ export function* fetchAllClusters () {
     )
 
     // Calculate permits and 'canUser*'
-    const _entityPermissionsToUserPermits = yield entityPermissionsToUserPermits.cached()
+    const _entityPermissionsToUserPermits = yield curryEntityPermissionsToUserPermits()
     for (const cluster of clustersInternal) {
       cluster.userPermits = _entityPermissionsToUserPermits(cluster)
       cluster.canUserUseCluster = canUserUseCluster(cluster.userPermits)
@@ -85,7 +85,7 @@ export function* fetchAllTemplates () {
     )
 
     // Calculate permits and 'canUser*'
-    const _entityPermissionsToUserPermits = yield entityPermissionsToUserPermits.cached()
+    const _entityPermissionsToUserPermits = yield curryEntityPermissionsToUserPermits()
     for (const template of templatesInternal) {
       template.userPermits = _entityPermissionsToUserPermits(template, true)
       template.canUserUseTemplate = canUserUseTemplate(template.userPermits)
@@ -116,7 +116,7 @@ export function* fetchAllVnicProfiles () {
     )
 
     // Calculate permits and 'canUser*'
-    const _entityPermissionsToUserPermits = yield entityPermissionsToUserPermits.cached()
+    const _entityPermissionsToUserPermits = yield curryEntityPermissionsToUserPermits()
     for (const vnicProfile of vnicProfilesInternal) {
       vnicProfile.userPermits = _entityPermissionsToUserPermits(vnicProfile)
       vnicProfile.canUserUseProfile = canUserUseVnicProfile(vnicProfile.userPermits)

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -35,9 +35,9 @@ import {
 
 import {
   callExternalAction,
+  curryEntityPermissionsToUserPermits,
   delay,
   doCheckTokenExpired,
-  entityPermissionsToUserPermits,
   mapCpuOptions,
 } from './utils'
 
@@ -88,8 +88,10 @@ const VM_FETCH_ADDITIONAL_SHALLOW = [
 export const EVERYONE_GROUP_ID = 'eee00000-0000-0000-0000-123456789eee'
 
 export function* transformAndPermitVm (vm) {
+  const _entityPermissionsToUserPermits = yield curryEntityPermissionsToUserPermits()
+
   const internalVm = Transforms.VM.toInternal({ vm })
-  internalVm.userPermits = yield entityPermissionsToUserPermits(internalVm)
+  internalVm.userPermits = _entityPermissionsToUserPermits(internalVm)
 
   internalVm.canUserChangeCd = canUserChangeCd(internalVm.userPermits)
   internalVm.canUserEditVm = canUserEditVm(internalVm.userPermits)
@@ -107,7 +109,7 @@ export function* transformAndPermitVm (vm) {
 
   // Permit disks fetched and transformed along with the VM
   for (const disk of internalVm.disks) {
-    disk.userPermits = yield entityPermissionsToUserPermits(disk)
+    disk.userPermits = _entityPermissionsToUserPermits(disk)
     disk.canUserEditDisk = canUserEditDisk(disk.userPermits)
   }
 

--- a/src/sagas/storageDomains.js
+++ b/src/sagas/storageDomains.js
@@ -50,8 +50,9 @@ function* fetchDataCenters () {
     )
 
     // Calculate permits and 'canUser*'
+    const _entityPermissionsToUserPermits = yield entityPermissionsToUserPermits.cached()
     for (const dataCenter of dataCentersInternal) {
-      dataCenter.userPermits = yield entityPermissionsToUserPermits(dataCenter)
+      dataCenter.userPermits = _entityPermissionsToUserPermits(dataCenter)
     }
 
     return dataCentersInternal
@@ -69,8 +70,9 @@ function* fetchDataAndIsoStorageDomains () {
       .filter(storageDomain => storageDomain.type === 'data' || storageDomain.type === 'iso')
 
     // Calculate permits and 'canUser*'
+    const _entityPermissionsToUserPermits = yield entityPermissionsToUserPermits.cached()
     for (const storageDomain of storageDomainsInternal) {
-      storageDomain.userPermits = yield entityPermissionsToUserPermits(storageDomain)
+      storageDomain.userPermits = _entityPermissionsToUserPermits(storageDomain)
       storageDomain.canUserUseDomain = canUserUseStorageDomain(storageDomain.userPermits)
       storageDomain.canUserUseIsoImages = canUserUseIsoImages(storageDomain.userPermits)
     }

--- a/src/sagas/storageDomains.js
+++ b/src/sagas/storageDomains.js
@@ -1,7 +1,7 @@
 import Api, { Transforms } from '_/ovirtapi'
 import { all, call, put, select } from 'redux-saga/effects'
 
-import { callExternalAction, entityPermissionsToUserPermits } from './utils'
+import { callExternalAction, curryEntityPermissionsToUserPermits } from './utils'
 import { canUserUseStorageDomain, canUserUseIsoImages } from '_/utils'
 
 import {
@@ -50,7 +50,7 @@ function* fetchDataCenters () {
     )
 
     // Calculate permits and 'canUser*'
-    const _entityPermissionsToUserPermits = yield entityPermissionsToUserPermits.cached()
+    const _entityPermissionsToUserPermits = yield curryEntityPermissionsToUserPermits()
     for (const dataCenter of dataCentersInternal) {
       dataCenter.userPermits = _entityPermissionsToUserPermits(dataCenter)
     }
@@ -70,7 +70,7 @@ function* fetchDataAndIsoStorageDomains () {
       .filter(storageDomain => storageDomain.type === 'data' || storageDomain.type === 'iso')
 
     // Calculate permits and 'canUser*'
-    const _entityPermissionsToUserPermits = yield entityPermissionsToUserPermits.cached()
+    const _entityPermissionsToUserPermits = yield curryEntityPermissionsToUserPermits()
     for (const storageDomain of storageDomainsInternal) {
       storageDomain.userPermits = _entityPermissionsToUserPermits(storageDomain)
       storageDomain.canUserUseDomain = canUserUseStorageDomain(storageDomain.userPermits)

--- a/src/sagas/utils.js
+++ b/src/sagas/utils.js
@@ -171,7 +171,7 @@ export function* selectorUserAndRoles () {
  * to a set of permits for the app's current user.  Function `mapEntityPermits` is called
  * to do the actual mapping.
  *
- * NOTE: For effiency sake, use the cached lookup version `cacheEntityPermissionsToUserPermits`
+ * NOTE: For effiency sake, use the cached lookup version `curryEntityPermissionsToUserPermits`
  * in calling code.  This helps keep the redux-saga effect queue small and memory use efficient.
  */
 export function* entityPermissionsToUserPermits (entity) {
@@ -189,7 +189,7 @@ export function* entityPermissionsToUserPermits (entity) {
  */
 export function* curryEntityPermissionsToUserPermits () {
   const userAndRoles = yield selectorUserAndRoles()
-  return (entity, ...rest) => mapEntityPermits(entity, userAndRoles, ...rest)
+  return (entity) => mapEntityPermits(entity, userAndRoles)
 }
 
 /**


### PR DESCRIPTION
Fixes: #1647 

In some cases, when a large number of entities are processed for permission to permit mapping, the code would just hang without indication of what went wrong.  At least 2 `yield` would be needed to process each entity.  Over the course of 1000+ entities, the 2000 `yield` calls seem to cause problems.

The mapping code has been optimized to allow using a lookup cached version.  Now only a single `yield` is required.  The change allows 1000+ entities to be processed successfully.

Signed-off-by: Scott J Dickerson <sdickers@redhat.com>