### PR TITLE
ui: add password and username to cloud init options

### DIFF
--- a/src/components/CreateVmWizard/dataPropTypes.js
+++ b/src/components/CreateVmWizard/dataPropTypes.js
@@ -23,8 +23,9 @@ export const BASIC_DATA_SHAPE = {
   cloudInitEnabled: PropTypes.bool,
   initHostname: PropTypes.string,
   initSshKeys: PropTypes.string,
+  initUsername: PropTypes.string,
   initTimezone: PropTypes.string,
-  initAdminPassword: PropTypes.string,
+  initPassword: PropTypes.string,
   initCustomScript: PropTypes.string,
 
   topology: PropTypes.exact({

--- a/src/components/CreateVmWizard/steps/BasicSettings.js
+++ b/src/components/CreateVmWizard/steps/BasicSettings.js
@@ -679,6 +679,22 @@ class BasicSettings extends React.Component {
                   onChange={value => this.handleChange('initSshKeys', value)}
                 />
               </FieldRow>
+              <FieldRow label={msg.password()} vertical>
+                <TextInput
+                  id={`${idPrefix}-cloudInitPassword-edit`}
+                  type='password'
+                  value={data.initPassword}
+                  onChange={value => this.handleChange('initPassword', value)}
+                />
+              </FieldRow>
+              <FieldRow label={msg.username()} vertical>
+                <TextInput
+                  id={`${idPrefix}-cloudInitUsername-edit`}
+                  type='text'
+                  value={data.initUsername}
+                  onChange={value => this.handleChange('initUsername', value)}
+                />
+              </FieldRow>
             </>
           )}
 
@@ -725,8 +741,8 @@ class BasicSettings extends React.Component {
                 <TextInput
                   id={`${idPrefix}-sysPrepAdminPassword-edit`}
                   type='password'
-                  value={data.initAdminPassword}
-                  onChange={value => this.handleChange('initAdminPassword', value)}
+                  value={data.initPassword}
+                  onChange={value => this.handleChange('initPassword', value)}
                 />
               </FieldRow>
 

--- a/src/components/CreateVmWizard/steps/SummaryReview.js
+++ b/src/components/CreateVmWizard/steps/SummaryReview.js
@@ -1,8 +1,8 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Label } from '@patternfly/react-core'
-import { InfoCircleIcon } from '@patternfly/react-icons'
+import { EyeIcon, EyeSlashIcon, InfoCircleIcon } from '@patternfly/react-icons'
 
 import { MsgContext, enumMsg, withMsg } from '_/intl'
 import { templateNameRenderer, userFormatOfBytes } from '_/helpers'
@@ -27,6 +27,30 @@ const Item = ({ id, label, children }) => (
     </div>
   </div>
 )
+
+const RevealablePassword = ({ password }) => {
+  const [revealed, setRevealed] = useState(false)
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center' }}>
+      <span>{revealed ? password : '******'}</span>
+      <button
+        onClick={() => setRevealed(!revealed)}
+        style={{
+          background: 'none',
+          border: 'none',
+        }}
+        title={revealed ? 'Hide password' : 'Show password'}
+      >
+        {revealed ? <EyeSlashIcon /> : <EyeIcon />}
+      </button>
+    </div>
+  )
+}
+
+RevealablePassword.propTypes = {
+  password: PropTypes.string.isRequired,
+}
 
 Item.propTypes = {
   id: PropTypes.string.isRequired,
@@ -210,6 +234,14 @@ const ReviewAdvanced = ({ id, operatingSystems, basic }) => {
             { basic.initSshKeys &&
               <Item id={`${id}-cloud-init-sshkey`} label={msg.sshAuthorizedKeys()}>{ basic.initSshKeys }</Item>
           }
+            { basic.initPassword && (
+              <Item id={`${id}-cloud-init-pwd`} label={msg.password()}>
+                <RevealablePassword password={basic.initPassword} />
+              </Item>
+            )}
+            { basic.initUsername &&
+              <Item id={`${id}-cloud-init-username`} label={msg.username()}>{ basic.initUsername }</Item>
+            }
           </div>
         </>
       )}
@@ -223,9 +255,9 @@ const ReviewAdvanced = ({ id, operatingSystems, basic }) => {
             { basic.initTimezone &&
               <Item id={`${id}-sysprep-tz`} label={msg.sysPrepTimezone()}>{ basic.initTimezone }</Item>
           }
-            { basic.initAdminPassword && (
-              <Item id={`${id}-sysprep-admin-pwd`} label={msg.sysPrepAdministratorPassword()}>
-                ******
+            { basic.initPassword && (
+              <Item id={`${id}-sysprep-pwd`} label={msg.sysPrepAdministratorPassword()}>
+                <RevealablePassword password={basic.initPassword} />
               </Item>
             )}
             { basic.initCustomScript && (

--- a/src/components/VmDetails/cards/DetailsCard/CloudInit/CloudInitForm.js
+++ b/src/components/VmDetails/cards/DetailsCard/CloudInit/CloudInitForm.js
@@ -1,6 +1,7 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState } from 'react'
 import PropTypes from 'prop-types'
 import {
+  Checkbox,
   FormGroup,
   TextArea,
   TextInput,
@@ -11,6 +12,9 @@ const CloudInitForm = ({ idPrefix, vm, onChange }) => {
   const { msg } = useContext(MsgContext)
   const cloudInitHostName = vm.getIn(['cloudInit', 'hostName'])
   const cloudInitSshAuthorizedKeys = vm.getIn(['cloudInit', 'sshAuthorizedKeys'])
+  const cloudInitUsername = vm.getIn(['cloudInit', 'username'])
+  const cloudInitPassword = vm.getIn(['cloudInit', 'password']) || ''
+  const [useConfiguredPassword, setUseConfiguredPassword] = useState(!!cloudInitPassword)
   return (
     <>
       <FormGroup
@@ -32,6 +36,39 @@ const CloudInitForm = ({ idPrefix, vm, onChange }) => {
           id={`${idPrefix}-cloud-init-ssh`}
           value={cloudInitSshAuthorizedKeys}
           onChange={value => onChange('cloudInitSshAuthorizedKeys', value)}
+        />
+      </FormGroup>
+      <FormGroup
+        label={msg.username()}
+        fieldId={`${idPrefix}-cloud-init-username`}
+      >
+        <TextInput
+          id={`${idPrefix}-cloud-init-username`}
+          value={cloudInitUsername}
+          onChange={value => onChange('cloudInitUsername', value)}
+        />
+      </FormGroup>
+      <Checkbox
+        id={`${idPrefix}-cloud-init-password-configured`}
+        label={msg.useConfiguredPassword()}
+        isChecked={useConfiguredPassword}
+        onChange={(checked) => {
+          setUseConfiguredPassword(checked)
+          if (!checked) {
+            onChange('cloudInitPassword', '')
+          }
+        }}
+      />
+      <FormGroup
+        label={msg.password()}
+        fieldId={`${idPrefix}-cloud-init-password`}
+      >
+        <TextInput
+          id={`${idPrefix}-cloud-init-password`}
+          type="password"
+          value={cloudInitPassword}
+          isDisabled={useConfiguredPassword}
+          onChange={value => onChange('cloudInitPassword', value)}
         />
       </FormGroup>
     </>

--- a/src/components/VmDetails/cards/DetailsCard/index.js
+++ b/src/components/VmDetails/cards/DetailsCard/index.js
@@ -328,7 +328,8 @@ class DetailsCard extends React.Component {
                 { fieldName: 'cloudInitSshAuthorizedKeys', value: template.getIn(['cloudInit', 'sshAuthorizedKeys']) },
                 { fieldName: 'cloudInitTimezone', value: template.getIn(['cloudInit', 'timezone']) },
                 { fieldName: 'cloudInitCustomScript', value: template.getIn(['cloudInit', 'customScript']) },
-                { fieldName: 'cloudInitPassword', value: template.getIn(['cloudInit', 'password']) }
+                { fieldName: 'cloudInitPassword', value: template.getIn(['cloudInit', 'password']) },
+                { fieldName: 'cloudInitUsername', value: template.getIn(['cloudInit', 'username']) }
               )
             }
           }
@@ -383,6 +384,11 @@ class DetailsCard extends React.Component {
         case 'enableInitTimezone': // Configure Timezone checkbox change
           updates = updates.setIn(['cloudInit', 'timezone'], value ? lastInitTimezone : '')
           initTimezoneUpdates.enableInitTimezone = value
+          fieldUpdated = 'cloudInit'
+          break
+
+        case 'cloudInitUsername':
+          updates = updates.setIn(['cloudInit', 'username'], value)
           fieldUpdated = 'cloudInit'
           break
 

--- a/src/intl/locales/en-US.json
+++ b/src/intl/locales/en-US.json
@@ -612,6 +612,7 @@
     "durationLabelStandard_w": "week",
     "durationLabelStandard_ww": "weeks",
     "durationLabelStandard_y": "year",
-    "durationLabelStandard_yy": "years"
+    "durationLabelStandard_yy": "years",
+    "useConfiguredPassword": "Use already configured password"
 
 }

--- a/src/intl/messages.js
+++ b/src/intl/messages.js
@@ -826,6 +826,7 @@ export const messages: { [messageId: string]: MessageType } = {
   warning: 'Warning',
   yes: 'Yes',
   youHaveNoAllowedVnicProfiles: 'You cannot create or edit NICs because you do not have permission to use any vNIC Profiles in the VM\'s Data Center.',
+  useConfiguredPassword: 'Use already configured password',
 }
 
 export type MessageIdType = $Keys<typeof messages>

--- a/src/ovirtapi/transform.js
+++ b/src/ovirtapi/transform.js
@@ -332,6 +332,7 @@ const VM = {
           ? {
             host_name: vm.cloudInit.hostName,
             authorized_ssh_keys: vm.cloudInit.sshAuthorizedKeys,
+            user_name: vm.cloudInit.username,
             root_password: vm.cloudInit.password,
             custom_script: vm.cloudInit.customScript,
             timezone: vm.cloudInit.timezone,
@@ -1127,6 +1128,7 @@ const CloudInit = {
       timezone: (vm.initialization && vm.initialization.timezone) || '',
       customScript: (vm.initialization && vm.initialization.custom_script) || '',
       password: (vm.initialization && vm.initialization.root_password) || '',
+      username: (vm.initialization && vm.initialization.user_name) || '',
     }
   },
 

--- a/src/ovirtapi/types.js
+++ b/src/ovirtapi/types.js
@@ -360,7 +360,9 @@ export type CloudInitType = {
   hostName: string,
   sshAuthorizedKeys: string,
   timezone: string,
-  customScript: string
+  customScript: string,
+  password: string,
+  username: string
 }
 
 export type ApiEventType = Object

--- a/src/sagas/vmChanges.js
+++ b/src/sagas/vmChanges.js
@@ -57,7 +57,8 @@ function* composeAndCreateVm ({ payload: { basic, nics, disks }, meta: { correla
         authorized_ssh_keys: basic.initSshKeys,
         custom_script: basic.initCustomScript,
         host_name: basic.initHostname,
-        root_password: basic.initAdminPassword,
+        user_name: basic.initUsername,
+        root_password: basic.initPassword,
         timezone: basic.initTimezone,
       }
       : {},


### PR DESCRIPTION
- When configuring cloud init for linux, have the ability to add a username and password.
- Make the password viewable in the summary instead of being a string value of *.
- Make the password edit field have the same checkbox as in the admin panel.

This fixes https://github.com/oVirt/ovirt-web-ui/issues/1514
