### PR TITLE
github actions: update action versions to current

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -24,13 +24,13 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: ovirt/checkout-action@main
 
       - name: Run automation/build.sh (installs build dependencies as necessary)
         run: ./automation/build.sh
 
       - name: Upload artifacts
-        uses: ovirt/upload-rpms-action@v2
+        uses: ovirt/upload-rpms-action@main
         with:
           directory: exported-artifacts/
 
@@ -48,7 +48,7 @@ jobs:
           dnf -y --disablerepo='*' --enablerepo='yarn*' install yarn
 
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: ovirt/checkout-action@main
 
       - name: Run 'yarn install' and 'yarn build' (like a developer would)
         run: |
@@ -72,12 +72,12 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: ovirt/checkout-action@main
 
       - name: Run automation/build.sh (installs build dependencies as necessary)
         run: ./automation/build.sh
 
       - name: Upload artifacts as rpm repo
-        uses: ovirt/upload-rpms-action@v2
+        uses: ovirt/upload-rpms-action@main
         with:
           directory: exported-artifacts/


### PR DESCRIPTION
Upgrade to currently supported versions of actions used in `check.yaml`.

Ref: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Signed-off-by: Scott J Dickerson <sdickers@redhat.com>