### PR TITLE
Fix getFormatedDateTime() to use current month instead of previous

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -296,7 +296,7 @@ export function getFormatedDateTime (timestamp) {
   const t = new Date(timestamp)
   return {
     time: `${formatTwoDigits(t.getHours())}:${formatTwoDigits(t.getMinutes())}:${formatTwoDigits(t.getSeconds())}`,
-    date: `${t.getDate()}/${t.getMonth()}/${t.getFullYear()}`,
+    date: `${t.getDate()}/${t.getMonth() + 1}/${t.getFullYear()}`,
   }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/oVirt/ovirt-web-ui/issues/1644
Since the JavaScript Date.getMonth() method returns the month value starting from 0 (0 to 11 range), need to add one when using.

Check for details: https://www.w3schools.com/jsref/jsref_getmonth.asp

Bug-Url: https://github.com/oVirt/ovirt-web-ui/issues/1644
Signed-off-by: Sharon Gratch <sgratch@redhat.com>